### PR TITLE
Add serial port devices searching/updating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ if(OFAPP_GITHASH)
     add_compile_definitions(OFAPP_GITHASH="${OFAPP_GITHASH}")
 endif()
 
-find_package(QT NAMES ${OFAPP_QT_VERSIONS} REQUIRED COMPONENTS Widgets LinguistTools)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets LinguistTools)
+find_package(QT NAMES ${OFAPP_QT_VERSIONS} REQUIRED COMPONENTS Widgets LinguistTools Concurrent)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets LinguistTools Concurrent)
 
 set(TS_FILES
         translation/AppTranslations_en_US.ts
@@ -69,6 +69,7 @@ else()
 endif()
 
 target_link_libraries(OpenFIREapp PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+target_link_libraries(OpenFIREapp PRIVATE Qt${QT_VERSION_MAJOR}::Concurrent)
 
 # Serial Port
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS SerialPort)

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -146,6 +146,9 @@ guiWindow::guiWindow(QWidget *parent)
     statusProgressBar->setVisible(false);
     ui->statusBar->addPermanentWidget(statusProgressBar);
 
+    // Disable ONLY the tab widget (doing this from the form also disables children, including the scroll area)
+    ui->tabWidget->setEnabled(false);
+
     // light mode styling adjustments:
     if(this->palette().window().color().value() > this->palette().text().color().value()) {
         ui->settingsDescBox->setStyleSheet("QGroupBox::title { color: #909000 }");

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -290,7 +290,7 @@ void guiWindow::DiffUpdate()
     if(App_Const::board.selectedProfile != App_Const::board.previousProfile)
         settingsDiff++;
 
-    for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
+    for(uint8_t i = 0; i < App_Const::profilesTable.count(); i++) {
         if(App_Const::profilesTable_orig[i].profName != App_Const::profilesTable[i].profName)
             settingsDiff++;
 
@@ -392,7 +392,7 @@ void guiWindow::on_confirmButton_clicked()
             App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
             App_Const::board.previousProfile = App_Const::board.selectedProfile;
 
-            for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
+            for(uint8_t i = 0; i < App_Const::profilesTable.count(); i++) {
                 App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
                 App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
                 App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -419,7 +419,12 @@ void guiWindow::on_confirmButton_clicked()
 void guiWindow::aliveTimer_timeout()
 {
     serialSearchWatcher.setFuture(serialSearchFuture);
+    // Why did Qt6 change this syntax?
+#if QT_VERSION_MAJOR > 5
     serialSearchFuture = QtConcurrent::run(&AppSerial::SearchPorts, &serial);
+#else
+    serialSearchFuture = QtConcurrent::run(&serial, &AppSerial::SearchPorts);
+#endif
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -27,7 +27,7 @@
 #include <QProgressBar>
 #include <QProcess>
 //#include <QStorageInfo>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 #include <QDebug>
 #include <QFileDialog>
 #include <QColorDialog>
@@ -62,7 +62,6 @@ guiWindow::guiWindow(QWidget *parent)
 
     // Connect together Serial stuff
     connect(&serialSearchWatcher, &QFutureWatcher<uint8_t>::finished, this, &guiWindow::serialPort_SearchFinished);
-    connect(&serialDisconnectWatcher, &QFutureWatcher<uint8_t>::finished, this, &guiWindow::serialPort_DisconnectFinished);
     connect(&serial.port, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
     connect(&serial, &AppSerial::Serial_SetProgressRange, this, &guiWindow::serialPort_progressSet);
     connect(&serial, &AppSerial::Serial_ProgressUpdate, this, &guiWindow::serialPort_progressUpdate);
@@ -840,8 +839,22 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         ui->tabWidget->setEnabled(false);
 
         if(serial.port.isOpen())
-            serialDisconnectWatcher.setFuture(serialDisconnectFuture);
-            serialDisconnectFuture = QtConcurrent::run(&AppSerial::Disconnect, &serial);
+            serial.Disconnect();
+
+        // reset stuff
+        testLabel[14]->setStyleSheet("");
+        testLabel[15]->setStyleSheet("");
+
+        // force disable test mode if it was set
+        if(testMode) {
+            testMode = false;
+            ui->buttonsTestArea->setEnabled(true);
+            ui->pinsTab->setEnabled(true);
+            ui->settingsTab->setEnabled(true);
+            ui->profilesTab->setEnabled(true);
+            ui->feedbackTestsBox->setEnabled(true);
+            ui->dangerZoneBox->setEnabled(true);
+        }
     }
     serialActive = false;
 }
@@ -1710,29 +1723,6 @@ void guiWindow::serialPort_SearchFinished()
             }
         }
     }
-}
-
-
-void guiWindow::serialPort_DisconnectFinished()
-{
-    // reset stuff
-    testLabel[14]->setStyleSheet("");
-    testLabel[15]->setStyleSheet("");
-
-    // force disable test mode if it was set
-    if(testMode) {
-        testMode = false;
-        ui->buttonsTestArea->setEnabled(true);
-        ui->pinsTab->setEnabled(true);
-        ui->settingsTab->setEnabled(true);
-        ui->profilesTab->setEnabled(true);
-        ui->feedbackTestsBox->setEnabled(true);
-        ui->dangerZoneBox->setEnabled(true);
-        serialActive = false;
-    }
-
-    serialActive = false;
-    ui->tabWidget->setEnabled(false);
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -751,50 +751,29 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->tabWidget->setEnabled(true);
             ui->customPinsEnabled->setChecked(App_Const::boolSettings[OF_Const::customPins]);
 
-            if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
-                ui->rumbleToggle->setEnabled(true),  ui->rumbleFFToggle->setEnabled(true);
-            else ui->rumbleToggle->setEnabled(false), ui->rumbleFFToggle->setEnabled(false);
-            ui->rumbleToggle->setChecked(App_Const::boolSettings[OF_Const::rumble]);
-
-            if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
-                ui->solenoidToggle->setEnabled(true);
-            else ui->solenoidToggle->setEnabled(false);
-            ui->solenoidToggle->setChecked(App_Const::boolSettings[OF_Const::solenoid]);
-
-            if((App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF]) || App_Const::boolSettings[OF_Const::solenoid])
-                ui->autofireToggle->setEnabled(true);
-            else ui->autofireToggle->setEnabled(false);
-            ui->autofireToggle->setChecked(App_Const::boolSettings[OF_Const::autofire]);
-
-            ui->simplePauseToggle->setChecked(App_Const::boolSettings[OF_Const::simplePause]);
-            ui->holdToPauseToggle->setChecked(App_Const::boolSettings[OF_Const::holdToPause]);
-
-            if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
-                ui->commonAnodeToggle->setEnabled(true);
-            else ui->commonAnodeToggle->setEnabled(false);
-            ui->commonAnodeToggle->setChecked(App_Const::boolSettings[OF_Const::commonAnode]);
-
-            ui->lowButtonsToggle->setChecked(App_Const::boolSettings[OF_Const::lowButtonsMode]);
-            ui->rumbleFFToggle->setChecked(App_Const::boolSettings[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable[OF_Const::autofireWaitFactor]);
+            ui->rumbleToggle->setChecked(App_Const::boolSettings_orig[OF_Const::rumble]);
+            ui->solenoidToggle->setChecked(App_Const::boolSettings_orig[OF_Const::solenoid]);
+            ui->autofireToggle->setChecked(App_Const::boolSettings_orig[OF_Const::autofire]);
+            ui->simplePauseToggle->setChecked(App_Const::boolSettings_orig[OF_Const::simplePause]);
+            ui->holdToPauseToggle->setChecked(App_Const::boolSettings_orig[OF_Const::holdToPause]);
+            ui->commonAnodeToggle->setChecked(App_Const::boolSettings_orig[OF_Const::commonAnode]);
+            ui->lowButtonsToggle->setChecked(App_Const::boolSettings_orig[OF_Const::lowButtonsMode]);
+            ui->rumbleFFToggle->setChecked(App_Const::boolSettings_orig[OF_Const::rumbleFF]);
+            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings_orig[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable_orig[OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings_orig[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable_orig[OF_Const::autofireWaitFactor]);
 
             ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
             ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
-
-            if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
-                ui->neopixelGroupBox->setEnabled(true);
-            else ui->neopixelGroupBox->setEnabled(false);
-            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]);
-            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDstatic]);
-            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
+            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::customLEDcount]);
+            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable_orig[OF_Const::customLEDstatic]);
+            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
 
             switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
             case 1:
@@ -831,7 +810,9 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 ui->tinyUSBLayoutToggle->setChecked(true);
                 break;
             }
+
         } else ui->comPortSelector->setCurrentIndex(0);
+
         serialPort_progressSet(0);
     } else {
         ui->boardLabel->clear();

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -59,37 +59,34 @@ guiWindow::guiWindow(QWidget *parent)
     }
 #endif
 
