### PR TITLE
Create dialout group if it doesn't exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Boards flashed with OpenFIRE *must be plugged in **before** launching the applic
 ##### Requirements: Anything with QT5 support.
  - Arch Linux: **TODO: Aur PKGBUILD when public**
  - Other distros: [Try the latest binary](https://github.com/TeamOpenFIRE/OpenFIRE-App/releases/latest) (built for Ubuntu 20.04 LTS, but should work for most distros?)
- - Make sure your user is part of the `dialout` group (`# usermod -a -G dialout insertusernamehere`); you'll be notified on startup if this is necessary.
+ - Make sure your user is part of the `dialout` group (`# usermod -a -G dialout insertusernamehere`); you'll be notified on startup if this is necessary. Log out and back in again for the change to take effect.
+   - If you get the error message `usermod: group 'dialout' does not exist` when running the command above, you'll need to create the group (`# groupadd dialout`) and reboot for the change to take effect before trying again.
 
 ### For Windows:
 ##### Requirements: Windows 7 and up (64-bit only).


### PR DESCRIPTION
The user may need to create the `dialout` group before adding a user to it. That requires a reboot. Logging out is insufficient.