### PR TITLE
Change Linux artifacts to AppImage exports

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -67,13 +67,13 @@ jobs:
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
     - name: Install linuxdeploy
-      if: ${{ matrix.os == "ubuntu-latest" }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: miurahr/install-linuxdeploy-action@v1
       with:
         plugins: qt appimage
 
     - name: Setup AppImage
-      if: ${{ matrix.os == "ubuntu-latest" }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         make install DESTDIR=AppDir
         install -Dm755 "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop" "AppDir/usr/share/applications/org.TeamOpenFIRE.OpenFIREapp.desktop"

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -74,7 +74,9 @@ jobs:
 
     - name: Setup AppImage
       if: ${{ matrix.os == 'ubuntu-latest' }}
+      # thanks linuxdeploy for not preinstalling your dependencies :<
       run: |
+        sudo apt install -y appstream libfuse2
         make install DESTDIR=AppDir
         install -Dm755 "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop" "AppDir/usr/share/applications/org.TeamOpenFIRE.OpenFIREapp.desktop"
         install -Dm755 "${{ github.workspace }}/ico/openfire.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/org.TeamOpenFIRE.OpenFIREapp.svg"

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,9 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "OpenFIRE-dev" ]
   pull_request:
-    branches: [ "OpenFIRE-dev" ]
 
 jobs:
   build:
@@ -16,12 +14,6 @@ jobs:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
-      # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release]
@@ -30,9 +22,14 @@ jobs:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
+            file: build
+            pretty: "Windows Artifact"
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
+            file: OpenFIRE_App-x86_64.AppImage
+            install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
+            pretty: "Linux AppImage"
         exclude:
           - os: windows-latest
             c_compiler: clang
@@ -64,41 +61,38 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        ${{ matrix.install_prefix }}
         -S ${{ github.workspace }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
-    - name: Upload a Build Artifact
+    - name: Install linuxdeploy
+      if: ${{ matrix.os == "ubuntu-latest" }}
+      uses: miurahr/install-linuxdeploy-action@v1
+      with:
+        plugins: qt appimage
+
+    - name: Setup AppImage
+      if: ${{ matrix.os == "ubuntu-latest" }}
+      run: |
+        make install DESTDIR=AppDir
+        install -Dm755 "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop" "AppDir/usr/share/applications/org.TeamOpenFIRE.OpenFIREapp.desktop"
+        install -Dm755 "${{ github.workspace }}/ico/openfire.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/org.TeamOpenFIRE.OpenFIREapp.svg"
+        linuxdeploy-x86_64.AppImage --plugin=qt --output=appimage --appdir AppDir
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+
+    - name: Upload Artifact
       uses: actions/upload-artifact@v4.3.1
       with:
         # Artifact name
-        name: OpenFIREapp-${{ matrix.os }} # optional, default is artifact
+        name: OpenFIREapp-${{ matrix.pretty }} # optional, default is artifact
         # A file, directory or wildcard pattern that describes what to upload
-        path: build
+        path: ${{ matrix.file }}
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v4.1.2
       with:
         # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
-        name: OpenFIREapp-${{ matrix.os }} # optional
-        # Destination path. Supports basic tilde expansion. Defaults to $GITHUB_WORKSPACE
-        # path: # optional
-        # A glob pattern matching the artifacts that should be downloaded. Ignored if name is specified.
-        # pattern: # optional
-        # When multiple artifacts are matched, this changes the behavior of the destination directories. If true, the downloaded artifacts will be in the same directory specified by path. If false, the downloaded artifacts will be extracted into individual named directories within the specified path.
-        # merge-multiple: # optional, default is false
-        # The GitHub token used to authenticate with the GitHub API. This is required when downloading artifacts from a different repository or from a different workflow run. If this is not specified, the action will attempt to download artifacts from the current repository and the current workflow run.
-        # github-token: # optional
-        # The repository owner and the repository name joined together by "/". If github-token is specified, this is the repository that artifacts will be downloaded from.
-        # repository: # optional, default is ${{ github.repository }}
-        # The id of the workflow run where the desired download artifact was uploaded from. If github-token is specified, this is the run that artifacts will be downloaded from.
-        # run-id: # optional, default is ${{ github.run_id }}
-          
-
-#    - name: Test
-#      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#      run: ctest --build-config ${{ matrix.build_type }}
+        name: OpenFIREapp-${{ matrix.pretty }} # optional

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -81,6 +81,7 @@ jobs:
         install -Dm755 "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop" "AppDir/usr/share/applications/org.TeamOpenFIRE.OpenFIREapp.desktop"
         install -Dm755 "${{ github.workspace }}/ico/openfire.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/org.TeamOpenFIRE.OpenFIREapp.svg"
         linuxdeploy-x86_64.AppImage --plugin=qt --output=appimage --appdir AppDir
+        cp ${{ matrix.file }} ${{ github.workspace }}
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
 
     - name: Upload Artifact

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,4 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
-name: CMake on multiple platforms
+name: CMake - Windows & Linux
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Boards flashed with OpenFIRE *must be plugged in **before** launching the applic
 ### For Linux:
 ##### Requirements: Anything with QT5 support.
  - Arch Linux: AUR PKGBUILD @ [`openfireapp`](https://aur.archlinux.org/packages/openfireapp)
- - Other distros: [Try the latest binary](https://github.com/TeamOpenFIRE/OpenFIRE-App/releases/latest) (built for Ubuntu 20.04 LTS, but should work for most distros?)
+ - Other distros: Use `OpenFIRE_App-x86_64.AppImage` [from the releases page](https://github.com/TeamOpenFIRE/OpenFIRE-App/releases/latest)
  - Make sure your user is part of the `dialout` group (`# usermod -a -G dialout insertusernamehere`); you'll be notified on startup if this is necessary. Log out and back in again for the change to take effect.
    - If you get the error message `usermod: group 'dialout' does not exist` when running the command above, you'll need to create the group (`# groupadd dialout`) and reboot for the change to take effect before trying again.
 

--- a/org.TeamOpenFIRE.OpenFIREapp.desktop
+++ b/org.TeamOpenFIRE.OpenFIREapp.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=OpenFIRE App
+Exec=OpenFIREapp
+GenericName=Configuration utility for the OpenFIRE lightgun system
+Icon=org.TeamOpenFIRE.OpenFIREapp
+NoDisplay=false
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=Utility;


### PR DESCRIPTION
Self-explanatory.

The AppImages produced works on both my current main desktop, as well as a bare basic Debian 12 install running the Xfce desktop with all traces of Qt removed. 

![2024_07-07 014923-OpenFIRE App - Aino](https://github.com/TeamOpenFIRE/OpenFIRE-App/assets/7321839/982de223-f681-46ff-8973-b1b4fd87e98f)
![2024_07-07 020914-Boxes](https://github.com/TeamOpenFIRE/OpenFIRE-App/assets/7321839/284666c9-7e3e-4b4a-927a-b50f9f95a3a9)