-    connect(&serialPort, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
+    // Kickstart serial thread properly
+    connect(&serial.serialWorker, &SerialThreadWorker::Worker_StartupFinished, this, &guiWindow::Worker_Started);
+    emit serial.operate();
 
+#if defined(OFAPP_VERSION) & defined(OFAPP_CODENAME)
+    this->setWindowTitle("OpenFIRE App - " + OFAPP_CODENAME + " [v" + OFAPP_VERSION + ']');
+#else
     this->setWindowTitle("OpenFIRE App - Tokinomiya [v3.0-dev]");
+#endif // OFAPP_VERSION
 
-    // get all fixed interactable elements marked to use event filter:
-    for(const auto child : this->findChildren<QPushButton*>()) {
+    // get all fixed interactable elements marked to use event filter for hover stuff:
+    for(const auto child : this->findChildren<QPushButton*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-    }
-    for(const auto child : this->findChildren<QCheckBox*>()) {
+
+    for(const auto child : this->findChildren<QCheckBox*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-        //if(!child->property("isFor").isNull()) connect(child, &QCheckBox::stateChanged, this, &NeroPrefixSettingsWindow::OptionSet);
-    }
-    for(const auto child : this->findChildren<QLineEdit*>()) {
+
+    for(const auto child : this->findChildren<QLineEdit*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-        //if(!child->property("isFor").isNull()) connect(child, &QLineEdit::textEdited, this, &NeroPrefixSettingsWindow::OptionSet);
-    }
-    for(const auto child : this->findChildren<QSpinBox*>()) {
+
+    for(const auto child : this->findChildren<QSpinBox*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-        // QSpinboxes' "valueChanged" signal isn't new syntax friendly?
-        //if(!child->property("isFor").isNull()) connect(child, SIGNAL(valueChanged(int)), this, SLOT(OptionSet()));
-    }
-    for(const auto child : this->findChildren<QComboBox*>()) {
+
+    for(const auto child : this->findChildren<QComboBox*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-        // QComboboxes aren't new syntax friendly?
-        //if(!child->property("isFor").isNull()) connect(child, SIGNAL(activated(int)), this, SLOT(OptionSet()));
-    }
-    for(const auto child : this->findChildren<QRadioButton*>()) {
+
+    for(const auto child : this->findChildren<QRadioButton*>())
         if(!child->property("trackable").isNull()) child->installEventFilter(this);
-        // QComboboxes aren't new syntax friendly?
-        //if(!child->property("isFor").isNull()) connect(child, SIGNAL(activated(int)), this, SLOT(OptionSet()));
-    }
 
     // Connect boards view "custom layouts" actions to the button
     ui->customLayoutToolBtn->addActions({ui->actionImport_Custom_Layout, ui->actionExport_Custom_Layout});
@@ -99,7 +96,7 @@ guiWindow::guiWindow(QWidget *parent)
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     // Setup test screen buttons
-    for(uint8_t i = 0; i < 16; i++) {
+    for(int i = 0; i < 16; i++) {
         testLabel[i] = new QLabel;
 
         // temperature sensor
@@ -134,15 +131,14 @@ guiWindow::guiWindow(QWidget *parent)
     // set hidden by default until a board with presets is loaded
     ui->presetsBox->setHidden(true);
 
-    // Finally get to the thing!
     aliveTimer = new QTimer();
     connect(aliveTimer, &QTimer::timeout, this, &guiWindow::aliveTimer_timeout);
+
     statusBar()->showMessage("Welcome to the OpenFIRE app!", 3000);
-    PortsSearch();
-    usbName.prepend("[No device]");
-    // TODO: what's a good validator to only accept character values within the range of an unsigned char?
-    //ui->productNameInput->setValidator(new QRegExpValidator(QRegExp("[A-Za-z0-9_]+"), this));
-    ui->comPortSelector->addItems(usbName);
+
+    statusProgressBar = new QProgressBar();
+    statusProgressBar->setVisible(false);
+    ui->statusBar->addPermanentWidget(statusProgressBar);
 
     // light mode styling adjustments:
     if(this->palette().window().color().value() > this->palette().text().color().value()) {
@@ -155,13 +151,13 @@ guiWindow::guiWindow(QWidget *parent)
 
 guiWindow::~guiWindow()
 {
-    if(serialPort.isOpen()) {
+    if(ui->comPortSelector->currentIndex() > 0) {
         statusBar()->showMessage("Sending undock request to board...");
-        serialPort.write("XE");
-        serialPort.waitForBytesWritten(1000);
-        serialPort.waitForReadyRead(1000);
-        serialPort.close();
+        emit serial.Disconnect();
     }
+
+    serial.SerialEnd();
+
     delete ui;
 }
 
@@ -206,373 +202,34 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
 }
 
 
-void guiWindow::PortsSearch()
+void guiWindow::Worker_Started()
 {
-    serialFoundList = QSerialPortInfo::availablePorts();
-    if(serialFoundList.isEmpty()) {
-        QMessageBox::critical(this, "ERROR: No devices detected!",  "Is the microcontroller board currently running OpenFIRE and is currently plugged in?\n"
-                                                                    "Make sure it's connected and recognized by the PC.\n\n"
-                                                                    "This app will now close.");
-        exit(1);
-    } else {
-        // Yeah, sue me, we reading this backwards to make stack management easier.
-        for(int i = serialFoundList.length() - 1; i >= 0; --i) {
-            if(serialFoundList.at(i).vendorIdentifier() == 0xF143) {
-                usbName.prepend(serialFoundList[i].systemLocation());
-                printf("Found device @ %s\n", serialFoundList.at(i).systemLocation().toLocal8Bit().constData());
-            } else {
-                if(!serialFoundList.at(i).systemLocation().contains("tty"))
-                    printf("Deleting dummy device %s\n", serialFoundList.at(i).systemLocation().toLocal8Bit().constData());
-                serialFoundList.removeAt(i);
-            }
-        }
-        if(!usbName.length()) {
-            QMessageBox::critical(this, "ERROR: No devices detected!",  "Is the microcontroller board currently running OpenFIRE and is currently plugged in?\n"
-                                                                        "Make sure it's connected and recognized by the PC.\n\n"
-                                                                        "This app will now close.");
-            exit(1);
-        }
-    }
-}
+    // Connect up Serial thread signals to the main app window
+    connect(serial.serialWorker.port, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
+    connect(&serial.serialWorker, &SerialThreadWorker::SearchPorts_Result, this, &guiWindow::serialPort_handleResult);
+    connect(&serial.serialWorker, &SerialThreadWorker::GetSettings_Result, this, &guiWindow::serialPort_handleResult);
+    connect(&serial.serialWorker, &SerialThreadWorker::OneShot_Result,     this, &guiWindow::serialPort_handleResult);
+    connect(&serial.serialWorker, &SerialThreadWorker::Commit_Result,      this, &guiWindow::serialPort_handleResult);
+    connect(&serial.serialWorker, &SerialThreadWorker::Disconnect_Result,  this, &guiWindow::serialPort_handleResult);
+    connect(&serial.serialWorker, &SerialThreadWorker::Serial_SetProgressRange, this, &guiWindow::serialPort_progressSet);
+    connect(&serial.serialWorker, &SerialThreadWorker::Serial_ProgressUpdate, this, &guiWindow::serialPort_progressUpdate);
 
+    serial.SearchPorts();
 
-// Bool returns success (false if failed)
-bool guiWindow::SerialInit(int portNum)
-{
-    serialPort.setPort(serialFoundList[portNum]);
-    serialPort.setBaudRate(QSerialPort::Baud9600);
-    if(serialPort.open(QIODevice::ReadWrite)) {
-        serialActive = true;
-        // windows needs DTR enabled to actually read responses.
-        serialPort.setDataTerminalReady(true);
-        serialPort.write("XP");
-        if(serialPort.waitForBytesWritten(500)) {
-            if(serialPort.waitForReadyRead(500)) {
-                QByteArray bufStr = serialPort.readLine().trimmed();
-                QList<QByteArray> buffer = bufStr.split(',');
-
-                if(buffer.at(0) == "CAMERROR: Not available") {
-                    QMessageBox::warning(this,  "Device Error: Camera not available!",
-                                                "Data received from the board indicates that the camera is in a bad state.\n"
-                                                "This can happen if the camera wires are crossed (data wire to clock pin, clock wire to data pin).\n\n"
-                                                "The camera must be removed or resoldered to resolve this.");
-                    buffer.takeFirst();
-                }
-
-                if(buffer.at(0).contains("OpenFIRE")) {
-                    printf("OpenFIRE gun detected!\n");
-
-                    App_Const::board.versionNumber = buffer.at(1).constData();
-                    printf("Version number: %s\n", App_Const::board.versionNumber.toLocal8Bit().constData());
-
-                    App_Const::board.versionCodename = buffer.at(2).constData();
-                    printf("Version codename: %s\n", App_Const::board.versionCodename.toLocal8Bit().constData());
-
-                    App_Const::board.boardType = buffer.at(3).constData();
-                    printf("Board type: %s\n", App_Const::board.boardType.toLocal8Bit().constData());
-
-                    App_Const::board.selectedProfile = buffer.at(4).toInt();
-                    App_Const::board.previousProfile = App_Const::board.selectedProfile;
-
-                    serialPort.write("Xli");
-                    serialPort.waitForBytesWritten(500);
-                    serialPort.waitForReadyRead(500);
-
-                    bufStr = serialPort.readLine().trimmed();
-                    buffer = bufStr.split(',');
-                    App_Const::tinyUSBtable.tinyUSBid = buffer.at(0);
-                    App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
-
-                    if(buffer[1] == "SERIALREADERR01")
-                        App_Const::tinyUSBtable.tinyUSBname = "";
-
-                    else App_Const::tinyUSBtable.tinyUSBname = buffer.at(1);
-
-                    App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
-
-                    SerialLoad();
-                    return true;
-                } else {
-                    printf("Port did not respond with expected response! Got: %s", buffer.join(',').constData());
-                    return false;
-                }
-            } else {
-                QMessageBox::warning(this,  "Data hasn't arrived! (Stale state?)",
-                                            "Device was detected, but initial settings request wasn't received in time!\n"
-                                            "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                                            "Try selecting the device again.");
-                return false;
-            }
-        } else {
-            printf("Couldn't send any data in time! Does the port even exist???\n");
-            return false;
-        }
-    } else {
-        QMessageBox::warning(this,  "Serial port is already in use!",
-                                    "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
-                                    "Please close the offending application and try selecting this port again.");
-        return false;
-    }
-}
-
-
-void guiWindow::SerialLoad()
-{
-    serialActive = true;
-    serialPort.clear();
-    serialPort.write("Xlb");
-    if(serialPort.waitForBytesWritten(500)) {
-        if(serialPort.waitForReadyRead(500)) {
-            QString bufStr = serialPort.readLine().trimmed();
-            QStringList buffer = bufStr.split(',');
-
-            // booleans
-            for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
-                if(!buffer.isEmpty()) {
-                    boolSettings[i] = buffer[i].toInt();
-                    boolSettings_orig[i] = boolSettings[i];
-                } else break;
-            }
-
-            // pins
-            if(boolSettings[OF_Const::customPins]) {
-                serialPort.clear();
-                serialPort.write("Xlp");
-                serialPort.waitForBytesWritten(500);
-                serialPort.waitForReadyRead(500);
-                App_Const::inputsMap_orig.clear(), App_Const::inputsMap.clear();
-                bufStr = serialPort.readLine().trimmed();
-                buffer = bufStr.split(',');
-                for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
-                    if(!buffer.isEmpty())
-                        App_Const::inputsMap_orig[i] = buffer[i].toInt();
-                    else break;
-                }
-            } else {
-                for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                    App_Const::inputsMap_orig[i] = OF_Const::btnUnmapped;
-            }
-
-            App_Const::inputsMap = App_Const::inputsMap_orig;
-
-            // settings
-            serialPort.clear();
-            serialPort.write("Xls");
-            serialPort.waitForBytesWritten(500);
-            serialPort.waitForReadyRead(500);
-            bufStr = serialPort.readLine().trimmed();
-            buffer = bufStr.split(',');
-            for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
-                if(!buffer.isEmpty()) {
-                    settingsTable[i] = buffer[i].toInt();
-                    settingsTable_orig[i] = settingsTable[i];
-                } else break;
-            }
-
-            // profiles
-            for(int i = 0; i < App_Const::profilesTable.count(); i++) {
-                delete topOffset.at(i);
-                delete bottomOffset.at(i);
-                delete leftOffset.at(i);
-                delete rightOffset.at(i);
-                delete TLled.at(i);
-                delete TRled.at(i);
-                delete renameBtn.at(i);
-                delete selectedProfile.at(i);
-                delete irSens.at(i);
-                delete runMode.at(i);
-                delete layoutMode.at(i);
-                delete color.at(i);
-                delete caliBtn.at(i);
-            }
-
-            topOffset.clear();
-            bottomOffset.clear();
-            leftOffset.clear();
-            rightOffset.clear();
-            TLled.clear();
-            TRled.clear();
-            renameBtn.clear();
-            selectedProfile.clear();
-            irSens.clear();
-            runMode.clear();
-            layoutMode.clear();
-            color.clear();
-            caliBtn.clear();
-
-            App_Const::profilesTable.clear(), App_Const::profilesTable_orig.clear();
-
-            // TODO: don't think we NEED to limit reading only to profiles count?
-            // perhaps just stop at the first invalid response from the board
-            int caliBtnRow;
-            for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
-                caliBtnRow = i/4;
-                serialPort.clear();
-                serialPort.write(QString("XlP%1").arg(i).toLocal8Bit());
-                serialPort.waitForBytesWritten(500);
-                if(serialPort.waitForReadyRead(500)) {
-                    // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
-                    bufStr = serialPort.readLine().trimmed();
-                    buffer = bufStr.split(',');
-
-                    App_Const::profilesTable << App_Const::profilesTable_s(), App_Const::profilesTable_orig << App_Const::profilesTable_s();
-
-                    // copy settings
-                    App_Const::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                    App_Const::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                    App_Const::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                    App_Const::profilesTable[i].color = buffer.takeFirst().toLong(),
-                    App_Const::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
-
-                    App_Const::profilesTable_orig[i] = App_Const::profilesTable.at(i);
-
-                    // create new assets for this profile
-                    renameBtn << new QPushButton();
-                    renameBtn.at(i)->setFlat(true);
-                    renameBtn.at(i)->setFixedWidth(20);
-                    renameBtn.at(i)->setIcon(QIcon(":/icon/edit.png"));
-                    renameBtn.at(i)->installEventFilter(this);
-                    renameBtn.at(i)->setProperty("slot", i);
-                    renameBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
-                    renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
-                                                  "<p>Aside from differentiating between different profiles for different displays, "
-                                                  "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
-                    connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
-
-                    selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Const::profilesTable.at(i).profName));
-                    if(i == App_Const::board.selectedProfile)
-                        selectedProfile.at(i)->setChecked(true);
-                    selectedProfile.at(i)->setFont(QFont("Monospace"));
-                    selectedProfile.at(i)->setProperty("slot", i);
-                    connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
-
-                    topOffset       << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).topOffset      ));
-                    bottomOffset    << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).bottomOffset   ));
-                    leftOffset      << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).leftOffset     ));
-                    rightOffset     << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).rightOffset    ));
-                    TLled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TLled          ));
-                    TRled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TRled          ));
-
-                    irSens << new QComboBox();
-                    irSens.at(i)->addItems({"Default", "Higher", "Highest"});
-                    irSens.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).irSensitivity);
-                    irSens.at(i)->installEventFilter(this);
-                    irSens.at(i)->setProperty("slot", i);
-                    irSens.at(i)->setProperty("type", App_Const::pBoxIRsens);
-                    irSens.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
-                    irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
-                                               "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
-                                               "adjusting this setting higher might fix issues with tracking.<br>"
-                                               "Conversely, setting sensitivity too high may cause indirect IR sources "
-                                               "(such as sunlight or IR bouncing off of reflective surfaces) "
-                                               "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>");
-                    connect(irSens.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                    runMode << new QComboBox();
-                    runMode.at(i)->addItems({"Normal", "1-Frame Avg", "2-Frame Avg"});
-                    runMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).runMode);
-                    runMode.at(i)->installEventFilter(this);
-                    runMode.at(i)->setProperty("slot", i);
-                    runMode.at(i)->setProperty("type", App_Const::pBoxRunMode);
-                    runMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
-                    runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
-                                                "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
-                                                "at the cost of a small increase in latency; conversely, disabling this position averaging can "
-                                                "reduce latency, at the cost of some added jitter in mouse movement.</p>"
-                                                "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>");
-                    connect(runMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                    layoutMode << new QComboBox();
-                    layoutMode.at(i)->addItems({"Square", "Diamond"});
-                    layoutMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).layoutType);
-                    layoutMode.at(i)->installEventFilter(this);
-                    layoutMode.at(i)->setProperty("slot", i);
-                    layoutMode.at(i)->setProperty("type", App_Const::pBoxLayout);
-                    layoutMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
-                    layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
-                                                   "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
-                                                   "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
-                                                   "which uses one emitter at the center of each side of the display.</p>"
-                                                   "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
-                                                   "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
-                                                   "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
-                                                   "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
-                                                   "<p>If unsure, use <b>Square Layout</b> "
-                                                   "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>");
-                    connect(layoutMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                    color << new QPushButton();
-                    color.at(i)->setFixedWidth(32);
-                    color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Const::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
-                    color.at(i)->installEventFilter(this);
-                    color.at(i)->setProperty("slot", i);
-                    color.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
-                    color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
-                                              "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
-                                              "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>");
-                    connect(color.at(i), &QPushButton::clicked, this, &guiWindow::colorBoxes_clicked);
-
-                    caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
-                    caliBtn.at(i)->installEventFilter(this);
-                    caliBtn.at(i)->setProperty("slot", i);
-                    caliBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                    caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
-                    caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
-                    connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
-
-                    topOffset.at(i)     ->setAlignment(Qt::AlignCenter);
-                    bottomOffset.at(i)  ->setAlignment(Qt::AlignCenter);
-                    leftOffset.at(i)    ->setAlignment(Qt::AlignCenter);
-                    rightOffset.at(i)   ->setAlignment(Qt::AlignCenter);
-                    TLled.at(i)         ->setAlignment(Qt::AlignCenter);
-                    TRled.at(i)         ->setAlignment(Qt::AlignCenter);
-
-                    ui->profilesArea->addWidget(renameBtn.at(i),       i+1, 0);
-                    ui->profilesArea->addWidget(selectedProfile.at(i), i+1, 1);
-                    ui->profilesArea->addWidget(topOffset.at(i),       i+1, 3);
-                    ui->profilesArea->addWidget(bottomOffset.at(i),    i+1, 5);
-                    ui->profilesArea->addWidget(leftOffset.at(i),      i+1, 7);
-                    ui->profilesArea->addWidget(rightOffset.at(i),     i+1, 9);
-                    ui->profilesArea->addWidget(TLled.at(i),           i+1, 11);
-                    ui->profilesArea->addWidget(TRled.at(i),           i+1, 13);
-                    ui->profilesArea->addWidget(irSens.at(i),          i+1, 15);
-                    ui->profilesArea->addWidget(runMode.at(i),         i+1, 17);
-                    ui->profilesArea->addWidget(layoutMode.at(i),      i+1, 19);
-                    ui->profilesArea->addWidget(color.at(i),           i+1, 21);
-
-                    ui->caliBtnsLayout->addWidget(caliBtn.at(i), caliBtnRow, i);
-
-                } else break;
-            }
-            serialActive = false;
-        } else QMessageBox::warning(this, "Sync Error: Data hasn't arrived!!",  "Device was detected, but settings request wasn't received in time!\n"
-                                                                                "This can happen if the app was closed in the middle of an operation.\n\n"
-                                                                                "Try selecting the device again.");
-    } else printf("Couldn't send any data in time! Does the port even exist???\n");
+    aliveTimer->start(ALIVE_TIMER);
 }
 
 
 void guiWindow::BoxesUpdate()
 {
     // enabling custom pins
-    if(boolSettings[OF_Const::customPins]) {
+    if(App_Const::boolSettings[OF_Const::customPins]) {
         // enable pinboxes
         for(int i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setEnabled(true);
 
         // if the custom pins setting *grabbed from the gun* has been set
-        if(boolSettings_orig[OF_Const::customPins]) {
+        if(App_Const::boolSettings_orig[OF_Const::customPins]) {
             // reset pinboxes
             for(int i = 0; i < pinBoxes.count(); i++)
                 pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
@@ -623,19 +280,19 @@ void guiWindow::DiffUpdate()
 {
     int settingsDiff = 0;
 
-    if(boolSettings_orig[OF_Const::customPins] != boolSettings[OF_Const::customPins])
+    if(App_Const::boolSettings_orig[OF_Const::customPins] != App_Const::boolSettings[OF_Const::customPins])
         settingsDiff++;
 
-    if(boolSettings[OF_Const::customPins])
+    if(App_Const::boolSettings[OF_Const::customPins])
         if(App_Const::inputsMap_orig != App_Const::inputsMap)
             settingsDiff++;
 
     for(uint8_t i = 1; i < OF_Const::boolTypesCount; i++)
-        if(boolSettings_orig[i] != boolSettings[i])
+        if(App_Const::boolSettings_orig[i] != App_Const::boolSettings[i])
             settingsDiff++;
 
     for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-        if(settingsTable_orig[i] != settingsTable[i])
+        if(App_Const::settingsTable_orig[i] != App_Const::settingsTable[i])
             settingsDiff++;
 
     if(App_Const::tinyUSBtable_orig.tinyUSBid != App_Const::tinyUSBtable.tinyUSBid)
@@ -706,11 +363,11 @@ QString guiWindow::PrettifyName(QString name)
 
 void guiWindow::PixelsDiff()
 {
-    if( settingsTable[OF_Const::customLEDcount]  == settingsTable_orig[OF_Const::customLEDcount]  &&
-        settingsTable[OF_Const::customLEDstatic] == settingsTable_orig[OF_Const::customLEDstatic] &&
-        settingsTable[OF_Const::customLEDcolor1] == settingsTable_orig[OF_Const::customLEDcolor1] &&
-        settingsTable[OF_Const::customLEDcolor2] == settingsTable_orig[OF_Const::customLEDcolor2] &&
-        settingsTable[OF_Const::customLEDcolor3] == settingsTable_orig[OF_Const::customLEDcolor3]) {
+    if( App_Const::settingsTable[OF_Const::customLEDcount]  == App_Const::settingsTable_orig[OF_Const::customLEDcount]  &&
+        App_Const::settingsTable[OF_Const::customLEDstatic] == App_Const::settingsTable_orig[OF_Const::customLEDstatic] &&
+        App_Const::settingsTable[OF_Const::customLEDcolor1] == App_Const::settingsTable_orig[OF_Const::customLEDcolor1] &&
+        App_Const::settingsTable[OF_Const::customLEDcolor2] == App_Const::settingsTable_orig[OF_Const::customLEDcolor2] &&
+        App_Const::settingsTable[OF_Const::customLEDcolor3] == App_Const::settingsTable_orig[OF_Const::customLEDcolor3]) {
         ui->pixelChangeNotice->setVisible(false);
     } else {
         ui->pixelChangeNotice->setVisible(true);
@@ -724,440 +381,45 @@ void guiWindow::on_confirmButton_clicked()
     messageBox.setInformativeText("These settings will be committed to your lightgun. Is that okay?");
 
     if(messageBox.exec() == QMessageBox::Yes) {
-        if(serialPort.isOpen()) {
-            serialActive = true;
-            aliveTimer->stop();
-            // send a signal so the gun pauses its test outputs for the save op.
-            serialPort.write("Xm");
-            serialPort.waitForBytesWritten(500);
+        serialActive = true;
 
-            QProgressBar *statusProgressBar = new QProgressBar();
-            ui->statusBar->addPermanentWidget(statusProgressBar);
-            ui->tabWidget->setEnabled(false);
-            ui->comPortSelector->setEnabled(false);
-            ui->confirmButton->setEnabled(false);
+        ui->tabWidget->setEnabled(false);
+        ui->comPortSelector->setEnabled(false);
+        ui->confirmButton->setEnabled(false);
 
-            QStringList serialQueue;
-            for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++)
-                serialQueue.append(QString("Xm.0.%1.%2").arg(i).arg(boolSettings[i]));
-
-            if(boolSettings[OF_Const::customPins])
-                for(uint8_t i = 0; i < App_Const::inputsMap.count(); i++)
-                    serialQueue.append(QString("Xm.1.%1.%2").arg(i).arg(App_Const::inputsMap.value(i)));
-
-            for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-                serialQueue.append(QString("Xm.2.%1.%2").arg(i).arg(settingsTable[i]));
-
-            serialQueue.append(QString("Xm.3.0.%1").arg(App_Const::tinyUSBtable.tinyUSBid));
-            if(!App_Const::tinyUSBtable.tinyUSBname.isEmpty())
-                serialQueue.append(QString("Xm.3.1.%1").arg(App_Const::tinyUSBtable.tinyUSBname));
-
-            for(uint8_t i = 0; i < 4; i++) {
-                serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Const::profilesTable[i].irSensitivity));
-                serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Const::profilesTable[i].runMode));
-                serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Const::profilesTable[i].layoutType));
-                serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Const::profilesTable[i].color));
-                serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(App_Const::profilesTable[i].profName));
-            }
-            serialQueue.append("XS");
-
-            statusProgressBar->setRange(0, serialQueue.length()-1);
-            bool success = true;
-
-            // throw out whatever's in the buffer if there's anything there.
-            serialPort.clear();
-
-            for(uint8_t i = 0; i < serialQueue.length(); i++) {
-                serialPort.write(serialQueue.at(i).toLocal8Bit());
-                serialPort.waitForBytesWritten(1000);
-                if(serialPort.waitForReadyRead(1000)) {
-                    QString buffer = serialPort.readLine();
-                    if(buffer.contains("OK:") || buffer.contains("NOENT:")) {
-                        statusProgressBar->setValue(statusProgressBar->value() + 1);
-                    } else if(i == serialQueue.length() - 1 && buffer.contains("Saving preferences...")) {
-                        for(uint8_t t = 0; t < 3; t++) {
-                            if(serialPort.atEnd()) { serialPort.waitForReadyRead(2000); }
-                            buffer = serialPort.readLine();
-                            if(buffer.contains("Settings saved to")) {
-                                success = true;
-                                break;
-                            }
-                        }
-
-                        if(success) {
-                            while(!serialPort.atEnd())
-                                serialPort.readLine();
-                        }
-                    }
-                }
-            }
-
-            ui->statusBar->removeWidget(statusProgressBar);
-            delete statusProgressBar;
-            ui->tabWidget->setEnabled(true);
-            ui->comPortSelector->setEnabled(true);
-
-            if(!success) printf("Settings syncing failed!?\n");
-            else {
-                statusBar()->showMessage("Sent settings successfully!", 5000);
-
-                // sync settings
-                for(int i = 0; i < OF_Const::boolTypesCount; i++)
-                    boolSettings_orig[i] = boolSettings[i];
-
-                if(boolSettings_orig[OF_Const::customPins])
-                    App_Const::inputsMap_orig = App_Const::inputsMap;
-                else for(int i = 0; i < App_Const::inputsMap.size(); i++)
-                        App_Const::inputsMap_orig[i] = -1;
-
-                for(int i = 0; i < OF_Const::settingsTypesCount; i++)
-                    settingsTable_orig[i] = settingsTable[i];
-
-                App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
-                App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
-                App_Const::board.previousProfile = App_Const::board.selectedProfile;
-
-                for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
-                    App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
-                    App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
-                    App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;
-                    App_Const::profilesTable_orig[i].color = App_Const::profilesTable[i].color;
-                    App_Const::profilesTable_orig[i].profName = App_Const::profilesTable[i].profName;
-                }
-
-                // Reflect new names in UI
-                LabelsUpdate();
-
-                // update (clear) diffs
-                PixelsDiff();
-                DiffUpdate();
-            }
-
-            serialActive = false;
-            aliveTimer->start(ALIVE_TIMER);
-            serialQueue.clear();
-
-            if(!serialPort.atEnd())
-                serialPort.readAll();
-
-        } else printf("Wait, this port wasn't open to begin with!!!\n");
+        emit serial.CommitSettings();
     } else { statusBar()->showMessage("Save operation canceled.", 3000); }
 }
 
 
 void guiWindow::aliveTimer_timeout()
 {
-    if(serialPort.isOpen()) {
-        serialPort.write(".");
-        if(!serialPort.waitForBytesWritten(1)) {
-            statusBar()->showMessage("Board hasn't responded to pulse; assuming it's been disconnected.");
-            serialPort.close();
-            ui->comPortSelector->setCurrentIndex(0);
-        }
-    }
+    emit serial.SearchPorts();
 }
 
 
-void guiWindow::on_comPortSelector_currentIndexChanged(int index)
+void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 {
-    // Clear stale states if any, and unmount old board if mounted.
+    // Clear stale states if any
     if(testMode)
         if(caliWindow != nullptr)
             caliWindow->Shutdown();
 
-    if(serialPort.isOpen()) {
-        serialActive = true;
-        serialPort.write("XE");
-        serialPort.waitForBytesWritten(2000);
-        serialPort.waitForReadyRead(2000);
-        serialPort.readAll();
-        serialPort.close();
-        serialActive = false;
-    }
+    // unmount old board if mounted
+    emit serial.Disconnect();
 
-    if(index > 0) {
+    if(ui->comPortSelector->currentIndex() > 0) {
         printf("COM port set to %d\n", ui->comPortSelector->currentIndex());
 
         // try to init serial port
         // if returns false, it failed, so just turn the index back to initial.
-        if(!SerialInit(index - 1)) {
-            ui->comPortSelector->setCurrentIndex(0);
-            aliveTimer->stop();
 
-        // else, serial port is online! What do we got?
-        } else {
-            // Clears old board layout items
-            if(pinBoxes.count()) {
-                for(uint8_t i = 0; i < pinBoxes.count(); i++)
-                    delete pinBoxes.at(i);
-                for(uint8_t i = 0; i < padding.count(); i++)
-                    delete padding.at(i);
-                for(uint8_t i = 0; i < pinLabel.count(); i++)
-                    delete pinLabel.at(i);
-
-                pinBoxes.clear();
-                padding.clear();
-                pinLabel.clear();
-            }
-
-            for(uint8_t i = 0; i < PINS_COUNT; i++) {
-                pinBoxes << new QComboBox();
-                pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinBoxes.at(i)->setProperty("slot", i);
-                pinBoxes.at(i)->setProperty("prevMapping", OF_Const::btnUnmapped+1);
-                pinBoxes.at(i)->setProperty("trackable", App_Const::trackPinbox);
-                pinBoxes.at(i)->installEventFilter(this);
-                // install items
-                pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
-                // clear out analog options for digital pins (< GPIO26)
-                // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
-                if(i < 26) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
-                }
-                // filter out SCL/SDA if possible.
-                if(i & 1) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                } else {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                }
-                connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
-
-                padding << new QWidget();
-                padding.at(i)->setMinimumHeight(25);
-
-                // I2C channel coloring
-                if(i & 0b0000010)
-                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
-
-                pinLabel.at(i)->setEnabled(false);
-                pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
-            }
-
-            aliveTimer->start(ALIVE_TIMER);
-            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Const::board.versionNumber, App_Const::board.versionCodename));
-
-            // update presets box if this board has any
-            ui->presetsBox->clear();
-
-            if(OF_Const::boardsAltPresets.count(App_Const::board.boardType.toStdString())) {
-                ui->presetsBox->setHidden(false);
-                ui->presetsBox->setEnabled(true);
-
-                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
-                for(auto &entry : altPresets)
-                    ui->presetsBox->addItem(entry.name);
-            } else {
-                ui->presetsBox->setEnabled(false);
-                ui->presetsBox->setHidden(true);
-            }
-
-            // set boxes to reflect indexes of inputsMap
-            BoxesUpdate();
-
-            LabelsUpdate();
-
-            // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(OF_Const::boardsBoxPositions.contains(App_Const::board.boardType.toStdString())) {
-                QFile resource(":/boardPics/" + App_Const::board.boardType);
-                resource.open(QIODevice::ReadOnly);
-                origBoardPicFile = resource.readAll();
-
-                for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
-                        ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                            OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
-                                            0);
-                        ui->PinsLeft->addWidget(pinLabel.at(i),
-                                            OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
-                                            1);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
-                        ui->PinsRight->addWidget(pinBoxes.at(i),
-                                            OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
-                                            1);
-                        ui->PinsRight->addWidget(pinLabel.at(i),
-                                            OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
-                                            0);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
-                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
-                                                 1,
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
-                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
-                                                 0,
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
-                    }
-                }
-            } else {
-                QFile resource(":/boardPics/generic");
-                resource.open(QIODevice::ReadOnly);
-                origBoardPicFile = resource.readAll();
-
-                for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
-                        ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                            OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
-                                            0);
-                        ui->PinsLeft->addWidget(pinLabel.at(i),
-                                            OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
-                                            1);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posRight) {
-                        ui->PinsRight->addWidget(pinBoxes.at(i),
-                                             OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
-                                             1);
-                        ui->PinsRight->addWidget(pinLabel.at(i),
-                                            OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
-                                            0);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posMiddle) {
-                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
-                                                 1,
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
-                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
-                                                 0,
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
-                    }
-                }
-            }
-
-            // aspect ratio hint needs to be set every time a new asset is loaded
-            boardPic.load(origBoardPicFile);
-            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
-
-            int prevPadCount;
-            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
-                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                    prevPadCount = padCount;
-                }
-            }
-            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
-                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                }
-            }
-
-            ui->tabWidget->setEnabled(true);
-            ui->customPinsEnabled->setChecked(boolSettings[OF_Const::customPins]);
-
-            if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
-                 ui->rumbleToggle->setEnabled(true),  ui->rumbleFFToggle->setEnabled(true);
-            else ui->rumbleToggle->setEnabled(false), ui->rumbleFFToggle->setEnabled(false);
-            ui->rumbleToggle->setChecked(boolSettings[OF_Const::rumble]);
-
-            if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
-                 ui->solenoidToggle->setEnabled(true);
-            else ui->solenoidToggle->setEnabled(false);
-            ui->solenoidToggle->setChecked(boolSettings[OF_Const::solenoid]);
-
-            if((boolSettings[OF_Const::rumble] && boolSettings[OF_Const::rumbleFF]) || boolSettings[OF_Const::solenoid])
-                ui->autofireToggle->setEnabled(true);
-            else ui->autofireToggle->setEnabled(false);
-            ui->autofireToggle->setChecked(boolSettings[OF_Const::autofire]);
-
-            ui->simplePauseToggle->setChecked(boolSettings[OF_Const::simplePause]);
-            ui->holdToPauseToggle->setChecked(boolSettings[OF_Const::holdToPause]);
-
-            if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
-                 ui->commonAnodeToggle->setEnabled(true);
-            else ui->commonAnodeToggle->setEnabled(false);
-            ui->commonAnodeToggle->setChecked(boolSettings[OF_Const::commonAnode]);
-
-            ui->lowButtonsToggle->setChecked(boolSettings[OF_Const::lowButtonsMode]);
-            ui->rumbleFFToggle->setChecked(boolSettings[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setEnabled(boolSettings[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(settingsTable[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setEnabled(boolSettings[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(settingsTable[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setEnabled(boolSettings[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(settingsTable[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setEnabled(boolSettings[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(settingsTable[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setEnabled(boolSettings[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(settingsTable[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setEnabled(boolSettings[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(settingsTable[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(boolSettings[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(settingsTable[OF_Const::autofireWaitFactor]);
-
-            ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-            ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
-
-            if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
-                 ui->neopixelGroupBox->setEnabled(true);
-            else ui->neopixelGroupBox->setEnabled(false);
-            ui->neopixelStrandLengthBox->setValue(settingsTable[OF_Const::customLEDcount]);
-            ui->customLEDstaticSpinbox->setValue(settingsTable[OF_Const::customLEDstatic]);
-            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(settingsTable[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(settingsTable[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(settingsTable[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
-
-            switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
-            case 1:
-                ui->tUSB_p1->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 2:
-                ui->tUSB_p2->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 3:
-                ui->tUSB_p3->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 4:
-                ui->tUSB_p4->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            default:
-                ui->tUSB_p1->setChecked(false);
-                ui->tUSB_p2->setChecked(false);
-                ui->tUSB_p3->setChecked(false);
-                ui->tUSB_p4->setChecked(false);
-                ui->tUSBLayoutSimple->setVisible(false);
-                ui->tUSBLayoutAdvanced->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(true);
-                break;
-            }
-        }
+        emit serial.GetSettings(ui->comPortSelector->currentText());
     } else {
         ui->boardLabel->clear();
         ui->versionLabel->clear();
 
-        if(serialPort.isOpen()) {
-            serialActive = true;
-            serialPort.write("XE");
-            serialPort.waitForBytesWritten(500);
-            serialPort.waitForReadyRead(500);
-            serialPort.readAll();
-            serialPort.close();
-            testLabel[14]->setStyleSheet("");
-            testLabel[15]->setStyleSheet("");
-
-            // force disable test mode if it was set
-            if(testMode) {
-                testMode = false;
-
-                ui->buttonsTestArea->setEnabled(true);
-                ui->testBtn->setText("Enable IR Test Mode");
-                ui->pinsTab->setEnabled(true);
-                ui->settingsTab->setEnabled(true);
-                ui->profilesTab->setEnabled(true);
-                ui->feedbackTestsBox->setEnabled(true);
-                ui->dangerZoneBox->setEnabled(true);
-                serialActive = false;
-            }
-            serialActive = false;
-        }
-
-        aliveTimer->stop();
-        ui->tabWidget->setEnabled(false);
+        emit serial.Disconnect();
     }
 }
 
@@ -1383,7 +645,7 @@ void guiWindow::colorBoxes_clicked()
 
 void guiWindow::on_customPinsEnabled_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::customPins] = arg1;
+    App_Const::boolSettings[OF_Const::customPins] = arg1;
     BoxesUpdate();
 
     if(arg1)
@@ -1434,7 +696,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
 
 void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::rumble] = arg1;
+    App_Const::boolSettings[OF_Const::rumble] = arg1;
     if(!arg1) {
         ui->rumbleFFToggle->setChecked(false);
         ui->rumbleFFToggle->setEnabled(false);
@@ -1447,7 +709,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
         ui->rumbleLengthBox->setEnabled(true);
         ui->rumbleTestBtn->setEnabled(true);
     }
-    if(!(arg1 && boolSettings[OF_Const::rumbleFF]) && !boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Const::boolSettings[OF_Const::rumbleFF]) && !App_Const::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1459,7 +721,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 
 void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::solenoid] = arg1;
+    App_Const::boolSettings[OF_Const::solenoid] = arg1;
     if(arg1) {
         ui->rumbleFFToggle->setChecked(false);
         ui->solenoidNormalIntervalBox->setEnabled(true);
@@ -1472,7 +734,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
         ui->solenoidHoldLengthBox->setEnabled(false);
         ui->solenoidTestBtn->setEnabled(false);
     }
-    if(!arg1 && !(boolSettings[OF_Const::rumble] && boolSettings[OF_Const::rumbleFF])) {
+    if(!arg1 && !(App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF])) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1484,7 +746,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 
 void guiWindow::on_autofireToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::autofire] = arg1;
+    App_Const::boolSettings[OF_Const::autofire] = arg1;
     if(arg1) { ui->autofireWaitFactorBox->setEnabled(true); } else { ui->autofireWaitFactorBox->setEnabled(false); }
     DiffUpdate();
 }
@@ -1492,14 +754,14 @@ void guiWindow::on_autofireToggle_stateChanged(int arg1)
 
 void guiWindow::on_simplePauseToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::simplePause] = arg1;
+    App_Const::boolSettings[OF_Const::simplePause] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::holdToPause] = arg1;
+    App_Const::boolSettings[OF_Const::holdToPause] = arg1;
     if(arg1) { ui->holdToPauseLengthBox->setEnabled(true); }
     else { ui->holdToPauseLengthBox->setEnabled(false); }
     DiffUpdate();
@@ -1508,23 +770,23 @@ void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 
 void guiWindow::on_commonAnodeToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::commonAnode] = arg1;
+    App_Const::boolSettings[OF_Const::commonAnode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_lowButtonsToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::lowButtonsMode] = arg1;
+    App_Const::boolSettings[OF_Const::lowButtonsMode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 {
-    boolSettings[OF_Const::rumbleFF] = arg1;
+    App_Const::boolSettings[OF_Const::rumbleFF] = arg1;
     if(arg1) { ui->solenoidToggle->setChecked(false); }
-    if(!(arg1 && boolSettings[OF_Const::rumble]) && !boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Const::boolSettings[OF_Const::rumble]) && !App_Const::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1536,49 +798,49 @@ void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 
 void guiWindow::on_rumbleIntensityBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::rumbleStrength] = arg1;
+    App_Const::settingsTable[OF_Const::rumbleStrength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleLengthBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::rumbleInterval] = arg1;
+    App_Const::settingsTable[OF_Const::rumbleInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseLengthBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::holdToPauseLength] = arg1;
+    App_Const::settingsTable[OF_Const::holdToPauseLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidNormalIntervalBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::solenoidNormalInterval] = arg1;
+    App_Const::settingsTable[OF_Const::solenoidNormalInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidFastIntervalBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::solenoidFastInterval] = arg1;
+    App_Const::settingsTable[OF_Const::solenoidFastInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidHoldLengthBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::solenoidHoldLength] = arg1;
+    App_Const::settingsTable[OF_Const::solenoidHoldLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_autofireWaitFactorBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::autofireWaitFactor] = arg1;
+    App_Const::settingsTable[OF_Const::autofireWaitFactor] = arg1;
     DiffUpdate();
 }
 
@@ -1707,7 +969,7 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
     if(isChecked && !serialActive) {
         // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
         if(sender()->property("slot").toInt() != App_Const::board.selectedProfile) {
-            serialPort.write(QString("XC%1").arg(sender()->property("slot").toInt()+1).toLocal8Bit());
+            emit serial.OneShotSend("XC" + QString::number(sender()->property("slot").toInt()+1));
             App_Const::board.selectedProfile = sender()->property("slot").toInt();
             DiffUpdate();
         }
@@ -1717,8 +979,8 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
 
 void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 {
-    settingsTable[OF_Const::customLEDcount] = arg1;
-    if(arg1 < settingsTable[OF_Const::customLEDstatic]) {
+    App_Const::settingsTable[OF_Const::customLEDcount] = arg1;
+    if(arg1 < App_Const::settingsTable[OF_Const::customLEDstatic]) {
         ui->customLEDstaticSpinbox->setValue(arg1);
     }
 
@@ -1731,10 +993,10 @@ void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 {
-    if(arg1 > settingsTable[OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(settingsTable[OF_Const::customLEDcount]); }
-    else { settingsTable[OF_Const::customLEDstatic] = arg1; }
+    if(arg1 > App_Const::settingsTable[OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]); }
+    else { App_Const::settingsTable[OF_Const::customLEDstatic] = arg1; }
     if(OF_Const::customLEDstatic) {
-        switch(settingsTable[OF_Const::customLEDstatic]) {
+        switch(App_Const::settingsTable[OF_Const::customLEDstatic]) {
         case 1:
             ui->customLEDstaticBtn1->setEnabled(true);
             ui->customLEDstaticBtn2->setEnabled(false);
@@ -1767,7 +1029,7 @@ void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticBtn1_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(settingsTable[OF_Const::customLEDcolor1]);
+    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor1]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1777,7 +1039,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        settingsTable[OF_Const::customLEDcolor1] = packedColor;
+        App_Const::settingsTable[OF_Const::customLEDcolor1] = packedColor;
         ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1790,7 +1052,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
 
 void guiWindow::on_customLEDstaticBtn2_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(settingsTable[OF_Const::customLEDcolor2]);
+    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor2]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1800,7 +1062,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        settingsTable[OF_Const::customLEDcolor2] = packedColor;
+        App_Const::settingsTable[OF_Const::customLEDcolor2] = packedColor;
         ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1813,7 +1075,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
 
 void guiWindow::on_customLEDstaticBtn3_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(settingsTable[OF_Const::customLEDcolor3]);
+    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor3]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1823,7 +1085,7 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        settingsTable[OF_Const::customLEDcolor3] = packedColor;
+        App_Const::settingsTable[OF_Const::customLEDcolor3] = packedColor;
         ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1842,13 +1104,10 @@ void guiWindow::caliBtns_clicked()
 
     caliWindow->showFullScreen();
 
-    serialPort.write(QString("XC%1CI%2L%3").arg(sender()->property("slot").toInt()+1)
-                                           .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).irSensitivity)
-                                           .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).layoutType)
-                                           .toLocal8Bit());
-
-    if(!serialPort.waitForBytesWritten(500))
-        ui->statusBar->showMessage("Could not send calibration request.");
+    emit serial.OneShotSend(QString("XC%1CI%2L%3").arg(sender()->property("slot").toInt()+1)
+                                                  .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).irSensitivity)
+                                                  .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).layoutType)
+                                                  .toLocal8Bit());
 }
 
 
@@ -1856,11 +1115,11 @@ void guiWindow::caliBtns_clicked()
 // TODO: move to appserial
 void guiWindow::serialPort_readyRead()
 {
-    debugWindow.AppendText(serialPort.peek(serialPort.bytesAvailable()));
+    debugWindow.AppendText(serial.serialWorker.port->peek(serial.serialWorker.port->bytesAvailable()));
 
     if(!serialActive) {
-        while(!serialPort.atEnd()) {
-            QString idleBuffer = serialPort.readLine();
+        while(!serial.serialWorker.port->atEnd()) {
+            QString idleBuffer = serial.serialWorker.port->readLine();
 
             if(idleBuffer.contains("Pressed:")) {
                 int btn = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
@@ -1882,10 +1141,11 @@ void guiWindow::serialPort_readyRead()
                 if(temp > tempShutoff) {        testLabel[14]->setStyleSheet("color: white;      background-color: #FF0000; font: bold"); }
                 else if(temp > tempWarning) {   testLabel[14]->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold"); }
                 else {                          testLabel[14]->setStyleSheet("color: black;      background-color: #11D00A; font: bold"); }
+            }
 
-            } else if(idleBuffer.contains("Analog:")) {
+            else if(idleBuffer.contains("Analog:")) {
                 // TODO: perhaps we should be using a small box area with a glyph depicting the aStick's coords instead of only showing cardinal directionality?
-                uint8_t analogDir = idleBuffer.trimmed().right(1).toInt();
+                uint8_t analogDir = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
 
                 // analog stick moved
                 if(analogDir) {
@@ -1906,9 +1166,10 @@ void guiWindow::serialPort_readyRead()
                     testLabel[15]->setText("Analog");
                     testLabel[15]->setStyleSheet("");
                 }
+            }
 
-            } else if(idleBuffer.contains("Profile: ")) {
-                uint8_t selection = idleBuffer.trimmed().right(1).toInt();
+            else if(idleBuffer.contains("Profile: ")) {
+                uint8_t selection = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
 
                 if(selection != App_Const::board.selectedProfile) {
                     App_Const::board.selectedProfile = selection;
@@ -1916,57 +1177,50 @@ void guiWindow::serialPort_readyRead()
                 }
 
                 DiffUpdate();
+            }
 
-            } else if(idleBuffer.contains("UpdatedProf: ")) {
-                uint8_t selection = idleBuffer.trimmed().right(1).toInt();
-
-                if(selection != App_Const::board.selectedProfile)
-                    selectedProfile[selection]->setChecked(true);
-
-                App_Const::board.selectedProfile = selection;
-
-                // TODO: ummmm this seems very unsafe. :/
-                // to be deprecated as "CalUpd" sends the same information, just much safer
-                serialPort.waitForReadyRead(10);
-                topOffset[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].topOffset = topOffset[selection]->text().toInt();
-
-                serialPort.waitForReadyRead(10);
-                bottomOffset[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].bottomOffset = bottomOffset[selection]->text().toInt();
-
-                serialPort.waitForReadyRead(10);
-                leftOffset[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].leftOffset = leftOffset[selection]->text().toInt();
-
-                serialPort.waitForReadyRead(10);
-                rightOffset[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].rightOffset = rightOffset[selection]->text().toInt();
-
-                serialPort.waitForReadyRead(10);
-                TLled[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].TLled = TLled[selection]->text().toFloat();
-
-                serialPort.waitForReadyRead(10);
-                TRled[selection]->setText(serialPort.readLine().trimmed());
-                App_Const::profilesTable[selection].TRled = TRled[selection]->text().toFloat();
-
-                DiffUpdate();
-
-            } else if(idleBuffer.contains("CalStage:")) {
+            else if(idleBuffer.contains("CalStage:")) {
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)
                         caliWindow->CaliModeSet(idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt());
+            }
 
-            } else if(idleBuffer.contains("CalUpd:")) {
+            else if(idleBuffer.contains("CalUpd:")) {
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)
                         caliWindow->CaliModeTextUpdate(idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed());
             }
+
+            else if(idleBuffer.contains("Entering Test Mode...")) {
+                if(caliWindow != nullptr)
+                    caliWindow->Shutdown();
+
+                caliWindow = new AppCaliWindow(nullptr, AppCaliWindow::modeIRTest);
+                connect(caliWindow, &AppCaliWindow::WindowExiting, this, &guiWindow::CaliWindowExiting);
+
+                caliWindow->showFullScreen();
+
+                testMode = true;
+
+                ui->buttonsTestArea->setEnabled(false);
+                ui->confirmButton->setEnabled(false);
+                ui->confirmButton->setText("[Disabled while in Test Mode]");
+                ui->pinsTab->setEnabled(false);
+                ui->settingsTab->setEnabled(false);
+                ui->profilesTab->setEnabled(false);
+                ui->feedbackTestsBox->setEnabled(false);
+                ui->dangerZoneBox->setEnabled(false);
+            }
+
+            else if(idleBuffer.contains("Cleared! Please reset the board.")) {
+                ui->comPortSelector->setCurrentIndex(0);
+                QMessageBox::information(this, "Successfully reset board settings",
+                                         "Please unplug the board and reinsert it into the PC.");
+            }
         }
 
     } else if(testMode) {
-        QString testBuffer = serialPort.readLine();
+        QString testBuffer = serial.serialWorker.port->readLine();
 
         if(testBuffer.contains(','))
             if(caliWindow != nullptr)
@@ -1976,78 +1230,589 @@ void guiWindow::serialPort_readyRead()
 }
 
 
+void guiWindow::serialPort_handleResult(const int &type, const bool &success)
+{
+    switch(type) {
+    case SerialThreadWorker::Serial_SearchPorts:
+        if(success) {
+            // ports have changed, update COM ports list
+            // if comPort only has "Nothing", safe to add items
+            if(ui->comPortSelector->count() == 0) {
+                if(serial.serialWorker.currentPorts.count()) {
+                    ui->comPortSelector->addItem("[Select a device]");
+                    ui->comPortSelector->setCurrentIndex(0);
+                    for(const auto port : serial.serialWorker.currentPorts)
+                        ui->comPortSelector->addItem(port.portName());
+                }
+            // if comPort is filled
+            // TODO: find some way to add new items without removing
+            } else {
+                if(serial.serialWorker.currentPorts.count()) {
+                    // if no active comPort
+                    if(ui->comPortSelector->currentIndex() <= 0) {
+                        while(ui->comPortSelector->count() > 1)
+                            ui->comPortSelector->removeItem(1);
+
+                        for(const auto port : serial.serialWorker.currentPorts)
+                            ui->comPortSelector->addItem(port.portName());
+                    // if comPort is active
+                    } else {
+                        // remove all other comPorts
+                        int i = 1;
+                        while(ui->comPortSelector->count() > 2) {
+                            if(i == ui->comPortSelector->currentIndex())
+                                i++;
+                            else ui->comPortSelector->removeItem(i);
+                        }
+
+                        // check if current comPort is still in devices list
+                        // TODO: probably a better way of doing this, meh
+                        bool inList = false;
+                        for(const auto port : serial.serialWorker.currentPorts)
+                            if(ui->comPortSelector->currentText() == port.portName())
+                                inList = true;
+                        if(!inList) {
+                            statusBar()->showMessage("Current board has been disconnected.");
+                            ui->comPortSelector->removeItem(1);
+                        }
+
+                        // append new items to list
+                        for(const auto port : serial.serialWorker.currentPorts)
+                            ui->comPortSelector->addItem(port.portName());
+                    }
+                // if ports list is cleared, assume no board can be connected.
+                } else {
+                    if(ui->comPortSelector->currentIndex() > 0)
+                        statusBar()->showMessage("Current board has been disconnected.");
+                    ui->comPortSelector->clear();
+                }
+            }
+        }
+        break;
+    case SerialThreadWorker::Serial_GetSettings:
+        if(success) {
+            for(int i = 0; i < topOffset.count(); i++) {
+                delete topOffset.at(i);
+                delete bottomOffset.at(i);
+                delete leftOffset.at(i);
+                delete rightOffset.at(i);
+                delete TLled.at(i);
+                delete TRled.at(i);
+                delete renameBtn.at(i);
+                delete selectedProfile.at(i);
+                delete irSens.at(i);
+                delete runMode.at(i);
+                delete layoutMode.at(i);
+                delete color.at(i);
+                delete caliBtn.at(i);
+            }
+
+            topOffset.clear();
+            bottomOffset.clear();
+            leftOffset.clear();
+            rightOffset.clear();
+            TLled.clear();
+            TRled.clear();
+            renameBtn.clear();
+            selectedProfile.clear();
+            irSens.clear();
+            runMode.clear();
+            layoutMode.clear();
+            color.clear();
+            caliBtn.clear();
+
+            int caliBtnRow;
+            for(uint8_t i = 0; i < App_Const::profilesTable.size(); i++) {
+                caliBtnRow = i/4;
+
+                // create new assets for this profile
+                renameBtn << new QPushButton();
+                renameBtn.at(i)->setFlat(true);
+                renameBtn.at(i)->setFixedWidth(20);
+                renameBtn.at(i)->setIcon(QIcon(":/icon/edit.png"));
+                renameBtn.at(i)->installEventFilter(this);
+                renameBtn.at(i)->setProperty("slot", i);
+                renameBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
+                renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
+                                              "<p>Aside from differentiating between different profiles for different displays, "
+                                              "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
+                connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
+
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Const::profilesTable.at(i).profName));
+                if(i == App_Const::board.selectedProfile)
+                    selectedProfile.at(i)->setChecked(true);
+                selectedProfile.at(i)->setFont(QFont("Monospace"));
+                selectedProfile.at(i)->setProperty("slot", i);
+                connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
+
+                topOffset       << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).topOffset      ));
+                bottomOffset    << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).bottomOffset   ));
+                leftOffset      << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).leftOffset     ));
+                rightOffset     << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).rightOffset    ));
+                TLled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TLled          ));
+                TRled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TRled          ));
+
+                irSens << new QComboBox();
+                irSens.at(i)->addItems({"Default", "Higher", "Highest"});
+                irSens.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).irSensitivity);
+                irSens.at(i)->installEventFilter(this);
+                irSens.at(i)->setProperty("slot", i);
+                irSens.at(i)->setProperty("type", App_Const::pBoxIRsens);
+                irSens.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
+                irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
+                                           "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
+                                           "adjusting this setting higher might fix issues with tracking.<br>"
+                                           "Conversely, setting sensitivity too high may cause indirect IR sources "
+                                           "(such as sunlight or IR bouncing off of reflective surfaces) "
+                                           "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>");
+                connect(irSens.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                runMode << new QComboBox();
+                runMode.at(i)->addItems({"Normal", "1-Frame Avg", "2-Frame Avg"});
+                runMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).runMode);
+                runMode.at(i)->installEventFilter(this);
+                runMode.at(i)->setProperty("slot", i);
+                runMode.at(i)->setProperty("type", App_Const::pBoxRunMode);
+                runMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
+                runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
+                                            "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
+                                            "at the cost of a small increase in latency; conversely, disabling this position averaging can "
+                                            "reduce latency, at the cost of some added jitter in mouse movement.</p>"
+                                            "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>");
+                connect(runMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                layoutMode << new QComboBox();
+                layoutMode.at(i)->addItems({"Square", "Diamond"});
+                layoutMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).layoutType);
+                layoutMode.at(i)->installEventFilter(this);
+                layoutMode.at(i)->setProperty("slot", i);
+                layoutMode.at(i)->setProperty("type", App_Const::pBoxLayout);
+                layoutMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
+                layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
+                                               "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
+                                               "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
+                                               "which uses one emitter at the center of each side of the display.</p>"
+                                               "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
+                                               "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
+                                               "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
+                                               "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
+                                               "<p>If unsure, use <b>Square Layout</b> "
+                                               "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>");
+                connect(layoutMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                color << new QPushButton();
+                color.at(i)->setFixedWidth(32);
+                color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Const::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
+                color.at(i)->installEventFilter(this);
+                color.at(i)->setProperty("slot", i);
+                color.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
+                color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
+                                          "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
+                                          "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>");
+                connect(color.at(i), &QPushButton::clicked, this, &guiWindow::colorBoxes_clicked);
+
+                caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
+                caliBtn.at(i)->installEventFilter(this);
+                caliBtn.at(i)->setProperty("slot", i);
+                caliBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
+                caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
+                connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
+
+                topOffset.at(i)     ->setAlignment(Qt::AlignCenter);
+                bottomOffset.at(i)  ->setAlignment(Qt::AlignCenter);
+                leftOffset.at(i)    ->setAlignment(Qt::AlignCenter);
+                rightOffset.at(i)   ->setAlignment(Qt::AlignCenter);
+                TLled.at(i)         ->setAlignment(Qt::AlignCenter);
+                TRled.at(i)         ->setAlignment(Qt::AlignCenter);
+
+                ui->profilesArea->addWidget(renameBtn.at(i),       i+1, 0);
+                ui->profilesArea->addWidget(selectedProfile.at(i), i+1, 1);
+                ui->profilesArea->addWidget(topOffset.at(i),       i+1, 3);
+                ui->profilesArea->addWidget(bottomOffset.at(i),    i+1, 5);
+                ui->profilesArea->addWidget(leftOffset.at(i),      i+1, 7);
+                ui->profilesArea->addWidget(rightOffset.at(i),     i+1, 9);
+                ui->profilesArea->addWidget(TLled.at(i),           i+1, 11);
+                ui->profilesArea->addWidget(TRled.at(i),           i+1, 13);
+                ui->profilesArea->addWidget(irSens.at(i),          i+1, 15);
+                ui->profilesArea->addWidget(runMode.at(i),         i+1, 17);
+                ui->profilesArea->addWidget(layoutMode.at(i),      i+1, 19);
+                ui->profilesArea->addWidget(color.at(i),           i+1, 21);
+
+                ui->caliBtnsLayout->addWidget(caliBtn.at(i), caliBtnRow, i);
+            }
+
+            // Clears old board layout items
+            if(pinBoxes.count()) {
+                for(uint8_t i = 0; i < pinBoxes.count(); i++)
+                    delete pinBoxes.at(i);
+                for(uint8_t i = 0; i < padding.count(); i++)
+                    delete padding.at(i);
+                for(uint8_t i = 0; i < pinLabel.count(); i++)
+                    delete pinLabel.at(i);
+
+                pinBoxes.clear();
+                padding.clear();
+                pinLabel.clear();
+            }
+
+            for(uint8_t i = 0; i < PINS_COUNT; i++) {
+                pinBoxes << new QComboBox();
+                pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinBoxes.at(i)->setProperty("slot", i);
+                pinBoxes.at(i)->setProperty("prevMapping", OF_Const::btnUnmapped+1);
+                pinBoxes.at(i)->setProperty("trackable", App_Const::trackPinbox);
+                pinBoxes.at(i)->installEventFilter(this);
+                // install items
+                pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
+                // clear out analog options for digital pins (< GPIO26)
+                // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
+                if(i < 26) {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
+                }
+                // filter out SCL/SDA if possible.
+                if(i & 1) {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                } else {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                }
+                connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
+
+                padding << new QWidget();
+                padding.at(i)->setMinimumHeight(25);
+
+                // I2C channel coloring
+                if(i & 0b0000010)
+                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+
+                pinLabel.at(i)->setEnabled(false);
+                pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
+            }
+
+            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Const::board.versionNumber, App_Const::board.versionCodename));
+
+            // update presets box if this board has any
+            ui->presetsBox->clear();
+
+            if(OF_Const::boardsAltPresets.count(App_Const::board.boardType.toStdString())) {
+                ui->presetsBox->setHidden(false);
+                ui->presetsBox->setEnabled(true);
+
+                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
+                for(auto &entry : altPresets)
+                    ui->presetsBox->addItem(entry.name);
+            } else {
+                ui->presetsBox->setEnabled(false);
+                ui->presetsBox->setHidden(true);
+            }
+
+            // set boxes to reflect indexes of inputsMap
+            BoxesUpdate();
+
+            LabelsUpdate();
+
+            // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
+            if(OF_Const::boardsBoxPositions.contains(App_Const::board.boardType.toStdString())) {
+                QFile resource(":/boardPics/" + App_Const::board.boardType);
+                resource.open(QIODevice::ReadOnly);
+                origBoardPicFile = resource.readAll();
+
+                for(int i = 0; i < PINS_COUNT; i++) {
+                    if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
+                        ui->PinsLeft->addWidget(pinBoxes.at(i),
+                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                0);
+                        ui->PinsLeft->addWidget(pinLabel.at(i),
+                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                1);
+                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
+                        ui->PinsRight->addWidget(pinBoxes.at(i),
+                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 1);
+                        ui->PinsRight->addWidget(pinLabel.at(i),
+                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 0);
+                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
+                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
+                                                     1,
+                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
+                                                     0,
+                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                    }
+                }
+            } else {
+                QFile resource(":/boardPics/generic");
+                resource.open(QIODevice::ReadOnly);
+                origBoardPicFile = resource.readAll();
+
+                for(int i = 0; i < PINS_COUNT; i++) {
+                    if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
+                        ui->PinsLeft->addWidget(pinBoxes.at(i),
+                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                0);
+                        ui->PinsLeft->addWidget(pinLabel.at(i),
+                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                1);
+                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posRight) {
+                        ui->PinsRight->addWidget(pinBoxes.at(i),
+                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 1);
+                        ui->PinsRight->addWidget(pinLabel.at(i),
+                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 0);
+                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posMiddle) {
+                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
+                                                     1,
+                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
+                                                     0,
+                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                    }
+                }
+            }
+
+            // aspect ratio hint needs to be set every time a new asset is loaded
+            boardPic.load(origBoardPicFile);
+            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+
+            int prevPadCount;
+            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
+                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                    prevPadCount = padCount;
+                }
+            }
+            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
+                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                }
+            }
+
+            ui->tabWidget->setEnabled(true);
+            ui->customPinsEnabled->setChecked(App_Const::boolSettings[OF_Const::customPins]);
+
+            if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
+                ui->rumbleToggle->setEnabled(true),  ui->rumbleFFToggle->setEnabled(true);
+            else ui->rumbleToggle->setEnabled(false), ui->rumbleFFToggle->setEnabled(false);
+            ui->rumbleToggle->setChecked(App_Const::boolSettings[OF_Const::rumble]);
+
+            if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
+                ui->solenoidToggle->setEnabled(true);
+            else ui->solenoidToggle->setEnabled(false);
+            ui->solenoidToggle->setChecked(App_Const::boolSettings[OF_Const::solenoid]);
+
+            if((App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF]) || App_Const::boolSettings[OF_Const::solenoid])
+                ui->autofireToggle->setEnabled(true);
+            else ui->autofireToggle->setEnabled(false);
+            ui->autofireToggle->setChecked(App_Const::boolSettings[OF_Const::autofire]);
+
+            ui->simplePauseToggle->setChecked(App_Const::boolSettings[OF_Const::simplePause]);
+            ui->holdToPauseToggle->setChecked(App_Const::boolSettings[OF_Const::holdToPause]);
+
+            if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
+                ui->commonAnodeToggle->setEnabled(true);
+            else ui->commonAnodeToggle->setEnabled(false);
+            ui->commonAnodeToggle->setChecked(App_Const::boolSettings[OF_Const::commonAnode]);
+
+            ui->lowButtonsToggle->setChecked(App_Const::boolSettings[OF_Const::lowButtonsMode]);
+            ui->rumbleFFToggle->setChecked(App_Const::boolSettings[OF_Const::rumbleFF]);
+            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable[OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable[OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable[OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable[OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable[OF_Const::autofireWaitFactor]);
+
+            ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
+            ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+
+            if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
+                ui->neopixelGroupBox->setEnabled(true);
+            else ui->neopixelGroupBox->setEnabled(false);
+            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]);
+            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDstatic]);
+            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
+
+            switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
+            case 1:
+                ui->tUSB_p1->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 2:
+                ui->tUSB_p2->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 3:
+                ui->tUSB_p3->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 4:
+                ui->tUSB_p4->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            default:
+                ui->tUSB_p1->setChecked(false);
+                ui->tUSB_p2->setChecked(false);
+                ui->tUSB_p3->setChecked(false);
+                ui->tUSB_p4->setChecked(false);
+                ui->tUSBLayoutSimple->setVisible(false);
+                ui->tUSBLayoutAdvanced->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(true);
+                break;
+            }
+        } else ui->comPortSelector->setCurrentIndex(0);
+        serialPort_progressSet(0);
+        break;
+    case SerialThreadWorker::Serial_OneShot:
+        break;
+    case SerialThreadWorker::Serial_Sync:
+        if(success) {
+            statusBar()->showMessage("Sent settings successfully!", 5000);
+
+            // sync settings
+            for(int i = 0; i < OF_Const::boolTypesCount; i++)
+                App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
+
+            if(App_Const::boolSettings_orig[OF_Const::customPins])
+                App_Const::inputsMap_orig = App_Const::inputsMap;
+            else for(int i = 0; i < App_Const::inputsMap.size(); i++)
+                    App_Const::inputsMap_orig[i] = -1;
+
+            for(int i = 0; i < OF_Const::settingsTypesCount; i++)
+                App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
+
+            App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
+            App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
+            App_Const::board.previousProfile = App_Const::board.selectedProfile;
+
+            for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
+                App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
+                App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
+                App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;
+                App_Const::profilesTable_orig[i].color = App_Const::profilesTable[i].color;
+                App_Const::profilesTable_orig[i].profName = App_Const::profilesTable[i].profName;
+            }
+
+            // Reflect new names in UI
+            LabelsUpdate();
+
+            // update (clear) diffs
+            PixelsDiff();
+            DiffUpdate();
+        } else printf("Settings syncing failed!?\n");
+        serialPort_progressSet(0);
+        ui->tabWidget->setEnabled(true);
+        ui->comPortSelector->setEnabled(true);
+        serialActive = false;
+        break;
+    case SerialThreadWorker::Serial_Disconnect:
+        // reset stuff
+        testLabel[14]->setStyleSheet("");
+        testLabel[15]->setStyleSheet("");
+        // force disable test mode if it was set
+        if(testMode) {
+            testMode = false;
+            ui->buttonsTestArea->setEnabled(true);
+            ui->pinsTab->setEnabled(true);
+            ui->settingsTab->setEnabled(true);
+            ui->profilesTab->setEnabled(true);
+            ui->feedbackTestsBox->setEnabled(true);
+            ui->dangerZoneBox->setEnabled(true);
+            serialActive = false;
+        }
+        serialActive = false;
+        ui->tabWidget->setEnabled(false);
+        break;
+    }
+}
+
+
+void guiWindow::serialPort_progressSet(const int &range)
+{
+    if(range) {
+        if(!statusProgressBar->isVisible())
+            statusProgressBar->setVisible(true);
+        statusProgressBar->setRange(0, range);
+    } else {
+        statusProgressBar->setVisible(false);
+        statusProgressBar->setValue(0);
+    }
+}
+
+
+void guiWindow::serialPort_progressUpdate(const int &pos)
+{
+    if(statusProgressBar->isVisible())
+        statusProgressBar->setValue(pos);
+}
+
+
 void guiWindow::on_rumbleTestBtn_clicked()
 {
-    serialPort.write("Xtr");
-    if(!serialPort.waitForBytesWritten(500)) QMessageBox::critical(this, "Lost connection!", "Somehow this happened I guess???");
-    else ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
+    emit serial.OneShotSend("Xtr");
+    ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
 }
 
 
 void guiWindow::on_solenoidTestBtn_clicked()
 {
-    serialPort.write("Xts");
-    if(!serialPort.waitForBytesWritten(500)) QMessageBox::critical(this, "Lost connection!", "Somehow this happened I guess???");
-    else ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
+    emit serial.OneShotSend("Xts");
+    ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
 }
 
 
 void guiWindow::on_redLedTestBtn_clicked()
 {
-    serialPort.write("XtR");
-    if(!serialPort.waitForBytesWritten(500)) QMessageBox::critical(this, "Lost connection!", "Somehow this happened I guess???");
-    else ui->statusBar->showMessage("Set LED to Red.", 2500);
+    emit serial.OneShotSend("XtR");
+    ui->statusBar->showMessage("Set LED to Red.", 2500);
 }
 
 
 void guiWindow::on_greenLedTestBtn_clicked()
 {
-    serialPort.write("XtG");
-    if(!serialPort.waitForBytesWritten(500)) QMessageBox::critical(this, "Lost connection!", "Somehow this happened I guess???");
-    else ui->statusBar->showMessage("Set LED to Green.", 2500);
+    emit serial.OneShotSend("XtG");
+    ui->statusBar->showMessage("Set LED to Green.", 2500);
 }
 
 
 void guiWindow::on_blueLedTestBtn_clicked()
 {
-    serialPort.write("XtB");
-    if(!serialPort.waitForBytesWritten(500)) QMessageBox::critical(this, "Lost connection!", "Somehow this happened I guess???");
-    else ui->statusBar->showMessage("Set LED to Blue.", 2500);
+    emit serial.OneShotSend("XtB");
+    ui->statusBar->showMessage("Set LED to Blue.", 2500);
 }
 
 
 void guiWindow::on_testBtn_clicked()
 {
-    if(serialPort.isOpen()) {
-        // Pre-emptively put a sock in the readyRead signal
-        serialActive = true;
-        aliveTimer->stop();
+    // Pre-emptively put a sock in the readyRead signal
+    serialActive = true;
 
-        if(caliWindow != nullptr)
-            caliWindow->Shutdown();
-
-        caliWindow = new AppCaliWindow(nullptr, AppCaliWindow::modeIRTest);
-        connect(caliWindow, &AppCaliWindow::WindowExiting, this, &guiWindow::CaliWindowExiting);
-
-        serialPort.write("XT");
-        serialPort.waitForBytesWritten(500);
-        serialPort.waitForReadyRead(500);
-
-        if(serialPort.readLine().trimmed() == "Entering Test Mode...") {
-            caliWindow->showFullScreen();
-
-            testMode = true;
-
-            ui->buttonsTestArea->setEnabled(false);
-            ui->confirmButton->setEnabled(false);
-            ui->confirmButton->setText("[Disabled while in Test Mode]");
-            ui->pinsTab->setEnabled(false);
-            ui->settingsTab->setEnabled(false);
-            ui->profilesTab->setEnabled(false);
-            ui->feedbackTestsBox->setEnabled(false);
-            ui->dangerZoneBox->setEnabled(false);
-        }
-    }
+    emit serial.OneShotSend("XT");
 }
 
 
@@ -2096,11 +1861,7 @@ void guiWindow::CaliWindowExiting(const int &mode,
         break;
     }
     case AppCaliWindow::modeIRTest:
-        if(serialPort.isOpen()) {
-            serialPort.write("XT");
-            serialPort.waitForBytesWritten(500);
-            serialPort.waitForReadyRead(500);
-        }
+        emit serial.OneShotSend("XT");
 
         testMode = false;
 
@@ -2112,7 +1873,6 @@ void guiWindow::CaliWindowExiting(const int &mode,
         ui->dangerZoneBox->setEnabled(true);
 
         serialActive = false;
-        aliveTimer->start(ALIVE_TIMER);
         break;
     case AppCaliWindow::modeAlignment:
     default:
@@ -2129,10 +1889,7 @@ void guiWindow::CaliWindowExiting(const int &mode,
 
 void guiWindow::CaliWindowRequestedExit()
 {
-    if(serialPort.isOpen()) {
-        serialPort.write("X");
-        serialPort.waitForBytesWritten(500);
-    }
+    emit serial.OneShotSend("X");
 }
 
 
@@ -2151,38 +1908,16 @@ void guiWindow::on_clearEepromBtn_clicked()
     messageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     messageBox.setDefaultButton(QMessageBox::Yes);
 
-    if(messageBox.exec() == QMessageBox::Yes) {
-        if(serialPort.isOpen()) {
-            serialActive = true;
-            // clear the buffer if anything's been sent.
-            while(!serialPort.atEnd())
-                serialPort.readLine();
-            serialPort.write("Xc");
-            serialPort.waitForBytesWritten(500);
-            if(serialPort.waitForReadyRead(2000)) {
-                QString buffer = serialPort.readLine();
-                if(buffer.trimmed() == "Cleared! Please reset the board.") {
-                    serialPort.write("XE");
-                    serialPort.waitForBytesWritten(2000);
-                    serialPort.close();
-                    serialActive = false;
-                    ui->comPortSelector->setCurrentIndex(0);
-                    QMessageBox::information(this, "Successfully reset board settings",
-                                                   "Please unplug the board and reinsert it into the PC.");
-                }
-            }
-        }
-    } else ui->statusBar->showMessage("Clear operation canceled.", 3000);
+    if(messageBox.exec() == QMessageBox::Yes)
+        emit serial.OneShotSend("Xc");
+    else ui->statusBar->showMessage("Clear operation canceled.", 3000);
 }
 
 
 void guiWindow::on_baudResetBtn_clicked()
 {
     // No need for workarounds, bootloader reset is in the firmware now.
-    serialActive = true;
-    serialPort.write("Xxx");
-    serialPort.waitForBytesWritten(500);
-    serialPort.close();
+    emit serial.OneShotSend("Xxx");
 
 /* test stuff for potential app FW update functionality
     // At least on my system, the Bootloader device takes ~7s to appear
@@ -2203,7 +1938,6 @@ void guiWindow::on_baudResetBtn_clicked()
 */
     ui->statusBar->showMessage("Board reset to bootloader.", 5000);
     ui->comPortSelector->setCurrentIndex(0);
-    serialActive = false;
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -27,6 +27,7 @@
 #include <QProgressBar>
 #include <QProcess>
 //#include <QStorageInfo>
+#include <QtConcurrent>
 #include <QDebug>
 #include <QFileDialog>
 #include <QColorDialog>
@@ -59,9 +60,18 @@ guiWindow::guiWindow(QWidget *parent)
     }
 #endif
 
-    // Kickstart serial thread properly
-    connect(&serial.serialWorker, &SerialThreadWorker::Worker_StartupFinished, this, &guiWindow::Worker_Started);
-    emit serial.operate();
+    // Connect together Serial stuff
+    connect(&serialSearchWatcher, &QFutureWatcher<uint8_t>::finished, this, &guiWindow::serialPort_SearchFinished);
+    connect(&serialDisconnectWatcher, &QFutureWatcher<uint8_t>::finished, this, &guiWindow::serialPort_DisconnectFinished);
+    connect(&serial.port, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
+    connect(&serial, &AppSerial::Serial_SetProgressRange, this, &guiWindow::serialPort_progressSet);
+    connect(&serial, &AppSerial::Serial_ProgressUpdate, this, &guiWindow::serialPort_progressUpdate);
+
+    connect(&aliveTimer, &QTimer::timeout, this, &guiWindow::aliveTimer_timeout);
+
+    // Start initial serial search
+    aliveTimer.start(ALIVE_TIMER);
+    aliveTimer_timeout();
 
 #if defined(OFAPP_VERSION) & defined(OFAPP_CODENAME)
     this->setWindowTitle("OpenFIRE App - " + OFAPP_CODENAME + " [v" + OFAPP_VERSION + ']');
@@ -131,9 +141,6 @@ guiWindow::guiWindow(QWidget *parent)
     // set hidden by default until a board with presets is loaded
     ui->presetsBox->setHidden(true);
 
-    aliveTimer = new QTimer();
-    connect(aliveTimer, &QTimer::timeout, this, &guiWindow::aliveTimer_timeout);
-
     statusBar()->showMessage("Welcome to the OpenFIRE app!", 3000);
 
     statusProgressBar = new QProgressBar();
@@ -153,10 +160,8 @@ guiWindow::~guiWindow()
 {
     if(ui->comPortSelector->currentIndex() > 0) {
         statusBar()->showMessage("Sending undock request to board...");
-        emit serial.Disconnect();
+        serial.Disconnect();
     }
-
-    serial.SerialEnd();
 
     delete ui;
 }
@@ -199,24 +204,6 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
     if(!(event->type() == QEvent::Wheel && object->inherits("QComboBox")))
         return QWidget::eventFilter(object, event);
     else return true;
-}
-
-
-void guiWindow::Worker_Started()
-{
-    // Connect up Serial thread signals to the main app window
-    connect(serial.serialWorker.port, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
-    connect(&serial.serialWorker, &SerialThreadWorker::SearchPorts_Result, this, &guiWindow::serialPort_handleResult);
-    connect(&serial.serialWorker, &SerialThreadWorker::GetSettings_Result, this, &guiWindow::serialPort_handleResult);
-    connect(&serial.serialWorker, &SerialThreadWorker::OneShot_Result,     this, &guiWindow::serialPort_handleResult);
-    connect(&serial.serialWorker, &SerialThreadWorker::Commit_Result,      this, &guiWindow::serialPort_handleResult);
-    connect(&serial.serialWorker, &SerialThreadWorker::Disconnect_Result,  this, &guiWindow::serialPort_handleResult);
-    connect(&serial.serialWorker, &SerialThreadWorker::Serial_SetProgressRange, this, &guiWindow::serialPort_progressSet);
-    connect(&serial.serialWorker, &SerialThreadWorker::Serial_ProgressUpdate, this, &guiWindow::serialPort_progressUpdate);
-
-    serial.SearchPorts();
-
-    aliveTimer->start(ALIVE_TIMER);
 }
 
 
@@ -387,14 +374,53 @@ void guiWindow::on_confirmButton_clicked()
         ui->comPortSelector->setEnabled(false);
         ui->confirmButton->setEnabled(false);
 
-        emit serial.CommitSettings();
+        if(serial.CommitSettings()) {
+            statusBar()->showMessage("Sent settings successfully!", 5000);
+
+            // sync settings
+            for(int i = 0; i < OF_Const::boolTypesCount; i++)
+                App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
+
+            if(App_Const::boolSettings_orig[OF_Const::customPins])
+                App_Const::inputsMap_orig = App_Const::inputsMap;
+            else for(int i = 0; i < App_Const::inputsMap.size(); i++)
+                    App_Const::inputsMap_orig[i] = -1;
+
+            for(int i = 0; i < OF_Const::settingsTypesCount; i++)
+                App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
+
+            App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
+            App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
+            App_Const::board.previousProfile = App_Const::board.selectedProfile;
+
+            for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
+                App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
+                App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
+                App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;
+                App_Const::profilesTable_orig[i].color = App_Const::profilesTable[i].color;
+                App_Const::profilesTable_orig[i].profName = App_Const::profilesTable[i].profName;
+            }
+
+            // Reflect new names in UI
+            LabelsUpdate();
+
+            // update (clear) diffs
+            PixelsDiff();
+            DiffUpdate();
+        } else printf("Settings syncing failed!?\n");
+
+        serialPort_progressSet(0);
+        ui->tabWidget->setEnabled(true);
+        ui->comPortSelector->setEnabled(true);
+        serialActive = false;
     } else { statusBar()->showMessage("Save operation canceled.", 3000); }
 }
 
 
 void guiWindow::aliveTimer_timeout()
 {
-    emit serial.SearchPorts();
+    serialSearchWatcher.setFuture(serialSearchFuture);
+    serialSearchFuture = QtConcurrent::run(&AppSerial::SearchPorts, &serial);
 }
 
 
@@ -405,22 +431,418 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         if(caliWindow != nullptr)
             caliWindow->Shutdown();
 
-    // unmount old board if mounted
-    emit serial.Disconnect();
-
     if(ui->comPortSelector->currentIndex() > 0) {
         printf("COM port set to %d\n", ui->comPortSelector->currentIndex());
 
         // try to init serial port
         // if returns false, it failed, so just turn the index back to initial.
+        serialActive = true;
+        if(serial.GetSettings(text)) {
+            for(int i = 0; i < topOffset.count(); i++) {
+                delete topOffset.at(i);
+                delete bottomOffset.at(i);
+                delete leftOffset.at(i);
+                delete rightOffset.at(i);
+                delete TLled.at(i);
+                delete TRled.at(i);
+                delete renameBtn.at(i);
+                delete selectedProfile.at(i);
+                delete irSens.at(i);
+                delete runMode.at(i);
+                delete layoutMode.at(i);
+                delete color.at(i);
+                delete caliBtn.at(i);
+            }
 
-        emit serial.GetSettings(ui->comPortSelector->currentText());
+            topOffset.clear();
+            bottomOffset.clear();
+            leftOffset.clear();
+            rightOffset.clear();
+            TLled.clear();
+            TRled.clear();
+            renameBtn.clear();
+            selectedProfile.clear();
+            irSens.clear();
+            runMode.clear();
+            layoutMode.clear();
+            color.clear();
+            caliBtn.clear();
+
+            int caliBtnRow;
+            for(uint8_t i = 0; i < App_Const::profilesTable.size(); i++) {
+                caliBtnRow = i/4;
+
+                // create new assets for this profile
+                renameBtn << new QPushButton();
+                renameBtn.at(i)->setFlat(true);
+                renameBtn.at(i)->setFixedWidth(20);
+                renameBtn.at(i)->setIcon(QIcon(":/icon/edit.png"));
+                renameBtn.at(i)->installEventFilter(this);
+                renameBtn.at(i)->setProperty("slot", i);
+                renameBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
+                renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
+                                              "<p>Aside from differentiating between different profiles for different displays, "
+                                              "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
+                connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
+
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Const::profilesTable.at(i).profName));
+                if(i == App_Const::board.selectedProfile)
+                    selectedProfile.at(i)->setChecked(true);
+                selectedProfile.at(i)->setFont(QFont("Monospace"));
+                selectedProfile.at(i)->setProperty("slot", i);
+                connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
+
+                topOffset       << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).topOffset      ));
+                bottomOffset    << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).bottomOffset   ));
+                leftOffset      << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).leftOffset     ));
+                rightOffset     << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).rightOffset    ));
+                TLled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TLled          ));
+                TRled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TRled          ));
+
+                irSens << new QComboBox();
+                irSens.at(i)->addItems({"Default", "Higher", "Highest"});
+                irSens.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).irSensitivity);
+                irSens.at(i)->installEventFilter(this);
+                irSens.at(i)->setProperty("slot", i);
+                irSens.at(i)->setProperty("type", App_Const::pBoxIRsens);
+                irSens.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
+                irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
+                                           "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
+                                           "adjusting this setting higher might fix issues with tracking.<br>"
+                                           "Conversely, setting sensitivity too high may cause indirect IR sources "
+                                           "(such as sunlight or IR bouncing off of reflective surfaces) "
+                                           "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>");
+                connect(irSens.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                runMode << new QComboBox();
+                runMode.at(i)->addItems({"Normal", "1-Frame Avg", "2-Frame Avg"});
+                runMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).runMode);
+                runMode.at(i)->installEventFilter(this);
+                runMode.at(i)->setProperty("slot", i);
+                runMode.at(i)->setProperty("type", App_Const::pBoxRunMode);
+                runMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
+                runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
+                                            "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
+                                            "at the cost of a small increase in latency; conversely, disabling this position averaging can "
+                                            "reduce latency, at the cost of some added jitter in mouse movement.</p>"
+                                            "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>");
+                connect(runMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                layoutMode << new QComboBox();
+                layoutMode.at(i)->addItems({"Square", "Diamond"});
+                layoutMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).layoutType);
+                layoutMode.at(i)->installEventFilter(this);
+                layoutMode.at(i)->setProperty("slot", i);
+                layoutMode.at(i)->setProperty("type", App_Const::pBoxLayout);
+                layoutMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
+                layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
+                                               "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
+                                               "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
+                                               "which uses one emitter at the center of each side of the display.</p>"
+                                               "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
+                                               "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
+                                               "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
+                                               "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
+                                               "<p>If unsure, use <b>Square Layout</b> "
+                                               "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>");
+                connect(layoutMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
+
+                color << new QPushButton();
+                color.at(i)->setFixedWidth(32);
+                color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Const::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
+                color.at(i)->installEventFilter(this);
+                color.at(i)->setProperty("slot", i);
+                color.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
+                color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
+                                          "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
+                                          "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>");
+                connect(color.at(i), &QPushButton::clicked, this, &guiWindow::colorBoxes_clicked);
+
+                caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
+                caliBtn.at(i)->installEventFilter(this);
+                caliBtn.at(i)->setProperty("slot", i);
+                caliBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
+                caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
+                connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
+
+                topOffset.at(i)     ->setAlignment(Qt::AlignCenter);
+                bottomOffset.at(i)  ->setAlignment(Qt::AlignCenter);
+                leftOffset.at(i)    ->setAlignment(Qt::AlignCenter);
+                rightOffset.at(i)   ->setAlignment(Qt::AlignCenter);
+                TLled.at(i)         ->setAlignment(Qt::AlignCenter);
+                TRled.at(i)         ->setAlignment(Qt::AlignCenter);
+
+                ui->profilesArea->addWidget(renameBtn.at(i),       i+1, 0);
+                ui->profilesArea->addWidget(selectedProfile.at(i), i+1, 1);
+                ui->profilesArea->addWidget(topOffset.at(i),       i+1, 3);
+                ui->profilesArea->addWidget(bottomOffset.at(i),    i+1, 5);
+                ui->profilesArea->addWidget(leftOffset.at(i),      i+1, 7);
+                ui->profilesArea->addWidget(rightOffset.at(i),     i+1, 9);
+                ui->profilesArea->addWidget(TLled.at(i),           i+1, 11);
+                ui->profilesArea->addWidget(TRled.at(i),           i+1, 13);
+                ui->profilesArea->addWidget(irSens.at(i),          i+1, 15);
+                ui->profilesArea->addWidget(runMode.at(i),         i+1, 17);
+                ui->profilesArea->addWidget(layoutMode.at(i),      i+1, 19);
+                ui->profilesArea->addWidget(color.at(i),           i+1, 21);
+
+                ui->caliBtnsLayout->addWidget(caliBtn.at(i), caliBtnRow, i);
+            }
+
+            // Clears old board layout items
+            if(pinBoxes.count()) {
+                for(uint8_t i = 0; i < pinBoxes.count(); i++)
+                    delete pinBoxes.at(i);
+                for(uint8_t i = 0; i < padding.count(); i++)
+                    delete padding.at(i);
+                for(uint8_t i = 0; i < pinLabel.count(); i++)
+                    delete pinLabel.at(i);
+
+                pinBoxes.clear();
+                padding.clear();
+                pinLabel.clear();
+            }
+
+            for(uint8_t i = 0; i < PINS_COUNT; i++) {
+                pinBoxes << new QComboBox();
+                pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinBoxes.at(i)->setProperty("slot", i);
+                pinBoxes.at(i)->setProperty("prevMapping", OF_Const::btnUnmapped+1);
+                pinBoxes.at(i)->setProperty("trackable", App_Const::trackPinbox);
+                pinBoxes.at(i)->installEventFilter(this);
+                // install items
+                pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
+                // clear out analog options for digital pins (< GPIO26)
+                // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
+                if(i < 26) {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
+                }
+                // filter out SCL/SDA if possible.
+                if(i & 1) {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                } else {
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                }
+                connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
+
+                padding << new QWidget();
+                padding.at(i)->setMinimumHeight(25);
+
+                // I2C channel coloring
+                if(i & 0b0000010)
+                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+
+                pinLabel.at(i)->setEnabled(false);
+                pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
+            }
+
+            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Const::board.versionNumber, App_Const::board.versionCodename));
+
+            // update presets box if this board has any
+            ui->presetsBox->clear();
+
+            if(OF_Const::boardsAltPresets.count(App_Const::board.boardType.toStdString())) {
+                ui->presetsBox->setHidden(false);
+                ui->presetsBox->setEnabled(true);
+
+                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
+                for(auto &entry : altPresets)
+                    ui->presetsBox->addItem(entry.name);
+            } else {
+                ui->presetsBox->setEnabled(false);
+                ui->presetsBox->setHidden(true);
+            }
+
+            // set boxes to reflect indexes of inputsMap
+            BoxesUpdate();
+
+            LabelsUpdate();
+
+            // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
+            if(OF_Const::boardsBoxPositions.contains(App_Const::board.boardType.toStdString())) {
+                QFile resource(":/boardPics/" + App_Const::board.boardType);
+                resource.open(QIODevice::ReadOnly);
+                origBoardPicFile = resource.readAll();
+
+                for(int i = 0; i < PINS_COUNT; i++) {
+                    if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
+                        ui->PinsLeft->addWidget(pinBoxes.at(i),
+                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                0);
+                        ui->PinsLeft->addWidget(pinLabel.at(i),
+                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                1);
+                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
+                        ui->PinsRight->addWidget(pinBoxes.at(i),
+                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 1);
+                        ui->PinsRight->addWidget(pinLabel.at(i),
+                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 0);
+                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
+                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
+                                                     1,
+                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
+                                                     0,
+                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                    }
+                }
+            } else {
+                QFile resource(":/boardPics/generic");
+                resource.open(QIODevice::ReadOnly);
+                origBoardPicFile = resource.readAll();
+
+                for(int i = 0; i < PINS_COUNT; i++) {
+                    if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
+                        ui->PinsLeft->addWidget(pinBoxes.at(i),
+                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                0);
+                        ui->PinsLeft->addWidget(pinLabel.at(i),
+                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                1);
+                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posRight) {
+                        ui->PinsRight->addWidget(pinBoxes.at(i),
+                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 1);
+                        ui->PinsRight->addWidget(pinLabel.at(i),
+                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 0);
+                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posMiddle) {
+                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
+                                                     1,
+                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
+                                                     0,
+                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                    }
+                }
+            }
+
+            // aspect ratio hint needs to be set every time a new asset is loaded
+            boardPic.load(origBoardPicFile);
+            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+
+            int prevPadCount;
+            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
+                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                    prevPadCount = padCount;
+                }
+            }
+            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
+                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                }
+            }
+
+            ui->tabWidget->setEnabled(true);
+            ui->customPinsEnabled->setChecked(App_Const::boolSettings[OF_Const::customPins]);
+
+            if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
+                ui->rumbleToggle->setEnabled(true),  ui->rumbleFFToggle->setEnabled(true);
+            else ui->rumbleToggle->setEnabled(false), ui->rumbleFFToggle->setEnabled(false);
+            ui->rumbleToggle->setChecked(App_Const::boolSettings[OF_Const::rumble]);
+
+            if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
+                ui->solenoidToggle->setEnabled(true);
+            else ui->solenoidToggle->setEnabled(false);
+            ui->solenoidToggle->setChecked(App_Const::boolSettings[OF_Const::solenoid]);
+
+            if((App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF]) || App_Const::boolSettings[OF_Const::solenoid])
+                ui->autofireToggle->setEnabled(true);
+            else ui->autofireToggle->setEnabled(false);
+            ui->autofireToggle->setChecked(App_Const::boolSettings[OF_Const::autofire]);
+
+            ui->simplePauseToggle->setChecked(App_Const::boolSettings[OF_Const::simplePause]);
+            ui->holdToPauseToggle->setChecked(App_Const::boolSettings[OF_Const::holdToPause]);
+
+            if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
+                ui->commonAnodeToggle->setEnabled(true);
+            else ui->commonAnodeToggle->setEnabled(false);
+            ui->commonAnodeToggle->setChecked(App_Const::boolSettings[OF_Const::commonAnode]);
+
+            ui->lowButtonsToggle->setChecked(App_Const::boolSettings[OF_Const::lowButtonsMode]);
+            ui->rumbleFFToggle->setChecked(App_Const::boolSettings[OF_Const::rumbleFF]);
+            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable[OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable[OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable[OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable[OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable[OF_Const::autofireWaitFactor]);
+
+            ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
+            ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+
+            if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
+                ui->neopixelGroupBox->setEnabled(true);
+            else ui->neopixelGroupBox->setEnabled(false);
+            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]);
+            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDstatic]);
+            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
+
+            switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
+            case 1:
+                ui->tUSB_p1->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 2:
+                ui->tUSB_p2->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 3:
+                ui->tUSB_p3->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            case 4:
+                ui->tUSB_p4->setChecked(true);
+                ui->tUSBLayoutAdvanced->setVisible(false);
+                ui->tUSBLayoutSimple->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(false);
+                break;
+            default:
+                ui->tUSB_p1->setChecked(false);
+                ui->tUSB_p2->setChecked(false);
+                ui->tUSB_p3->setChecked(false);
+                ui->tUSB_p4->setChecked(false);
+                ui->tUSBLayoutSimple->setVisible(false);
+                ui->tUSBLayoutAdvanced->setVisible(true);
+                ui->tinyUSBLayoutToggle->setChecked(true);
+                break;
+            }
+        } else ui->comPortSelector->setCurrentIndex(0);
+        serialPort_progressSet(0);
     } else {
         ui->boardLabel->clear();
         ui->versionLabel->clear();
 
-        emit serial.Disconnect();
+        if(serial.port.isOpen())
+            serialDisconnectWatcher.setFuture(serialDisconnectFuture);
+            serialDisconnectFuture = QtConcurrent::run(&AppSerial::Disconnect, &serial);
     }
+    serialActive = false;
 }
 
 
@@ -969,7 +1391,7 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
     if(isChecked && !serialActive) {
         // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
         if(sender()->property("slot").toInt() != App_Const::board.selectedProfile) {
-            emit serial.OneShotSend("XC" + QString::number(sender()->property("slot").toInt()+1));
+            serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1));
             App_Const::board.selectedProfile = sender()->property("slot").toInt();
             DiffUpdate();
         }
@@ -1104,10 +1526,10 @@ void guiWindow::caliBtns_clicked()
 
     caliWindow->showFullScreen();
 
-    emit serial.OneShotSend(QString("XC%1CI%2L%3").arg(sender()->property("slot").toInt()+1)
-                                                  .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).irSensitivity)
-                                                  .arg(App_Const::profilesTable.at(sender()->property("slot").toInt()).layoutType)
-                                                  .toLocal8Bit());
+    serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1) +
+                       "C" + // Calibrate byte
+                       "I" + QByteArray::number(App_Const::profilesTable.at(sender()->property("slot").toInt()).irSensitivity) +
+                       "L" + QByteArray::number(App_Const::profilesTable.at(sender()->property("slot").toInt()).layoutType));
 }
 
 
@@ -1115,11 +1537,11 @@ void guiWindow::caliBtns_clicked()
 // TODO: move to appserial
 void guiWindow::serialPort_readyRead()
 {
-    debugWindow.AppendText(serial.serialWorker.port->peek(serial.serialWorker.port->bytesAvailable()));
+    debugWindow.AppendText(serial.port.peek(serial.port.bytesAvailable()));
 
     if(!serialActive) {
-        while(!serial.serialWorker.port->atEnd()) {
-            QString idleBuffer = serial.serialWorker.port->readLine();
+        while(!serial.port.atEnd()) {
+            QString idleBuffer = serial.port.readLine();
 
             if(idleBuffer.contains("Pressed:")) {
                 int btn = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
@@ -1220,7 +1642,7 @@ void guiWindow::serialPort_readyRead()
         }
 
     } else if(testMode) {
-        QString testBuffer = serial.serialWorker.port->readLine();
+        QString testBuffer = serial.port.readLine();
 
         if(testBuffer.contains(','))
             if(caliWindow != nullptr)
@@ -1230,525 +1652,86 @@ void guiWindow::serialPort_readyRead()
 }
 
 
-void guiWindow::serialPort_handleResult(const int &type, const bool &success)
+void guiWindow::serialPort_SearchFinished()
 {
-    switch(type) {
-    case SerialThreadWorker::Serial_SearchPorts:
-        if(success) {
-            // ports have changed, update COM ports list
-            // if comPort only has "Nothing", safe to add items
-            if(ui->comPortSelector->count() == 0) {
-                if(serial.serialWorker.currentPorts.count()) {
-                    ui->comPortSelector->addItem("[Select a device]");
-                    ui->comPortSelector->setCurrentIndex(0);
-                    for(const auto port : serial.serialWorker.currentPorts)
-                        ui->comPortSelector->addItem(port.portName());
-                }
+    // if ports have changed
+    if(serialSearchFuture.result()) {
+        // ports have changed, update COM ports list
+        // if comPort only has "Nothing", safe to add items
+        if(ui->comPortSelector->count() == 0) {
+            if(serial.currentPorts.count()) {
+                ui->comPortSelector->addItem("[Select a device]");
+                ui->comPortSelector->setCurrentIndex(0);
+                for(const auto port : serial.currentPorts)
+                    ui->comPortSelector->addItem(port.portName());
+            }
             // if comPort is filled
             // TODO: find some way to add new items without removing
-            } else {
-                if(serial.serialWorker.currentPorts.count()) {
-                    // if no active comPort
-                    if(ui->comPortSelector->currentIndex() <= 0) {
-                        while(ui->comPortSelector->count() > 1)
-                            ui->comPortSelector->removeItem(1);
+        } else {
+            if(serial.currentPorts.count()) {
+                // if no active comPort
+                if(ui->comPortSelector->currentIndex() <= 0) {
+                    while(ui->comPortSelector->count() > 1)
+                        ui->comPortSelector->removeItem(1);
 
-                        for(const auto port : serial.serialWorker.currentPorts)
-                            ui->comPortSelector->addItem(port.portName());
+                    for(const auto port : serial.currentPorts)
+                        ui->comPortSelector->addItem(port.portName());
                     // if comPort is active
-                    } else {
-                        // remove all other comPorts
-                        int i = 1;
-                        while(ui->comPortSelector->count() > 2) {
-                            if(i == ui->comPortSelector->currentIndex())
-                                i++;
-                            else ui->comPortSelector->removeItem(i);
-                        }
-
-                        // check if current comPort is still in devices list
-                        // TODO: probably a better way of doing this, meh
-                        bool inList = false;
-                        for(const auto port : serial.serialWorker.currentPorts)
-                            if(ui->comPortSelector->currentText() == port.portName())
-                                inList = true;
-                        if(!inList) {
-                            statusBar()->showMessage("Current board has been disconnected.");
-                            ui->comPortSelector->removeItem(1);
-                        }
-
-                        // append new items to list
-                        for(const auto port : serial.serialWorker.currentPorts)
-                            ui->comPortSelector->addItem(port.portName());
-                    }
-                // if ports list is cleared, assume no board can be connected.
                 } else {
-                    if(ui->comPortSelector->currentIndex() > 0)
+                    // remove all other comPorts
+                    int i = 1;
+                    while(ui->comPortSelector->count() > 2) {
+                        if(i == ui->comPortSelector->currentIndex())
+                            i++;
+                        else ui->comPortSelector->removeItem(i);
+                    }
+
+                    // check if current comPort is still in devices list
+                    // TODO: probably a better way of doing this, meh
+                    bool inList = false;
+                    for(const auto port : serial.currentPorts)
+                        if(ui->comPortSelector->currentText() == port.portName())
+                            inList = true;
+                    if(!inList) {
                         statusBar()->showMessage("Current board has been disconnected.");
-                    ui->comPortSelector->clear();
+                        ui->comPortSelector->removeItem(1);
+                    }
+
+                    // append new items to list
+                    for(const auto port : serial.currentPorts)
+                        ui->comPortSelector->addItem(port.portName());
                 }
+                // if ports list is cleared, assume no board can be connected.
+            } else {
+                if(ui->comPortSelector->currentIndex() > 0)
+                    statusBar()->showMessage("Current board has been disconnected.");
+                ui->comPortSelector->clear();
             }
         }
-        break;
-    case SerialThreadWorker::Serial_GetSettings:
-        if(success) {
-            for(int i = 0; i < topOffset.count(); i++) {
-                delete topOffset.at(i);
-                delete bottomOffset.at(i);
-                delete leftOffset.at(i);
-                delete rightOffset.at(i);
-                delete TLled.at(i);
-                delete TRled.at(i);
-                delete renameBtn.at(i);
-                delete selectedProfile.at(i);
-                delete irSens.at(i);
-                delete runMode.at(i);
-                delete layoutMode.at(i);
-                delete color.at(i);
-                delete caliBtn.at(i);
-            }
-
-            topOffset.clear();
-            bottomOffset.clear();
-            leftOffset.clear();
-            rightOffset.clear();
-            TLled.clear();
-            TRled.clear();
-            renameBtn.clear();
-            selectedProfile.clear();
-            irSens.clear();
-            runMode.clear();
-            layoutMode.clear();
-            color.clear();
-            caliBtn.clear();
-
-            int caliBtnRow;
-            for(uint8_t i = 0; i < App_Const::profilesTable.size(); i++) {
-                caliBtnRow = i/4;
-
-                // create new assets for this profile
-                renameBtn << new QPushButton();
-                renameBtn.at(i)->setFlat(true);
-                renameBtn.at(i)->setFixedWidth(20);
-                renameBtn.at(i)->setIcon(QIcon(":/icon/edit.png"));
-                renameBtn.at(i)->installEventFilter(this);
-                renameBtn.at(i)->setProperty("slot", i);
-                renameBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
-                renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
-                                              "<p>Aside from differentiating between different profiles for different displays, "
-                                              "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
-                connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
-
-                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Const::profilesTable.at(i).profName));
-                if(i == App_Const::board.selectedProfile)
-                    selectedProfile.at(i)->setChecked(true);
-                selectedProfile.at(i)->setFont(QFont("Monospace"));
-                selectedProfile.at(i)->setProperty("slot", i);
-                connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
-
-                topOffset       << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).topOffset      ));
-                bottomOffset    << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).bottomOffset   ));
-                leftOffset      << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).leftOffset     ));
-                rightOffset     << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).rightOffset    ));
-                TLled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TLled          ));
-                TRled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TRled          ));
-
-                irSens << new QComboBox();
-                irSens.at(i)->addItems({"Default", "Higher", "Highest"});
-                irSens.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).irSensitivity);
-                irSens.at(i)->installEventFilter(this);
-                irSens.at(i)->setProperty("slot", i);
-                irSens.at(i)->setProperty("type", App_Const::pBoxIRsens);
-                irSens.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
-                irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
-                                           "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
-                                           "adjusting this setting higher might fix issues with tracking.<br>"
-                                           "Conversely, setting sensitivity too high may cause indirect IR sources "
-                                           "(such as sunlight or IR bouncing off of reflective surfaces) "
-                                           "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>");
-                connect(irSens.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                runMode << new QComboBox();
-                runMode.at(i)->addItems({"Normal", "1-Frame Avg", "2-Frame Avg"});
-                runMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).runMode);
-                runMode.at(i)->installEventFilter(this);
-                runMode.at(i)->setProperty("slot", i);
-                runMode.at(i)->setProperty("type", App_Const::pBoxRunMode);
-                runMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
-                runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
-                                            "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
-                                            "at the cost of a small increase in latency; conversely, disabling this position averaging can "
-                                            "reduce latency, at the cost of some added jitter in mouse movement.</p>"
-                                            "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>");
-                connect(runMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                layoutMode << new QComboBox();
-                layoutMode.at(i)->addItems({"Square", "Diamond"});
-                layoutMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).layoutType);
-                layoutMode.at(i)->installEventFilter(this);
-                layoutMode.at(i)->setProperty("slot", i);
-                layoutMode.at(i)->setProperty("type", App_Const::pBoxLayout);
-                layoutMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
-                layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
-                                               "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
-                                               "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
-                                               "which uses one emitter at the center of each side of the display.</p>"
-                                               "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
-                                               "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
-                                               "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
-                                               "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
-                                               "<p>If unsure, use <b>Square Layout</b> "
-                                               "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>");
-                connect(layoutMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
-
-                color << new QPushButton();
-                color.at(i)->setFixedWidth(32);
-                color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Const::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
-                color.at(i)->installEventFilter(this);
-                color.at(i)->setProperty("slot", i);
-                color.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
-                color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
-                                          "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
-                                          "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>");
-                connect(color.at(i), &QPushButton::clicked, this, &guiWindow::colorBoxes_clicked);
-
-                caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
-                caliBtn.at(i)->installEventFilter(this);
-                caliBtn.at(i)->setProperty("slot", i);
-                caliBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
-                caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
-                caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
-                connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
-
-                topOffset.at(i)     ->setAlignment(Qt::AlignCenter);
-                bottomOffset.at(i)  ->setAlignment(Qt::AlignCenter);
-                leftOffset.at(i)    ->setAlignment(Qt::AlignCenter);
-                rightOffset.at(i)   ->setAlignment(Qt::AlignCenter);
-                TLled.at(i)         ->setAlignment(Qt::AlignCenter);
-                TRled.at(i)         ->setAlignment(Qt::AlignCenter);
-
-                ui->profilesArea->addWidget(renameBtn.at(i),       i+1, 0);
-                ui->profilesArea->addWidget(selectedProfile.at(i), i+1, 1);
-                ui->profilesArea->addWidget(topOffset.at(i),       i+1, 3);
-                ui->profilesArea->addWidget(bottomOffset.at(i),    i+1, 5);
-                ui->profilesArea->addWidget(leftOffset.at(i),      i+1, 7);
-                ui->profilesArea->addWidget(rightOffset.at(i),     i+1, 9);
-                ui->profilesArea->addWidget(TLled.at(i),           i+1, 11);
-                ui->profilesArea->addWidget(TRled.at(i),           i+1, 13);
-                ui->profilesArea->addWidget(irSens.at(i),          i+1, 15);
-                ui->profilesArea->addWidget(runMode.at(i),         i+1, 17);
-                ui->profilesArea->addWidget(layoutMode.at(i),      i+1, 19);
-                ui->profilesArea->addWidget(color.at(i),           i+1, 21);
-
-                ui->caliBtnsLayout->addWidget(caliBtn.at(i), caliBtnRow, i);
-            }
-
-            // Clears old board layout items
-            if(pinBoxes.count()) {
-                for(uint8_t i = 0; i < pinBoxes.count(); i++)
-                    delete pinBoxes.at(i);
-                for(uint8_t i = 0; i < padding.count(); i++)
-                    delete padding.at(i);
-                for(uint8_t i = 0; i < pinLabel.count(); i++)
-                    delete pinLabel.at(i);
-
-                pinBoxes.clear();
-                padding.clear();
-                pinLabel.clear();
-            }
-
-            for(uint8_t i = 0; i < PINS_COUNT; i++) {
-                pinBoxes << new QComboBox();
-                pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinBoxes.at(i)->setProperty("slot", i);
-                pinBoxes.at(i)->setProperty("prevMapping", OF_Const::btnUnmapped+1);
-                pinBoxes.at(i)->setProperty("trackable", App_Const::trackPinbox);
-                pinBoxes.at(i)->installEventFilter(this);
-                // install items
-                pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
-                // clear out analog options for digital pins (< GPIO26)
-                // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
-                if(i < 26) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
-                }
-                // filter out SCL/SDA if possible.
-                if(i & 1) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                } else {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                }
-                connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
-
-                padding << new QWidget();
-                padding.at(i)->setMinimumHeight(25);
-
-                // I2C channel coloring
-                if(i & 0b0000010)
-                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
-
-                pinLabel.at(i)->setEnabled(false);
-                pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
-            }
-
-            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Const::board.versionNumber, App_Const::board.versionCodename));
-
-            // update presets box if this board has any
-            ui->presetsBox->clear();
-
-            if(OF_Const::boardsAltPresets.count(App_Const::board.boardType.toStdString())) {
-                ui->presetsBox->setHidden(false);
-                ui->presetsBox->setEnabled(true);
-
-                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
-                for(auto &entry : altPresets)
-                    ui->presetsBox->addItem(entry.name);
-            } else {
-                ui->presetsBox->setEnabled(false);
-                ui->presetsBox->setHidden(true);
-            }
-
-            // set boxes to reflect indexes of inputsMap
-            BoxesUpdate();
-
-            LabelsUpdate();
-
-            // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(OF_Const::boardsBoxPositions.contains(App_Const::board.boardType.toStdString())) {
-                QFile resource(":/boardPics/" + App_Const::board.boardType);
-                resource.open(QIODevice::ReadOnly);
-                origBoardPicFile = resource.readAll();
-
-                for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
-                        ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
-                                                0);
-                        ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
-                                                1);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
-                        ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
-                                                 1);
-                        ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
-                                                 0);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
-                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
-                                                     1,
-                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
-                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
-                                                     0,
-                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
-                    }
-                }
-            } else {
-                QFile resource(":/boardPics/generic");
-                resource.open(QIODevice::ReadOnly);
-                origBoardPicFile = resource.readAll();
-
-                for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
-                        ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
-                                                0);
-                        ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
-                                                1);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posRight) {
-                        ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
-                                                 1);
-                        ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
-                                                 0);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posMiddle) {
-                        ui->PinsCenterSub->addWidget(pinBoxes.at(i),
-                                                     1,
-                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
-                        ui->PinsCenterSub->addWidget(pinLabel.at(i),
-                                                     0,
-                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
-                    }
-                }
-            }
-
-            // aspect ratio hint needs to be set every time a new asset is loaded
-            boardPic.load(origBoardPicFile);
-            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
-
-            int prevPadCount;
-            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
-                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                    prevPadCount = padCount;
-                }
-            }
-            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
-                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                }
-            }
-
-            ui->tabWidget->setEnabled(true);
-            ui->customPinsEnabled->setChecked(App_Const::boolSettings[OF_Const::customPins]);
-
-            if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
-                ui->rumbleToggle->setEnabled(true),  ui->rumbleFFToggle->setEnabled(true);
-            else ui->rumbleToggle->setEnabled(false), ui->rumbleFFToggle->setEnabled(false);
-            ui->rumbleToggle->setChecked(App_Const::boolSettings[OF_Const::rumble]);
-
-            if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
-                ui->solenoidToggle->setEnabled(true);
-            else ui->solenoidToggle->setEnabled(false);
-            ui->solenoidToggle->setChecked(App_Const::boolSettings[OF_Const::solenoid]);
-
-            if((App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF]) || App_Const::boolSettings[OF_Const::solenoid])
-                ui->autofireToggle->setEnabled(true);
-            else ui->autofireToggle->setEnabled(false);
-            ui->autofireToggle->setChecked(App_Const::boolSettings[OF_Const::autofire]);
-
-            ui->simplePauseToggle->setChecked(App_Const::boolSettings[OF_Const::simplePause]);
-            ui->holdToPauseToggle->setChecked(App_Const::boolSettings[OF_Const::holdToPause]);
-
-            if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
-                ui->commonAnodeToggle->setEnabled(true);
-            else ui->commonAnodeToggle->setEnabled(false);
-            ui->commonAnodeToggle->setChecked(App_Const::boolSettings[OF_Const::commonAnode]);
-
-            ui->lowButtonsToggle->setChecked(App_Const::boolSettings[OF_Const::lowButtonsMode]);
-            ui->rumbleFFToggle->setChecked(App_Const::boolSettings[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable[OF_Const::autofireWaitFactor]);
-
-            ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-            ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
-
-            if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
-                ui->neopixelGroupBox->setEnabled(true);
-            else ui->neopixelGroupBox->setEnabled(false);
-            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]);
-            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDstatic]);
-            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
-
-            switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
-            case 1:
-                ui->tUSB_p1->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 2:
-                ui->tUSB_p2->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 3:
-                ui->tUSB_p3->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            case 4:
-                ui->tUSB_p4->setChecked(true);
-                ui->tUSBLayoutAdvanced->setVisible(false);
-                ui->tUSBLayoutSimple->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(false);
-                break;
-            default:
-                ui->tUSB_p1->setChecked(false);
-                ui->tUSB_p2->setChecked(false);
-                ui->tUSB_p3->setChecked(false);
-                ui->tUSB_p4->setChecked(false);
-                ui->tUSBLayoutSimple->setVisible(false);
-                ui->tUSBLayoutAdvanced->setVisible(true);
-                ui->tinyUSBLayoutToggle->setChecked(true);
-                break;
-            }
-        } else ui->comPortSelector->setCurrentIndex(0);
-        serialPort_progressSet(0);
-        break;
-    case SerialThreadWorker::Serial_OneShot:
-        break;
-    case SerialThreadWorker::Serial_Sync:
-        if(success) {
-            statusBar()->showMessage("Sent settings successfully!", 5000);
-
-            // sync settings
-            for(int i = 0; i < OF_Const::boolTypesCount; i++)
-                App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
-
-            if(App_Const::boolSettings_orig[OF_Const::customPins])
-                App_Const::inputsMap_orig = App_Const::inputsMap;
-            else for(int i = 0; i < App_Const::inputsMap.size(); i++)
-                    App_Const::inputsMap_orig[i] = -1;
-
-            for(int i = 0; i < OF_Const::settingsTypesCount; i++)
-                App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
-
-            App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
-            App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
-            App_Const::board.previousProfile = App_Const::board.selectedProfile;
-
-            for(uint8_t i = 0; i < PROFILES_COUNT; i++) {
-                App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
-                App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
-                App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;
-                App_Const::profilesTable_orig[i].color = App_Const::profilesTable[i].color;
-                App_Const::profilesTable_orig[i].profName = App_Const::profilesTable[i].profName;
-            }
-
-            // Reflect new names in UI
-            LabelsUpdate();
-
-            // update (clear) diffs
-            PixelsDiff();
-            DiffUpdate();
-        } else printf("Settings syncing failed!?\n");
-        serialPort_progressSet(0);
-        ui->tabWidget->setEnabled(true);
-        ui->comPortSelector->setEnabled(true);
-        serialActive = false;
-        break;
-    case SerialThreadWorker::Serial_Disconnect:
-        // reset stuff
-        testLabel[14]->setStyleSheet("");
-        testLabel[15]->setStyleSheet("");
-        // force disable test mode if it was set
-        if(testMode) {
-            testMode = false;
-            ui->buttonsTestArea->setEnabled(true);
-            ui->pinsTab->setEnabled(true);
-            ui->settingsTab->setEnabled(true);
-            ui->profilesTab->setEnabled(true);
-            ui->feedbackTestsBox->setEnabled(true);
-            ui->dangerZoneBox->setEnabled(true);
-            serialActive = false;
-        }
-        serialActive = false;
-        ui->tabWidget->setEnabled(false);
-        break;
     }
+}
+
+
+void guiWindow::serialPort_DisconnectFinished()
+{
+    // reset stuff
+    testLabel[14]->setStyleSheet("");
+    testLabel[15]->setStyleSheet("");
+
+    // force disable test mode if it was set
+    if(testMode) {
+        testMode = false;
+        ui->buttonsTestArea->setEnabled(true);
+        ui->pinsTab->setEnabled(true);
+        ui->settingsTab->setEnabled(true);
+        ui->profilesTab->setEnabled(true);
+        ui->feedbackTestsBox->setEnabled(true);
+        ui->dangerZoneBox->setEnabled(true);
+        serialActive = false;
+    }
+
+    serialActive = false;
+    ui->tabWidget->setEnabled(false);
 }
 
 
@@ -1765,45 +1748,48 @@ void guiWindow::serialPort_progressSet(const int &range)
 }
 
 
-void guiWindow::serialPort_progressUpdate(const int &pos)
+void guiWindow::serialPort_progressUpdate(const int &pos, const char *statusText)
 {
     if(statusProgressBar->isVisible())
         statusProgressBar->setValue(pos);
+
+    if(statusText != nullptr)
+        ui->statusBar->showMessage(statusText, 5000);
 }
 
 
 void guiWindow::on_rumbleTestBtn_clicked()
 {
-    emit serial.OneShotSend("Xtr");
-    ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
+    if(serial.OneShotSend("Xtr"))
+        ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
 }
 
 
 void guiWindow::on_solenoidTestBtn_clicked()
 {
-    emit serial.OneShotSend("Xts");
-    ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
+    if(serial.OneShotSend("Xts"))
+        ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
 }
 
 
 void guiWindow::on_redLedTestBtn_clicked()
 {
-    emit serial.OneShotSend("XtR");
-    ui->statusBar->showMessage("Set LED to Red.", 2500);
+    if(serial.OneShotSend("XtR"))
+        ui->statusBar->showMessage("Set LED to Red.", 2500);
 }
 
 
 void guiWindow::on_greenLedTestBtn_clicked()
 {
-    emit serial.OneShotSend("XtG");
-    ui->statusBar->showMessage("Set LED to Green.", 2500);
+    if(serial.OneShotSend("XtG"))
+        ui->statusBar->showMessage("Set LED to Green.", 2500);
 }
 
 
 void guiWindow::on_blueLedTestBtn_clicked()
 {
-    emit serial.OneShotSend("XtB");
-    ui->statusBar->showMessage("Set LED to Blue.", 2500);
+    if(serial.OneShotSend("XtB"))
+        ui->statusBar->showMessage("Set LED to Blue.", 2500);
 }
 
 
@@ -1812,7 +1798,7 @@ void guiWindow::on_testBtn_clicked()
     // Pre-emptively put a sock in the readyRead signal
     serialActive = true;
 
-    emit serial.OneShotSend("XT");
+    serial.OneShotSend("XT");
 }
 
 
@@ -1861,18 +1847,18 @@ void guiWindow::CaliWindowExiting(const int &mode,
         break;
     }
     case AppCaliWindow::modeIRTest:
-        emit serial.OneShotSend("XT");
+        if(serial.OneShotSend("XT")) {
+            testMode = false;
 
-        testMode = false;
+            ui->buttonsTestArea->setEnabled(true);
+            ui->pinsTab->setEnabled(true);
+            ui->settingsTab->setEnabled(true);
+            ui->profilesTab->setEnabled(true);
+            ui->feedbackTestsBox->setEnabled(true);
+            ui->dangerZoneBox->setEnabled(true);
 
-        ui->buttonsTestArea->setEnabled(true);
-        ui->pinsTab->setEnabled(true);
-        ui->settingsTab->setEnabled(true);
-        ui->profilesTab->setEnabled(true);
-        ui->feedbackTestsBox->setEnabled(true);
-        ui->dangerZoneBox->setEnabled(true);
-
-        serialActive = false;
+            serialActive = false;
+        }
         break;
     case AppCaliWindow::modeAlignment:
     default:
@@ -1889,7 +1875,7 @@ void guiWindow::CaliWindowExiting(const int &mode,
 
 void guiWindow::CaliWindowRequestedExit()
 {
-    emit serial.OneShotSend("X");
+    serial.OneShotSend("X");
 }
 
 
@@ -1909,7 +1895,7 @@ void guiWindow::on_clearEepromBtn_clicked()
     messageBox.setDefaultButton(QMessageBox::Yes);
 
     if(messageBox.exec() == QMessageBox::Yes)
-        emit serial.OneShotSend("Xc");
+        serial.OneShotSend("Xc");
     else ui->statusBar->showMessage("Clear operation canceled.", 3000);
 }
 
@@ -1917,7 +1903,7 @@ void guiWindow::on_clearEepromBtn_clicked()
 void guiWindow::on_baudResetBtn_clicked()
 {
     // No need for workarounds, bootloader reset is in the firmware now.
-    emit serial.OneShotSend("Xxx");
+    serial.OneShotSend("Xxx");
 
 /* test stuff for potential app FW update functionality
     // At least on my system, the Bootloader device takes ~7s to appear

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -837,6 +837,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
     } else {
         ui->boardLabel->clear();
         ui->versionLabel->clear();
+        ui->tabWidget->setEnabled(false);
 
         if(serial.port.isOpen())
             serialDisconnectWatcher.setFuture(serialDisconnectFuture);

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -164,8 +164,6 @@ private slots:
 
     void serialPort_SearchFinished();
 
-    void serialPort_DisconnectFinished();
-
     void serialPort_progressSet(const int &);
 
     void serialPort_progressUpdate(const int &, const char* = nullptr);
@@ -235,9 +233,6 @@ private:
     // result of async serial operations
     QFuture<bool> serialSearchFuture;
     QFutureWatcher<bool> serialSearchWatcher;
-
-    QFuture<void> serialDisconnectFuture;
-    QFutureWatcher<void> serialDisconnectWatcher;
 
     bool serialActive = false;
 

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -34,6 +34,8 @@
 #include "../boards/OpenFIREshared.h"
 #include <QMainWindow>
 #include <QSerialPort>
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QGraphicsItem>
 #include <QPen>
 #include <QTimer>
@@ -62,8 +64,6 @@ public:
     ~guiWindow();
 
 private slots:
-    void Worker_Started();
-
     void aliveTimer_timeout();
 
     void on_comPortSelector_currentTextChanged(const QString &);
@@ -162,11 +162,13 @@ private slots:
 
     void serialPort_readyRead();
 
-    void serialPort_handleResult(const int &, const bool & = false);
+    void serialPort_SearchFinished();
+
+    void serialPort_DisconnectFinished();
 
     void serialPort_progressSet(const int &);
 
-    void serialPort_progressUpdate(const int &);
+    void serialPort_progressUpdate(const int &, const char* = nullptr);
 
     void on_actionOpenFIRE_Documentation_triggered();
 
@@ -228,12 +230,18 @@ private:
     //
     // vvv---Internal Values---vvv
 
-    SerialThreadController serial;
+    AppSerial serial;
+
+    // result of async serial operations
+    QFuture<bool> serialSearchFuture;
+    QFutureWatcher<bool> serialSearchWatcher;
+
+    QFuture<void> serialDisconnectFuture;
+    QFutureWatcher<void> serialDisconnectWatcher;
 
     bool serialActive = false;
 
     /// @brief      Temperature thresholds (which should be a customizable setting in the settingsTable)
-    // TODO: add this to settingsTable (5.1?)
     uint8_t tempWarning = 35;
     uint8_t tempShutoff = 42;
 
@@ -242,7 +250,7 @@ private:
 
     /// @brief      Timer that probes the board if it's still plugged in
     /// @details    Timer interval is provided in ms by ALIVE_TIMER
-    QTimer *aliveTimer;
+    QTimer aliveTimer;
 
     // ^^^---Internal Values---^^^
     //

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -30,6 +30,7 @@
 #include "constants.h"
 #include "appcali.h"
 #include "appdebug.h"
+#include "appserial.h"
 #include "../boards/OpenFIREshared.h"
 #include <QMainWindow>
 #include <QSerialPort>
@@ -44,6 +45,7 @@
 #include <QPushButton>
 #include <QRadioButton>
 #include <QSvgWidget>
+#include <QProgressBar>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -60,15 +62,15 @@ public:
     ~guiWindow();
 
 private slots:
+    void Worker_Started();
+
     void aliveTimer_timeout();
 
-    void on_comPortSelector_currentIndexChanged(int index);
+    void on_comPortSelector_currentTextChanged(const QString &);
 
     void on_confirmButton_clicked();
 
     void pinBoxes_currentIndexChanged(int index);
-
-    void serialPort_readyRead();
 
     void renameBoxes_clicked();
 
@@ -158,6 +160,14 @@ private slots:
 
     void on_tabWidget_currentChanged(int index);
 
+    void serialPort_readyRead();
+
+    void serialPort_handleResult(const int &, const bool & = false);
+
+    void serialPort_progressSet(const int &);
+
+    void serialPort_progressUpdate(const int &);
+
     void on_actionOpenFIRE_Documentation_triggered();
 
     void on_actionOpenFIRE_Serial_Usage_triggered();
@@ -206,19 +216,6 @@ private:
     /// @details    Controls enablement of certain settings in the NeoPixels section of settings
     void PixelsDiff();
 
-    /// @brief      Search for available serial port devices
-    /// @details    Filters for OpenFIRE devices specifically
-    // (TODO: move to appserial)
-    void PortsSearch();
-
-    /// @brief      Pair serial device to portNum device, and start grabbing its info
-    /// @returns    True if device could be initiated, false if syncing failed
-    bool SerialInit(int portNum);
-
-    /// @brief      Grab firmware settings from serial device
-    /// @details    Currently only called by the success route of SerialInit
-    void SerialLoad();
-
     /// @brief      Disables given setting of a combobox
     /// @arg        Combobox item, index number to toggle, enable state to set to
     void SetComboBoxItemEnabled(QComboBox * comboBox, const int index, const bool enabled) {
@@ -231,30 +228,9 @@ private:
     //
     // vvv---Internal Values---vvv
 
-    QSerialPort serialPort;
+    SerialThreadController serial;
 
     bool serialActive = false;
-
-    /// @brief      List of serial port objects that were found in PortsSearch()
-    QList<QSerialPortInfo> serialFoundList;
-
-    /// @brief      Extracted COM paths, as provided from serialFoundList
-    QStringList usbName;
-
-    /// @brief      Current array of booleans
-    /// @details    Meant for toggle/on-off type settings specifically
-    bool boolSettings[OF_Const::boolTypesCount];
-
-    /// @brief      Array of booleans last synced from the microcontroller
-    /// @details    This is only updated on saving and loading settings successfully
-    bool boolSettings_orig[OF_Const::boolTypesCount];
-
-    /// @brief      Current array of tunable settings
-    uint32_t settingsTable[OF_Const::settingsTypesCount];
-
-    /// @brief      Array of tunables last synced from the microcontroller
-    /// @details    This is only updated on saving and loading settings successfully
-    uint32_t settingsTable_orig[OF_Const::settingsTypesCount];
 
     /// @brief      Temperature thresholds (which should be a customizable setting in the settingsTable)
     // TODO: add this to settingsTable (5.1?)
@@ -306,5 +282,7 @@ private:
     QVector<QPushButton*> color;
     QVector<QPushButton*> renameBtn;
     QVector<QPushButton*> caliBtn;
+
+    QProgressBar *statusProgressBar = nullptr;
 };
 #endif // GUIWINDOW_H

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -21,9 +21,6 @@
 // Maximum amount of GPIO that the RP2040 microcontroller has available
 #define PINS_COUNT 30
 
-// Default maximum amount of profiles to read in (TODO: could just be made a flexible number)
-#define PROFILES_COUNT 4
-
 // Interval of the aliveTimer object that probes the board to ensure it's connected
 #define ALIVE_TIMER 5000
 

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -61,6 +61,9 @@
           <height>0</height>
          </size>
         </property>
+        <property name="placeholderText">
+         <string>[No devices detected]</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -108,9 +111,6 @@
     </item>
     <item>
      <widget class="QTabWidget" name="tabWidget">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
       <property name="tabPosition">
        <enum>QTabWidget::TabPosition::South</enum>
       </property>

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -91,6 +91,7 @@ bool AppSerial::GetSettings(const QString &portName)
                         App_Const::board.selectedProfile = buffer.at(4).toInt();
                         App_Const::board.previousProfile = App_Const::board.selectedProfile;
 
+                        // get TUSB info
                         port.write("Xli");
                         port.waitForBytesWritten(500);
                         port.waitForReadyRead(500);
@@ -109,6 +110,8 @@ bool AppSerial::GetSettings(const QString &portName)
                         emit Serial_ProgressUpdate(1, "Getting Settings (1)");
 
                         port.clear();
+
+                        // get toggles
                         port.write("Xlb");
                         if(port.waitForBytesWritten(500)) {
                             if(port.waitForReadyRead(500)) {
@@ -167,11 +170,9 @@ bool AppSerial::GetSettings(const QString &portName)
                                 // profiles
                                 App_Const::profilesTable.clear(), App_Const::profilesTable_orig.clear();
 
-                                // TODO: don't think we NEED to limit reading only to profiles count?
-                                // perhaps just stop at the first invalid response from the board
                                 for(uint8_t i = 0;; i++) {
                                     port.clear();
-                                    port.write(QString("XlP%1").arg(i).toLocal8Bit());
+                                    port.write("XlP" + QByteArray::number(i));
                                     port.waitForBytesWritten(500);
                                     if(port.waitForReadyRead(500)) {
                                         // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
@@ -182,16 +183,16 @@ bool AppSerial::GetSettings(const QString &portName)
 
                                         // copy settings
                                         App_Const::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                                            App_Const::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                                            App_Const::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                                            App_Const::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                            App_Const::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+                                        App_Const::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
+                                        App_Const::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
+                                        App_Const::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].runMode = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
+                                        App_Const::profilesTable[i].color = buffer.takeFirst().toLong(),
+                                        App_Const::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
 
                                         App_Const::profilesTable_orig[i] = App_Const::profilesTable.at(i);
                                     } else break;
@@ -202,9 +203,9 @@ bool AppSerial::GetSettings(const QString &portName)
                                 return true;
 
                             } else QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
-                                                     "Device was detected, but settings request wasn't received in time!\n"
-                                                     "This can happen if the app was closed in the middle of an operation.\n\n"
-                                                     "Try selecting the device again.");
+                                                                 "Device was detected, but settings request wasn't received in time!\n"
+                                                                 "This can happen if the app was closed in the middle of an operation.\n\n"
+                                                                 "Try selecting the device again.");
                         } else {
                             printf("Couldn't send any data in time! Does the port even exist???\n");
                             return false;
@@ -214,10 +215,10 @@ bool AppSerial::GetSettings(const QString &portName)
                         return false;
                     }
                 } else {
-                    QMessageBox::warning(nullptr,  "Data hasn't arrived! (Stale state?)",
-                                         "Device was detected, but initial settings request wasn't received in time!\n"
-                                         "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                                         "Try selecting the device again.");
+                    QMessageBox::warning(nullptr,   "Data hasn't arrived! (Stale state?)",
+                                                    "Device was detected, but initial settings request wasn't received in time!\n"
+                                                    "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
+                                                    "Try selecting the device again.");
                     return false;
                 }
             } else {
@@ -225,9 +226,9 @@ bool AppSerial::GetSettings(const QString &portName)
                 return false;
             }
         } else {
-            QMessageBox::warning(nullptr,  "Serial port is already in use!",
-                                 "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
-                                 "Please close the offending application and try selecting this port again.");
+            QMessageBox::warning(nullptr,   "Serial port is already in use!",
+                                            "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
+                                            "Please close the offending application and try selecting this port again.");
             return false;
         }
     } else return false;
@@ -238,8 +239,9 @@ bool AppSerial::OneShotSend(const QByteArray &string)
 {
     if(port.isOpen()) {
         port.write(string);
-        port.waitForBytesWritten(1000);
-        return true;
+        if(port.waitForBytesWritten(1000))
+            return true;
+        else return false;
     } else return false;
 }
 
@@ -285,8 +287,9 @@ bool AppSerial::CommitSettings()
             if(port.waitForReadyRead(1000)) {
                 QString buffer = port.readLine();
                 if(buffer.contains("OK:") || buffer.contains("NOENT:")) {
-                    emit Serial_ProgressUpdate(i);
+                    emit Serial_ProgressUpdate(i, "Committing settings to microcontroller...");
                 } else if(i == serialQueue.length() - 1 && buffer.contains("Saving preferences...")) {
+                    emit Serial_ProgressUpdate(serialQueue.length()-1, "Successfully synced settings!");
                     return true;
                 } else return false;
             } else return false;
@@ -299,8 +302,8 @@ void AppSerial::Disconnect()
 {
     if(port.isOpen()) {
         port.write("XE");
-        port.waitForBytesWritten(1000);
-        port.waitForReadyRead(1000);
+        port.waitForBytesWritten(500);
+        port.waitForReadyRead(500);
         port.close();
     }
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -1,8 +1,308 @@
 #include "appserial.h"
+#include "constants.h"
+#include "../boards/OpenFIREshared.h"
+#include <QMessageBox>
 
-AppSerialDevice::AppSerialDevice(QObject *parent)
-    : QObject{parent}
+bool SerialThreadWorker::SearchPorts()
 {
+    QList<QSerialPortInfo> serialFoundList = QSerialPortInfo::availablePorts();
+    if(!serialFoundList.isEmpty()) {
+        // Yeah, sue me, we reading this backwards to make stack management easier.
+        for(int i = serialFoundList.length() - 1; i >= 0; --i) {
+            if(serialFoundList.at(i).vendorIdentifier() == 0xF143) {
+                printf("Found device @ %s\n", serialFoundList.at(i).systemLocation().toLocal8Bit().constData());
+            } else {
+                if(!serialFoundList.at(i).systemLocation().contains("tty"))
+                    printf("Deleting dummy device %s\n", serialFoundList.at(i).systemLocation().toLocal8Bit().constData());
+                serialFoundList.removeAt(i);
+            }
+        }
 
+        // Compare to and replace original list only if entries differ.
+        if(currentPorts.size() != serialFoundList.size()) {
+            currentPorts = serialFoundList;
+            printf("Current ports list does not match new list, overriding...\n");
+            currentPortsNames = GeneratePortsList(currentPorts);
+            return true;
+        } else for(const auto port : serialFoundList) {
+            if(!currentPortsNames.contains(port.portName())) {
+                currentPorts = serialFoundList;
+                printf("%s not found in current ports, overriding old serial devices list...\n", port.portName().toLocal8Bit().constData());
+                currentPortsNames = GeneratePortsList(currentPorts);
+                return true;
+            }
+        }
+        return false;
+    } else return true;
 }
 
+QStringList SerialThreadWorker::GeneratePortsList(const QList<QSerialPortInfo> &portsList)
+{
+    QStringList newList;
+
+    for(const auto port : portsList)
+        newList.append(port.portName());
+
+    return newList;
+}
+
+bool SerialThreadWorker::GetSettings(const QString &portName)
+{
+    for(const auto curPort : currentPorts)
+        if(portName == curPort.portName())
+            port->setPort(curPort);
+
+    if(!port->portName().isEmpty()) {
+        port->setBaudRate(QSerialPort::Baud9600);
+        if(port->open(QIODevice::ReadWrite)) {
+            //serialActive = true;
+
+            // windows needs DTR enabled to actually read responses.
+            port->setDataTerminalReady(true);
+
+            port->write("XP");
+            if(port->waitForBytesWritten(500)) {
+                if(port->waitForReadyRead(500)) {
+                    QByteArray bufStr = port->readLine().trimmed();
+                    QList<QByteArray> buffer = bufStr.split(',');
+
+                    if(buffer.at(0) == "CAMERROR: Not available") {
+                        QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
+                                             "Data received from the board indicates that the camera is in a bad state.\n"
+                                             "This can happen if the camera wires are crossed (data wire to clock pin, clock wire to data pin).\n\n"
+                                             "The camera must be removed or resoldered to resolve this.");
+                        buffer.takeFirst();
+                    }
+
+                    if(buffer.at(0).contains("OpenFIRE")) {
+                        printf("OpenFIRE gun detected!\n");
+
+                        emit Serial_SetProgressRange(5);
+
+                        App_Const::board.versionNumber = buffer.at(1).constData();
+                        printf("Version number: %s\n", App_Const::board.versionNumber.toLocal8Bit().constData());
+
+                        App_Const::board.versionCodename = buffer.at(2).constData();
+                        printf("Version codename: %s\n", App_Const::board.versionCodename.toLocal8Bit().constData());
+
+                        App_Const::board.boardType = buffer.at(3).constData();
+                        printf("Board type: %s\n", App_Const::board.boardType.toLocal8Bit().constData());
+
+                        App_Const::board.selectedProfile = buffer.at(4).toInt();
+                        App_Const::board.previousProfile = App_Const::board.selectedProfile;
+
+                        port->write("Xli");
+                        port->waitForBytesWritten(500);
+                        port->waitForReadyRead(500);
+
+                        bufStr = port->readLine().trimmed();
+                        buffer = bufStr.split(',');
+                        App_Const::tinyUSBtable.tinyUSBid = buffer.at(0);
+                        App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
+
+                        if(buffer[1] == "SERIALREADERR01")
+                            App_Const::tinyUSBtable.tinyUSBname = "";
+
+                        else App_Const::tinyUSBtable.tinyUSBname = buffer.at(1);
+
+                        App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
+
+                        emit Serial_ProgressUpdate(1);
+
+                        port->clear();
+                        port->write("Xlb");
+                        if(port->waitForBytesWritten(500)) {
+                            if(port->waitForReadyRead(500)) {
+                                QString bufStr = port->readLine().trimmed();
+                                QStringList buffer = bufStr.split(',');
+
+                                // booleans
+                                for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
+                                    if(!buffer.isEmpty()) {
+                                        App_Const::boolSettings[i] = buffer[i].toInt();
+                                        App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
+                                    } else break;
+                                }
+
+                                emit Serial_ProgressUpdate(2);
+
+                                // pins
+                                if(App_Const::boolSettings[OF_Const::customPins]) {
+                                    port->clear();
+                                    port->write("Xlp");
+                                    port->waitForBytesWritten(500);
+                                    port->waitForReadyRead(500);
+                                    App_Const::inputsMap_orig.clear(), App_Const::inputsMap.clear();
+                                    bufStr = port->readLine().trimmed();
+                                    buffer = bufStr.split(',');
+                                    for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
+                                        if(!buffer.isEmpty())
+                                            App_Const::inputsMap_orig[i] = buffer[i].toInt();
+                                        else break;
+                                    }
+                                } else {
+                                    for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                                        App_Const::inputsMap_orig[i] = OF_Const::btnUnmapped;
+                                }
+
+                                emit Serial_ProgressUpdate(3);
+
+                                App_Const::inputsMap = App_Const::inputsMap_orig;
+
+                                // settings
+                                port->clear();
+                                port->write("Xls");
+                                port->waitForBytesWritten(500);
+                                port->waitForReadyRead(500);
+                                bufStr = port->readLine().trimmed();
+                                buffer = bufStr.split(',');
+                                for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
+                                    if(!buffer.isEmpty()) {
+                                        App_Const::settingsTable[i] = buffer[i].toInt();
+                                        App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
+                                    } else break;
+                                }
+
+                                emit Serial_ProgressUpdate(4);
+
+                                // profiles
+                                App_Const::profilesTable.clear(), App_Const::profilesTable_orig.clear();
+
+                                // TODO: don't think we NEED to limit reading only to profiles count?
+                                // perhaps just stop at the first invalid response from the board
+                                for(uint8_t i = 0;; i++) {
+                                    port->clear();
+                                    port->write(QString("XlP%1").arg(i).toLocal8Bit());
+                                    port->waitForBytesWritten(500);
+                                    if(port->waitForReadyRead(500)) {
+                                        // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
+                                        bufStr = port->readLine().trimmed();
+                                        buffer = bufStr.split(',');
+
+                                        App_Const::profilesTable << App_Const::profilesTable_s(), App_Const::profilesTable_orig << App_Const::profilesTable_s();
+
+                                        // copy settings
+                                        App_Const::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
+                                            App_Const::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
+                                            App_Const::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].runMode = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
+                                            App_Const::profilesTable[i].color = buffer.takeFirst().toLong(),
+                                            App_Const::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+
+                                        App_Const::profilesTable_orig[i] = App_Const::profilesTable.at(i);
+                                    } else break;
+                                }
+                                emit Serial_ProgressUpdate(5);
+                                return true;
+                            } else QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
+                                                     "Device was detected, but settings request wasn't received in time!\n"
+                                                     "This can happen if the app was closed in the middle of an operation.\n\n"
+                                                     "Try selecting the device again.");
+                        } else {
+                            printf("Couldn't send any data in time! Does the port even exist???\n");
+                            return false;
+                        }
+                    } else {
+                        printf("Port did not respond with expected response! Got: %s", buffer.join(',').constData());
+                        return false;
+                    }
+                } else {
+                    //QMessageBox::warning(this,  "Data hasn't arrived! (Stale state?)",
+                    //                     "Device was detected, but initial settings request wasn't received in time!\n"
+                    //                     "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
+                    //                     "Try selecting the device again.");
+                    return false;
+                }
+            } else {
+                printf("Couldn't send any data in time! Does the port even exist???\n");
+                return false;
+            }
+        } else {
+            //QMessageBox::warning(this,  "Serial port is already in use!",
+            //                     "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
+            //                     "Please close the offending application and try selecting this port again.");
+            return false;
+        }
+    } else return false;
+    return false;
+}
+
+bool SerialThreadWorker::OneShotSend(const QString &string)
+{
+    if(port->isOpen()) {
+        port->write(string.toLocal8Bit());
+        port->waitForBytesWritten(1000);
+        return true;
+    } else return false;
+}
+
+bool SerialThreadWorker::CommitSettings()
+{
+    if(port->isOpen()) {
+        // send a signal so the gun pauses its test outputs for the save op.
+        port->write("Xm");
+        port->waitForBytesWritten(1000);
+
+        QStringList serialQueue;
+        for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++)
+            serialQueue.append(QString("Xm.0.%1.%2").arg(i).arg(App_Const::boolSettings[i]));
+
+        if(App_Const::boolSettings[OF_Const::customPins])
+            for(uint8_t i = 0; i < App_Const::inputsMap.count(); i++)
+                serialQueue.append(QString("Xm.1.%1.%2").arg(i).arg(App_Const::inputsMap.value(i)));
+
+        for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
+            serialQueue.append(QString("Xm.2.%1.%2").arg(i).arg(App_Const::settingsTable[i]));
+
+        serialQueue.append(QString("Xm.3.0.%1").arg(App_Const::tinyUSBtable.tinyUSBid));
+        if(!App_Const::tinyUSBtable.tinyUSBname.isEmpty())
+            serialQueue.append(QString("Xm.3.1.%1").arg(App_Const::tinyUSBtable.tinyUSBname));
+
+        for(uint8_t i = 0; i < 4; i++) {
+            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Const::profilesTable[i].irSensitivity));
+            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Const::profilesTable[i].runMode));
+            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Const::profilesTable[i].layoutType));
+            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Const::profilesTable[i].color));
+            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(App_Const::profilesTable[i].profName));
+        }
+        serialQueue.append("XS");
+
+        emit Serial_SetProgressRange(serialQueue.length()-1);
+
+        // throw out whatever's in the buffer if there's anything there.
+        port->clear();
+
+        for(uint8_t i = 0; i < serialQueue.length(); i++) {
+            port->write(serialQueue.at(i).toLocal8Bit());
+            port->waitForBytesWritten(1000);
+            if(port->waitForReadyRead(1000)) {
+                QString buffer = port->readLine();
+                if(buffer.contains("OK:") || buffer.contains("NOENT:")) {
+                    emit Serial_ProgressUpdate(i);
+                } else if(i == serialQueue.length() - 1 && buffer.contains("Saving preferences...")) {
+                    return true;
+                } else return false;
+            } else return false;
+        }
+    } else return false;
+    return false;
+}
+
+bool SerialThreadWorker::Disconnect()
+{
+    if(port->isOpen()) {
+        port->write("XE");
+        port->waitForBytesWritten(1000);
+        port->waitForReadyRead(1000);
+        port->close();
+    }
+
+    port->setPortName("");
+
+    return true;
+}

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -3,7 +3,7 @@
 #include "../boards/OpenFIREshared.h"
 #include <QMessageBox>
 
-bool SerialThreadWorker::SearchPorts()
+bool AppSerial::SearchPorts()
 {
     QList<QSerialPortInfo> serialFoundList = QSerialPortInfo::availablePorts();
     if(!serialFoundList.isEmpty()) {
@@ -24,7 +24,7 @@ bool SerialThreadWorker::SearchPorts()
             printf("Current ports list does not match new list, overriding...\n");
             currentPortsNames = GeneratePortsList(currentPorts);
             return true;
-        } else for(const auto port : serialFoundList) {
+        } else for(const auto &port : serialFoundList) {
             if(!currentPortsNames.contains(port.portName())) {
                 currentPorts = serialFoundList;
                 printf("%s not found in current ports, overriding old serial devices list...\n", port.portName().toLocal8Bit().constData());
@@ -36,34 +36,34 @@ bool SerialThreadWorker::SearchPorts()
     } else return true;
 }
 
-QStringList SerialThreadWorker::GeneratePortsList(const QList<QSerialPortInfo> &portsList)
+QStringList AppSerial::GeneratePortsList(const QList<QSerialPortInfo> &portsList)
 {
     QStringList newList;
 
-    for(const auto port : portsList)
+    for(const auto &port : portsList)
         newList.append(port.portName());
 
     return newList;
 }
 
-bool SerialThreadWorker::GetSettings(const QString &portName)
+bool AppSerial::GetSettings(const QString &portName)
 {
-    for(const auto curPort : currentPorts)
+    for(const auto &curPort : currentPorts)
         if(portName == curPort.portName())
-            port->setPort(curPort);
+            port.setPort(curPort);
 
-    if(!port->portName().isEmpty()) {
-        port->setBaudRate(QSerialPort::Baud9600);
-        if(port->open(QIODevice::ReadWrite)) {
+    if(!port.portName().isEmpty()) {
+        port.setBaudRate(QSerialPort::Baud9600);
+        if(port.open(QIODevice::ReadWrite)) {
             //serialActive = true;
 
             // windows needs DTR enabled to actually read responses.
-            port->setDataTerminalReady(true);
+            port.setDataTerminalReady(true);
 
-            port->write("XP");
-            if(port->waitForBytesWritten(500)) {
-                if(port->waitForReadyRead(500)) {
-                    QByteArray bufStr = port->readLine().trimmed();
+            port.write("XP");
+            if(port.waitForBytesWritten(500)) {
+                if(port.waitForReadyRead(500)) {
+                    QByteArray bufStr = port.readLine().trimmed();
                     QList<QByteArray> buffer = bufStr.split(',');
 
                     if(buffer.at(0) == "CAMERROR: Not available") {
@@ -91,29 +91,28 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                         App_Const::board.selectedProfile = buffer.at(4).toInt();
                         App_Const::board.previousProfile = App_Const::board.selectedProfile;
 
-                        port->write("Xli");
-                        port->waitForBytesWritten(500);
-                        port->waitForReadyRead(500);
+                        port.write("Xli");
+                        port.waitForBytesWritten(500);
+                        port.waitForReadyRead(500);
 
-                        bufStr = port->readLine().trimmed();
+                        bufStr = port.readLine().trimmed();
                         buffer = bufStr.split(',');
                         App_Const::tinyUSBtable.tinyUSBid = buffer.at(0);
                         App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
 
                         if(buffer[1] == "SERIALREADERR01")
                             App_Const::tinyUSBtable.tinyUSBname = "";
-
                         else App_Const::tinyUSBtable.tinyUSBname = buffer.at(1);
 
                         App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
 
-                        emit Serial_ProgressUpdate(1);
+                        emit Serial_ProgressUpdate(1, "Getting Settings (1)");
 
-                        port->clear();
-                        port->write("Xlb");
-                        if(port->waitForBytesWritten(500)) {
-                            if(port->waitForReadyRead(500)) {
-                                QString bufStr = port->readLine().trimmed();
+                        port.clear();
+                        port.write("Xlb");
+                        if(port.waitForBytesWritten(500)) {
+                            if(port.waitForReadyRead(500)) {
+                                QString bufStr = port.readLine().trimmed();
                                 QStringList buffer = bufStr.split(',');
 
                                 // booleans
@@ -124,16 +123,16 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                                     } else break;
                                 }
 
-                                emit Serial_ProgressUpdate(2);
+                                emit Serial_ProgressUpdate(2, "Getting Settings (2)");
 
                                 // pins
                                 if(App_Const::boolSettings[OF_Const::customPins]) {
-                                    port->clear();
-                                    port->write("Xlp");
-                                    port->waitForBytesWritten(500);
-                                    port->waitForReadyRead(500);
+                                    port.clear();
+                                    port.write("Xlp");
+                                    port.waitForBytesWritten(500);
+                                    port.waitForReadyRead(500);
                                     App_Const::inputsMap_orig.clear(), App_Const::inputsMap.clear();
-                                    bufStr = port->readLine().trimmed();
+                                    bufStr = port.readLine().trimmed();
                                     buffer = bufStr.split(',');
                                     for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
                                         if(!buffer.isEmpty())
@@ -145,16 +144,16 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                                         App_Const::inputsMap_orig[i] = OF_Const::btnUnmapped;
                                 }
 
-                                emit Serial_ProgressUpdate(3);
+                                emit Serial_ProgressUpdate(3, "Getting Settings (3)");
 
                                 App_Const::inputsMap = App_Const::inputsMap_orig;
 
                                 // settings
-                                port->clear();
-                                port->write("Xls");
-                                port->waitForBytesWritten(500);
-                                port->waitForReadyRead(500);
-                                bufStr = port->readLine().trimmed();
+                                port.clear();
+                                port.write("Xls");
+                                port.waitForBytesWritten(500);
+                                port.waitForReadyRead(500);
+                                bufStr = port.readLine().trimmed();
                                 buffer = bufStr.split(',');
                                 for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
                                     if(!buffer.isEmpty()) {
@@ -163,7 +162,7 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                                     } else break;
                                 }
 
-                                emit Serial_ProgressUpdate(4);
+                                emit Serial_ProgressUpdate(4, "Getting Profiles Data");
 
                                 // profiles
                                 App_Const::profilesTable.clear(), App_Const::profilesTable_orig.clear();
@@ -171,12 +170,12 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                                 // TODO: don't think we NEED to limit reading only to profiles count?
                                 // perhaps just stop at the first invalid response from the board
                                 for(uint8_t i = 0;; i++) {
-                                    port->clear();
-                                    port->write(QString("XlP%1").arg(i).toLocal8Bit());
-                                    port->waitForBytesWritten(500);
-                                    if(port->waitForReadyRead(500)) {
+                                    port.clear();
+                                    port.write(QString("XlP%1").arg(i).toLocal8Bit());
+                                    port.waitForBytesWritten(500);
+                                    if(port.waitForReadyRead(500)) {
                                         // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
-                                        bufStr = port->readLine().trimmed();
+                                        bufStr = port.readLine().trimmed();
                                         buffer = bufStr.split(',');
 
                                         App_Const::profilesTable << App_Const::profilesTable_s(), App_Const::profilesTable_orig << App_Const::profilesTable_s();
@@ -197,8 +196,11 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                                         App_Const::profilesTable_orig[i] = App_Const::profilesTable.at(i);
                                     } else break;
                                 }
-                                emit Serial_ProgressUpdate(5);
+
+                                emit Serial_ProgressUpdate(5, "Successfully synced data!");
+
                                 return true;
+
                             } else QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
                                                      "Device was detected, but settings request wasn't received in time!\n"
                                                      "This can happen if the app was closed in the middle of an operation.\n\n"
@@ -208,14 +210,14 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                             return false;
                         }
                     } else {
-                        printf("Port did not respond with expected response! Got: %s", buffer.join(',').constData());
+                        printf("Port did not respond with expected response! Got: %s\n", buffer.join(',').constData());
                         return false;
                     }
                 } else {
-                    //QMessageBox::warning(this,  "Data hasn't arrived! (Stale state?)",
-                    //                     "Device was detected, but initial settings request wasn't received in time!\n"
-                    //                     "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                    //                     "Try selecting the device again.");
+                    QMessageBox::warning(nullptr,  "Data hasn't arrived! (Stale state?)",
+                                         "Device was detected, but initial settings request wasn't received in time!\n"
+                                         "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
+                                         "Try selecting the device again.");
                     return false;
                 }
             } else {
@@ -223,30 +225,30 @@ bool SerialThreadWorker::GetSettings(const QString &portName)
                 return false;
             }
         } else {
-            //QMessageBox::warning(this,  "Serial port is already in use!",
-            //                     "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
-            //                     "Please close the offending application and try selecting this port again.");
+            QMessageBox::warning(nullptr,  "Serial port is already in use!",
+                                 "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
+                                 "Please close the offending application and try selecting this port again.");
             return false;
         }
     } else return false;
     return false;
 }
 
-bool SerialThreadWorker::OneShotSend(const QString &string)
+bool AppSerial::OneShotSend(const QByteArray &string)
 {
-    if(port->isOpen()) {
-        port->write(string.toLocal8Bit());
-        port->waitForBytesWritten(1000);
+    if(port.isOpen()) {
+        port.write(string);
+        port.waitForBytesWritten(1000);
         return true;
     } else return false;
 }
 
-bool SerialThreadWorker::CommitSettings()
+bool AppSerial::CommitSettings()
 {
-    if(port->isOpen()) {
+    if(port.isOpen()) {
         // send a signal so the gun pauses its test outputs for the save op.
-        port->write("Xm");
-        port->waitForBytesWritten(1000);
+        port.write("Xm");
+        port.waitForBytesWritten(1000);
 
         QStringList serialQueue;
         for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++)
@@ -275,13 +277,13 @@ bool SerialThreadWorker::CommitSettings()
         emit Serial_SetProgressRange(serialQueue.length()-1);
 
         // throw out whatever's in the buffer if there's anything there.
-        port->clear();
+        port.clear();
 
         for(uint8_t i = 0; i < serialQueue.length(); i++) {
-            port->write(serialQueue.at(i).toLocal8Bit());
-            port->waitForBytesWritten(1000);
-            if(port->waitForReadyRead(1000)) {
-                QString buffer = port->readLine();
+            port.write(serialQueue.at(i).toLocal8Bit());
+            port.waitForBytesWritten(1000);
+            if(port.waitForReadyRead(1000)) {
+                QString buffer = port.readLine();
                 if(buffer.contains("OK:") || buffer.contains("NOENT:")) {
                     emit Serial_ProgressUpdate(i);
                 } else if(i == serialQueue.length() - 1 && buffer.contains("Saving preferences...")) {
@@ -293,16 +295,14 @@ bool SerialThreadWorker::CommitSettings()
     return false;
 }
 
-bool SerialThreadWorker::Disconnect()
+void AppSerial::Disconnect()
 {
-    if(port->isOpen()) {
-        port->write("XE");
-        port->waitForBytesWritten(1000);
-        port->waitForReadyRead(1000);
-        port->close();
+    if(port.isOpen()) {
+        port.write("XE");
+        port.waitForBytesWritten(1000);
+        port.waitForReadyRead(1000);
+        port.close();
     }
 
-    port->setPortName("");
-
-    return true;
+    port.setPortName("");
 }

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -3,18 +3,165 @@
 
 #include <QObject>
 #include <QSerialPort>
+#include <QSerialPortInfo>
+#include <QThread>
 
-class AppSerialDevice : public QObject
+class SerialThreadWorker : public QObject
 {
     Q_OBJECT
+
 public:
-    explicit AppSerialDevice(QObject *parent = nullptr);
+    SerialThreadWorker() {};
 
-private:
+    enum {
+        Serial_SearchPorts = 0,
+        Serial_GetSettings,
+        Serial_OneShot,
+        Serial_Sync,
+        Serial_Disconnect
+    } serialReturnTypes_e;
 
+    QSerialPort *port;
+
+    /// @brief      Primary list of found serial devices
+    /// @note       Only to be updated when new found ports list is different from this one.
+    QList<QSerialPortInfo> currentPorts;
+
+    QStringList currentPortsNames;
+
+    /// @brief      Searches for new serial devices
+    /// @returns    Whether devices list has changed (true) or not (false)
+    /// @note       If found devices are different, this list is merged into the new currentPorts.
+    bool SearchPorts();
+
+    QStringList GeneratePortsList(const QList<QSerialPortInfo> &);
+
+    /// @brief      Grabs settings from connected Serial device to App_Const
+    /// @returns    Success (true) or failure (false)
+    /// @param      Index of currentPorts list to pull from
+    bool GetSettings(const QString &);
+
+    /// @brief      Sends serial message to currently connected Serial device
+    /// @returns    Success (true) or failure (false)
+    /// @param      QString
+    ///             String to send to device
+    bool OneShotSend(const QString &);
+
+    /// @brief      Commits settings (App_Const) to currently connected Serial device
+    /// @returns    Success (true) or failure (false)
+    bool CommitSettings();
+
+    /// @brief      Disconnects current serial device and clears port name
+    /// @returns    Always true
+    bool Disconnect();
 
 signals:
+    void Worker_StartupFinished();
 
+    /// @brief      Signal emitted at the end of SearchPorts method.
+    /// @param      int
+    ///             Serial method indicator
+    /// @param      bool
+    ///             Result of SearchPorts method
+    void SearchPorts_Result(const int &, const bool &);
+
+    /// @brief      Signal emitted at the end of GetSettings method.
+    /// @param      int
+    ///             Serial method indicator
+    /// @param      bool
+    ///             Result of GetSettings method
+    void GetSettings_Result(const int &, const bool &);
+
+    /// @brief      Signal emitted at the end of OneShotSend method.
+    /// @param      int
+    ///             Serial method indicator
+    /// @param      bool
+    ///             Result of OneShotSend method
+    void OneShot_Result(const int &, const bool &);
+
+    /// @brief      Signal emitted at the end of CommitSettings method.
+    /// @param      int
+    ///             Serial method indicator
+    /// @param      bool
+    ///             Result of CommitSettings method
+    void Commit_Result(const int &, const bool &);
+
+    /// @brief      Signal emitted at the end of Disconnect method.
+    /// @param      int
+    ///             Serial method indicator
+    void Disconnect_Result(const int &, const bool &);
+
+    /// @brief
+    void Serial_SetProgressRange(const int &);
+
+    /// @brief
+    void Serial_ProgressUpdate(const int &);
+
+public slots:
+    /// @brief      "Constructor" process for the thread + serialDevice setup, if needed
+    void serialProcessStartup() {
+        port = new QSerialPort();
+        emit Worker_StartupFinished();
+    }
+
+    /// @brief      Runs SearchPorts method
+    void Sig_SearchPorts() { emit SearchPorts_Result(Serial_SearchPorts, SearchPorts()); }
+
+    /// @brief      Runs GetSettings method
+    void Sig_GetSettings(const QString &portName) { emit GetSettings_Result(Serial_GetSettings, GetSettings(portName)); }
+
+    /// @brief      Runs OneShotSend method
+    void Sig_OneShotSend(const QString &buffer) { emit OneShot_Result(Serial_OneShot, OneShotSend(buffer)); }
+
+    /// @brief      Runs CommitSettings method
+    void Sig_CommitSettings() { emit Commit_Result(Serial_Sync, CommitSettings()); }
+
+    void Sig_Disconnect() { emit Disconnect_Result(Serial_Disconnect, Disconnect()); }
+};
+
+class SerialThreadController : public QObject
+{
+    Q_OBJECT
+    QThread serialThread;
+public:
+    SerialThreadController() {
+        serialWorker.moveToThread(&serialThread);
+        connect(this, &SerialThreadController::operate,        &serialWorker, &SerialThreadWorker::serialProcessStartup);
+        connect(this, &SerialThreadController::SearchPorts,    &serialWorker, &SerialThreadWorker::Sig_SearchPorts);
+        connect(this, &SerialThreadController::GetSettings,    &serialWorker, &SerialThreadWorker::Sig_GetSettings);
+        connect(this, &SerialThreadController::OneShotSend,    &serialWorker, &SerialThreadWorker::Sig_OneShotSend);
+        connect(this, &SerialThreadController::CommitSettings, &serialWorker, &SerialThreadWorker::Sig_CommitSettings);
+        connect(this, &SerialThreadController::Disconnect,     &serialWorker, &SerialThreadWorker::Sig_Disconnect);
+        serialThread.start();
+    }
+
+    void SerialEnd() {
+        serialThread.quit();
+        serialThread.wait();
+    }
+    SerialThreadWorker serialWorker;
+signals:
+    /// @brief      Starts the serialProcess "constructor" in the thread.
+    void operate();
+
+    ////// Senders
+
+    /// @brief      Signal thread to run SearchPorts method.
+    void SearchPorts();
+
+    /// @brief      Signal thread to run GetSettings method.
+    void GetSettings(const QString &);
+
+    /// @brief      Signal thread to run OneShotSend method.
+    /// @param      QString
+    ///             String to send
+    void OneShotSend(const QString &);
+
+    /// @brief      Signal thread to run CommitSettings method.
+    void CommitSettings();
+
+    /// @brief      Signal thread to run Disconnect method.
+    void Disconnect();
 
 };
 

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -4,15 +4,12 @@
 #include <QObject>
 #include <QSerialPort>
 #include <QSerialPortInfo>
-#include <QThread>
 
-class SerialThreadWorker : public QObject
+class AppSerial : public QObject
 {
     Q_OBJECT
 
 public:
-    SerialThreadWorker() {};
-
     enum {
         Serial_SearchPorts = 0,
         Serial_GetSettings,
@@ -21,7 +18,7 @@ public:
         Serial_Disconnect
     } serialReturnTypes_e;
 
-    QSerialPort *port;
+    QSerialPort port;
 
     /// @brief      Primary list of found serial devices
     /// @note       Only to be updated when new found ports list is different from this one.
@@ -34,6 +31,10 @@ public:
     /// @note       If found devices are different, this list is merged into the new currentPorts.
     bool SearchPorts();
 
+    /// @brief      Creates a string list of ports based on given list of serial devices
+    /// @returns    New list of port names
+    /// @param      QList
+    ///             Serial ports list
     QStringList GeneratePortsList(const QList<QSerialPortInfo> &);
 
     /// @brief      Grabs settings from connected Serial device to App_Const
@@ -45,124 +46,21 @@ public:
     /// @returns    Success (true) or failure (false)
     /// @param      QString
     ///             String to send to device
-    bool OneShotSend(const QString &);
+    bool OneShotSend(const QByteArray &);
 
     /// @brief      Commits settings (App_Const) to currently connected Serial device
     /// @returns    Success (true) or failure (false)
     bool CommitSettings();
 
     /// @brief      Disconnects current serial device and clears port name
-    /// @returns    Always true
-    bool Disconnect();
+    void Disconnect();
 
 signals:
-    void Worker_StartupFinished();
-
-    /// @brief      Signal emitted at the end of SearchPorts method.
-    /// @param      int
-    ///             Serial method indicator
-    /// @param      bool
-    ///             Result of SearchPorts method
-    void SearchPorts_Result(const int &, const bool &);
-
-    /// @brief      Signal emitted at the end of GetSettings method.
-    /// @param      int
-    ///             Serial method indicator
-    /// @param      bool
-    ///             Result of GetSettings method
-    void GetSettings_Result(const int &, const bool &);
-
-    /// @brief      Signal emitted at the end of OneShotSend method.
-    /// @param      int
-    ///             Serial method indicator
-    /// @param      bool
-    ///             Result of OneShotSend method
-    void OneShot_Result(const int &, const bool &);
-
-    /// @brief      Signal emitted at the end of CommitSettings method.
-    /// @param      int
-    ///             Serial method indicator
-    /// @param      bool
-    ///             Result of CommitSettings method
-    void Commit_Result(const int &, const bool &);
-
-    /// @brief      Signal emitted at the end of Disconnect method.
-    /// @param      int
-    ///             Serial method indicator
-    void Disconnect_Result(const int &, const bool &);
-
     /// @brief
     void Serial_SetProgressRange(const int &);
 
     /// @brief
-    void Serial_ProgressUpdate(const int &);
-
-public slots:
-    /// @brief      "Constructor" process for the thread + serialDevice setup, if needed
-    void serialProcessStartup() {
-        port = new QSerialPort();
-        emit Worker_StartupFinished();
-    }
-
-    /// @brief      Runs SearchPorts method
-    void Sig_SearchPorts() { emit SearchPorts_Result(Serial_SearchPorts, SearchPorts()); }
-
-    /// @brief      Runs GetSettings method
-    void Sig_GetSettings(const QString &portName) { emit GetSettings_Result(Serial_GetSettings, GetSettings(portName)); }
-
-    /// @brief      Runs OneShotSend method
-    void Sig_OneShotSend(const QString &buffer) { emit OneShot_Result(Serial_OneShot, OneShotSend(buffer)); }
-
-    /// @brief      Runs CommitSettings method
-    void Sig_CommitSettings() { emit Commit_Result(Serial_Sync, CommitSettings()); }
-
-    void Sig_Disconnect() { emit Disconnect_Result(Serial_Disconnect, Disconnect()); }
-};
-
-class SerialThreadController : public QObject
-{
-    Q_OBJECT
-    QThread serialThread;
-public:
-    SerialThreadController() {
-        serialWorker.moveToThread(&serialThread);
-        connect(this, &SerialThreadController::operate,        &serialWorker, &SerialThreadWorker::serialProcessStartup);
-        connect(this, &SerialThreadController::SearchPorts,    &serialWorker, &SerialThreadWorker::Sig_SearchPorts);
-        connect(this, &SerialThreadController::GetSettings,    &serialWorker, &SerialThreadWorker::Sig_GetSettings);
-        connect(this, &SerialThreadController::OneShotSend,    &serialWorker, &SerialThreadWorker::Sig_OneShotSend);
-        connect(this, &SerialThreadController::CommitSettings, &serialWorker, &SerialThreadWorker::Sig_CommitSettings);
-        connect(this, &SerialThreadController::Disconnect,     &serialWorker, &SerialThreadWorker::Sig_Disconnect);
-        serialThread.start();
-    }
-
-    void SerialEnd() {
-        serialThread.quit();
-        serialThread.wait();
-    }
-    SerialThreadWorker serialWorker;
-signals:
-    /// @brief      Starts the serialProcess "constructor" in the thread.
-    void operate();
-
-    ////// Senders
-
-    /// @brief      Signal thread to run SearchPorts method.
-    void SearchPorts();
-
-    /// @brief      Signal thread to run GetSettings method.
-    void GetSettings(const QString &);
-
-    /// @brief      Signal thread to run OneShotSend method.
-    /// @param      QString
-    ///             String to send
-    void OneShotSend(const QString &);
-
-    /// @brief      Signal thread to run CommitSettings method.
-    void CommitSettings();
-
-    /// @brief      Signal thread to run Disconnect method.
-    void Disconnect();
-
+    void Serial_ProgressUpdate(const int &, const char* = nullptr);
 };
 
 #endif // APPSERIAL_H

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,6 +18,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+#include "../boards/OpenFIREshared.h"
 #include <QString>
 #include <QVector>
 #include <QMap>
@@ -72,6 +73,21 @@ public:
 
     // Currently loaded board object
     static inline boardInfo_s board;
+
+    /// @brief      Current array of booleans
+    /// @details    Meant for toggle/on-off type settings specifically
+    static inline bool boolSettings[OF_Const::boolTypesCount] = { false };
+
+    /// @brief      Array of booleans last synced from the microcontroller
+    /// @details    This is only updated on saving and loading settings successfully
+    static inline bool boolSettings_orig[OF_Const::boolTypesCount] = { false };
+
+    /// @brief      Current array of tunable settings
+    static inline uint32_t settingsTable[OF_Const::settingsTypesCount] = { 0 };
+
+    /// @brief      Array of tunables last synced from the microcontroller
+    /// @details    This is only updated on saving and loading settings successfully
+    static inline uint32_t settingsTable_orig[OF_Const::settingsTypesCount] = { 0 };
 
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;


### PR DESCRIPTION
The original "board must be connected" requirement has been removed, as is the old "alive timer" method of sending characters to check if the device is still connected - now ports are searched at the alive timer interval (on its own thread), and is compared - any differences will overwrite the list of COM devices in the main app window, including accounting for going to/from "no valid devices".

Alongside this, everything directly serial related have been moved to their own AppSerial class.

On a side note, profiles count is now determined exclusively by the size of the profiles tables collected during initial sync - so the App *should* be able to handle any amount of profiles should a custom firmware use larger profile tables.

Closes #16 (finally)