### PR TITLE
Update serial communications to work with FW 6.x+, decouple I2C peripheral for new addons

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -51,6 +51,12 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Get short SHA
+      id: get-short-sha
+      run: |
+        id=$(echo ${{github.sha}} | cut -c 1-7)
+        echo "id=$id" >> $GITHUB_OUTPUT
+
     - name: Install Qt(5)
       if: ${{ matrix.qt_version == '5.15.2' }}
       uses: jurplel/install-qt-action@v4
@@ -76,6 +82,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
         -DOFAPP_QT_VERSIONS=Qt5
         ${{ matrix.install_prefix }}
         -S ${{ github.workspace }}
@@ -86,6 +93,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
         ${{ matrix.install_prefix }}
         -S ${{ github.workspace }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -53,9 +53,7 @@ jobs:
 
     - name: Get short SHA
       id: get-short-sha
-      run: |
-        id=$(echo ${{github.sha}} | cut -c 1-7)
-        echo "id=$id" >> $GITHUB_OUTPUT
+      run: echo "id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Install Qt(5)
       if: ${{ matrix.qt_version == '5.15.2' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(NOT OFAPP_QT_VERSIONS)
     set(OFAPP_QT_VERSIONS Qt6)
 endif()
 
+# required to make use of definitions in `OpenFIREshared.h` for App usage
 add_compile_definitions(OF_APP)
 
 add_compile_definitions(OFAPP_VERSION="${PROJECT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
+cmake_policy(VERSION 3.5)
 
-project(OpenFIREapp VERSION 0.9 LANGUAGES CXX)
+project(OpenFIREapp VERSION 2.99.0 LANGUAGES CXX)
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
@@ -15,9 +16,12 @@ endif()
 
 add_compile_definitions(OF_APP)
 
-if(OFAPP_VERSION)
-    add_compile_definitions(OFAPP_VERSION="${OFAPP_VERSION}")
+add_compile_definitions(OFAPP_VERSION="${PROJECT_VERSION}")
+
+if(NOT OFAPP_CODENAME)
+    set(OFAPP_CODENAME "Tokinomiya")
 endif()
+add_compile_definitions(OFAPP_CODENAME="${OFAPP_CODENAME}")
 
 if(OFAPP_GITHASH)
     add_compile_definitions(OFAPP_GITHASH="${OFAPP_GITHASH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ set(PROJECT_SOURCES
         src/appcali.h
         src/appcali.cpp
         src/appcali.ui
+        src/apppreviewer.h
+        src/apppreviewer.cpp
+        src/apppreviewer.ui
         src/appdebug.h
         src/appdebug.cpp
         src/appdebug.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(TS_FILES
 
 set(PROJECT_SOURCES
         src/main.cpp
-        src/constants.h
+        src/appcommon.h
         src/appmainwindow.cpp
         src/appmainwindow.h
         src/appmainwindow.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(NOT OFAPP_QT_VERSIONS)
     set(OFAPP_QT_VERSIONS Qt6)
 endif()
 
+add_compile_definitions(OF_APP)
+
 if(OFAPP_VERSION)
     add_compile_definitions(OFAPP_VERSION="${OFAPP_VERSION}")
 endif()

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 
 ## Features:
  - **Cross-platform Qt application,** portable across Linux & Windows desktops & Raspberry Pi systems.
- - **Simple to use:** select the gun from the dropdown, and configure away!
- - See and manage current pins layout, toggle on and off custom mappings, set other tunables, and change the gun's USB identifier all on the fly.
- - Calibrate any of the loaded profiles using an intuitive fullscreen interface, making things 
- - Also serves as a testing utility for button input, solenoid/rumble force feedback, and camera.
+ - **Simple to use:** Plug in and select the gun from the dropdown, and configure away!
+ - See and manage current pins layout, toggle on and off custom mappings, manage other tunable settings such as FFB and I2C peripherals, and change the gun's USB identifier all on the fly.
+ - Calibrate any of the loaded profiles using an intuitive interactive fullscreen interface for easy and accurate calibrations.
+ - View ideal alignment of emitters using the IR Emitter Alignment Assistant.
+ - Also serves as a testing utility for digital and analog inputs, force feedback devices, camera, and more.
 
 ## Running:
-Boards flashed with OpenFIRE *must be plugged in **before** launching the application.* The app will notify if it can't find any compatible boards connected.
+Run `OpenFIREapp`. From the main window, available devices will be periodically refreshed and shown in the *COM Port* dropdown box. Even without any devices currently plugged in, you can still access the *IR Emitter Alignment Assistant* or preview supported boards and their default layouts by selecting *View Compatible Boards* from the *Help* app menu button.
+
+When a board(s) is connected, select the port corresponding to your microcontroller to dock it to the app (undocking any currently docked board, if any). Devices that fail to communicate correctly with the App can be rebooted to their bootloader so they can be updated to the latest available firmware version.
 
 ### For Linux:
 ##### Requirements: Anything that supports Qt 5.15.X at minimum.
@@ -54,7 +57,7 @@ Boards flashed with OpenFIRE *must be plugged in **before** launching the applic
 ### For Windows:
 #### Qt 5.15.2 needs to be installed from the Archive section of the Qt Installation Wizard/Maintenance Tool, which comes with all needed additional components
 #### Qt 6.x requires installing the respective SerialPort extension for the version
- - Should be buildable through CMake w/ msys2 (follow Arch Linux instructions) or the Qt Creator IDE.
+ - The project can be opened in the Qt Creator IDE, assuming the system has the appropriate Qt libraries for their desired version/environment installed. Alternatively, it should be buildable via CMake inside of an mingw-w64 environment, however this has yet to be tested adequately to be confirmed.
 
 ### TODO:
  - Implement version comparison to latest OpenFIRE GitHub release (or at least latest as of the GUI version).

--- a/src/appabout.cpp
+++ b/src/appabout.cpp
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    App info window.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "appabout.h"
 #include "ui_appabout.h"
 

--- a/src/appabout.h
+++ b/src/appabout.h
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    App info window.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef APPABOUT_H
 #define APPABOUT_H
 

--- a/src/appcali.cpp
+++ b/src/appcali.cpp
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Fullscreen Windows interface for Calibration et al.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "appcali.h"
 #include "ui_appcali.h"
 

--- a/src/appcali.cpp
+++ b/src/appcali.cpp
@@ -657,34 +657,33 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
     }
 }
 
-void AppCaliWindow::CaliModeTextUpdate(const QString &text)
+void AppCaliWindow::CaliModeTextUpdate(const uint8_t &type, const char* data)
 {
-    int type = text.front().digitValue();
-
     if(bitmapText) {
         switch(type) {
         case 1: // top offset
-            topOffset = text.mid(text.indexOf('.')+1).trimmed().toInt();
+            memcpy(&topOffset, data, 4);
+            qDebug() << topOffset;
             profileBitmaps[0]->setPixmap(GenerateText({caliTypesPrefixes.at(0) + QString::number(topOffset)}));
             break;
         case 2: // bottom offset
-            bottomOffset = text.mid(text.indexOf('.')+1).trimmed().toInt();
+            memcpy(&bottomOffset, data, 4);
             profileBitmaps[1]->setPixmap(GenerateText({caliTypesPrefixes.at(1) + QString::number(bottomOffset)}));
             break;
         case 3: // left offset
-            leftOffset = text.mid(text.indexOf('.')+1).trimmed().toInt();
+            memcpy(&leftOffset, data, 4);
             profileBitmaps[2]->setPixmap(GenerateText({caliTypesPrefixes.at(2) + QString::number(leftOffset)}));
             break;
         case 4: // right offset
-            rightOffset = text.mid(text.indexOf('.')+1).trimmed().toInt();
+            memcpy(&rightOffset, data, 4);
             profileBitmaps[3]->setPixmap(GenerateText({caliTypesPrefixes.at(3) + QString::number(rightOffset)}));
             break;
         case 5: // topleft
-            topLeftLed = text.mid(text.indexOf('.')+1).trimmed().toFloat();
+            memcpy(&topLeftLed, data, 4);
             profileBitmaps[4]->setPixmap(GenerateText({caliTypesPrefixes.at(4) + QString::number(topLeftLed, 'g', 6)}));
             break;
         case 6: // topright
-            topRightLed = text.mid(text.indexOf('.')+1).trimmed().toFloat();
+            memcpy(&topRightLed, data, 4);
             profileBitmaps[5]->setPixmap(GenerateText({caliTypesPrefixes.at(5) + QString::number(topRightLed, 'g', 6)}));
             // HACK: re-update final scene since this may happen AFTER the verification check stage
             CaliModeSet(Cali_Verify);
@@ -708,18 +707,18 @@ void AppCaliWindow::CaliModeTextUpdate(const QString &text)
     }
 }
 
-void AppCaliWindow::TestModeDraw(const QStringList &coordsList)
+void AppCaliWindow::TestModeDraw(const int coordsList[12])
 {
-    testPoints[testPointTL]->setRect(   coordsList[0].toInt()  - 25,  coordsList[1].toInt()  - 25, 50, 50);
-    testPoints[testPointTR]->setRect(   coordsList[2].toInt()  - 25,  coordsList[3].toInt()  - 25, 50, 50);
-    testPoints[testPointBL]->setRect(   coordsList[4].toInt()  - 25,  coordsList[5].toInt()  - 25, 50, 50);
-    testPoints[testPointBR]->setRect(   coordsList[6].toInt()  - 25,  coordsList[7].toInt()  - 25, 50, 50);
-    testPoints[testPointMed]->setRect(  coordsList[8].toInt()  - 25,  coordsList[9].toInt()  - 25, 50, 50);
-    testPoints[testPointD]->setRect(    coordsList[10].toInt() - 25,  coordsList[11].toInt() - 25, 50, 50);
+    testPoints[testPointTL]->setRect(   coordsList[0]  - 25,  coordsList[1]  - 25, 50, 50);
+    testPoints[testPointTR]->setRect(   coordsList[2]  - 25,  coordsList[3]  - 25, 50, 50);
+    testPoints[testPointBL]->setRect(   coordsList[4]  - 25,  coordsList[5]  - 25, 50, 50);
+    testPoints[testPointBR]->setRect(   coordsList[6]  - 25,  coordsList[7]  - 25, 50, 50);
+    testPoints[testPointMed]->setRect(  coordsList[8]  - 25,  coordsList[9]  - 25, 50, 50);
+    testPoints[testPointD]->setRect(    coordsList[10] - 25,  coordsList[11] - 25, 50, 50);
 
-    testBox->setPolygon(QPolygonF() << QPointF(coordsList[0].toInt(), coordsList[1].toInt())
-                                    << QPointF(coordsList[2].toInt(), coordsList[3].toInt())
-                                    << QPointF(coordsList[6].toInt(), coordsList[7].toInt())
-                                    << QPointF(coordsList[4].toInt(), coordsList[5].toInt())
-                                    << QPointF(coordsList[0].toInt(), coordsList[1].toInt()));
+    testBox->setPolygon(QPolygonF() << QPointF(coordsList[0], coordsList[1])
+                                    << QPointF(coordsList[2], coordsList[3])
+                                    << QPointF(coordsList[6], coordsList[7])
+                                    << QPointF(coordsList[4], coordsList[5])
+                                    << QPointF(coordsList[0], coordsList[1]));
 }

--- a/src/appcali.cpp
+++ b/src/appcali.cpp
@@ -663,7 +663,6 @@ void AppCaliWindow::CaliModeTextUpdate(const uint8_t &type, const char* data)
         switch(type) {
         case 1: // top offset
             memcpy(&topOffset, data, 4);
-            qDebug() << topOffset;
             profileBitmaps[0]->setPixmap(GenerateText({caliTypesPrefixes.at(0) + QString::number(topOffset)}));
             break;
         case 2: // bottom offset

--- a/src/appcali.h
+++ b/src/appcali.h
@@ -88,14 +88,21 @@ public:
     ~AppCaliWindow();
 
     /// @brief      Update calibration window with new status
-    /// @details    Stuff
+    /// @param      int
+    ///             One of CaliSteps_e
     void CaliModeSet(const int &);
 
     /// @brief      Update calibration window's profile text with new data
-    void CaliModeTextUpdate(const QString &);
+    /// @param      uint8_t
+    ///             Type of text to update
+    /// @param      Char string
+    ///             Buffer data
+    void CaliModeTextUpdate(const uint8_t &, const char*);
 
     /// @brief      Update test mode window with list of new coords
-    void TestModeDraw(const QStringList &);
+    /// @param      Array of ints
+    ///             Coordinates of the twelve test points used to draw
+    void TestModeDraw(const int[12]);
 
     int GetWindowMode() { return mode; }
 

--- a/src/appcali.h
+++ b/src/appcali.h
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Fullscreen Windows interface for Calibration et al.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef APPCALI_H
 #define APPCALI_H
 

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -1,5 +1,7 @@
 /*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
-    Copyright (C) 2024  Team OpenFIRE
+    Common shared assets & constants.
+
+    Copyright (C) 2025  Team OpenFIRE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,15 +17,15 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSTANTS_H
-#define CONSTANTS_H
+#ifndef APPCOMMON_H
+#define APPCOMMON_H
 
 #include "../boards/OpenFIREshared.h"
 #include <QString>
 #include <QVector>
 #include <QMap>
 
-class App_Const
+class App_Common
 {
 public:
     enum {

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -77,17 +77,17 @@ public:
     } tinyUSBtable_s;
 
     typedef struct profilesTable_t {
-        uint16_t topOffset      = 0;
-        uint16_t bottomOffset   = 0;
-        uint16_t leftOffset     = 0;
-        uint16_t rightOffset    = 0;
-        uint16_t TLled          = 0;
-        uint16_t TRled          = 0;
-        uint8_t irSensitivity   = 0;
-        uint8_t runMode         = 0;
-        uint8_t layoutType      = false;
+        int32_t  topOffset      = 0;
+        int32_t  bottomOffset   = 0;
+        int32_t  leftOffset     = 0;
+        int32_t  rightOffset    = 0;
+        float    TLled          = 0;
+        float    TRled          = 0;
+        uint8_t  irSensitivity  = 0;
+        uint8_t  runMode        = 0;
+        uint8_t  layoutType     = false;
         uint32_t color          = 0;
-        QString profName        = "";
+        QByteArray profName     = "";
     } profilesTable_s;
 
     // Currently loaded board object

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -50,6 +50,11 @@ public:
         trackTestItem
     } uiTrackableObjects_e;
 
+    enum {
+        dataCurrent = 0,
+        dataOrig
+    } dataBlocks_e;
+
     /// @brief      Names list for buttons
     /// @details    Needs to match the same order as Firmware's
     ///             `ButtonIndex_e`
@@ -104,27 +109,15 @@ public:
 
     /// @brief      Current array of booleans
     /// @details    Meant for toggle/on-off type settings specifically
-    static inline bool boolSettings[OF_Const::boolTypesCount] = { false };
-
-    /// @brief      Array of booleans last synced from the microcontroller
-    /// @details    This is only updated on saving and loading settings successfully
-    static inline bool boolSettings_orig[OF_Const::boolTypesCount] = { false };
+    static inline bool boolSettings[2][OF_Const::boolTypesCount] = { false };
 
     /// @brief      Current array of tunable settings
-    static inline uint32_t settingsTable[OF_Const::settingsTypesCount] = { 0 };
-
-    /// @brief      Array of tunables last synced from the microcontroller
-    /// @details    This is only updated on saving and loading settings successfully
-    static inline uint32_t settingsTable_orig[OF_Const::settingsTypesCount] = { 0 };
+    static inline uint32_t settingsTable[2][OF_Const::settingsTypesCount] = { 0 };
 
     /// @brief      Array of I2C peripheral devices that can be toggled
-    static inline bool i2cPeriphs[OF_Const::i2cDevicesCount] = { false };
+    static inline bool i2cPeriphs[2][OF_Const::i2cDevicesCount] = { false };
 
-    /// @brief      Array of I2C peripheral devices last synced from the microcontroller
-    /// @details    This is only updated on saving and loading settings successfully
-    static inline bool i2cPeriphs_orig[OF_Const::i2cDevicesCount] = { false };
-
-    static inline uint32_t i2cOledPrefs[OF_Const::oledSettingsTypes] = { false };
+    static inline uint32_t i2cOledPrefs[2][OF_Const::oledSettingsTypes] = { false };
 
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -100,6 +100,8 @@ public:
     // Currently loaded board object
     static inline boardInfo_s board;
 
+    //// TODO: merge orig into main arrays to make them 2D arrays (where second array = main or orig)
+
     /// @brief      Current array of booleans
     /// @details    Meant for toggle/on-off type settings specifically
     static inline bool boolSettings[OF_Const::boolTypesCount] = { false };
@@ -121,6 +123,8 @@ public:
     /// @brief      Array of I2C peripheral devices last synced from the microcontroller
     /// @details    This is only updated on saving and loading settings successfully
     static inline bool i2cPeriphs_orig[OF_Const::i2cDevicesCount] = { false };
+
+    static inline uint32_t i2cOledPrefs[OF_Const::oledSettingsTypes] = { false };
 
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -21,9 +21,13 @@
 #define APPCOMMON_H
 
 #include "../boards/OpenFIREshared.h"
+
 #include <QString>
 #include <QVector>
 #include <QMap>
+
+// Maximum amount of GPIO that the RP2040 microcontroller has available
+#define PINS_COUNT 30
 
 class App_Common
 {
@@ -46,6 +50,9 @@ public:
         trackTestItem
     } uiTrackableObjects_e;
 
+    /// @brief      Names list for buttons
+    /// @details    Needs to match the same order as Firmware's
+    ///             `ButtonIndex_e`
     static inline const QStringList testLabelNames = {
         "Trigger",
         "Button A",

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -55,26 +55,6 @@ public:
         dataOrig
     } dataBlocks_e;
 
-    /// @brief      Names list for buttons
-    /// @details    Needs to match the same order as Firmware's
-    ///             `ButtonIndex_e`
-    static inline const QStringList testLabelNames = {
-        "Trigger",
-        "Button A",
-        "Button B",
-        "Start",
-        "Select",
-        "D-Pad Up",
-        "D-Pad Down",
-        "D-Pad Left",
-        "D-Pad Right",
-        "Button C",
-        "Pedal",
-        "Pedal 2",
-        "Pump Action",
-        "Home"
-    };
-
     typedef struct boardInfo_t {
         uint8_t    selectedProfile;
         uint8_t    previousProfile;

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -115,6 +115,13 @@ public:
     /// @details    This is only updated on saving and loading settings successfully
     static inline uint32_t settingsTable_orig[OF_Const::settingsTypesCount] = { 0 };
 
+    /// @brief      Array of I2C peripheral devices that can be toggled
+    static inline bool i2cPeriphs[OF_Const::i2cDevicesCount] = { false };
+
+    /// @brief      Array of I2C peripheral devices last synced from the microcontroller
+    /// @details    This is only updated on saving and loading settings successfully
+    static inline bool i2cPeriphs_orig[OF_Const::i2cDevicesCount] = { false };
+
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;
     // TinyUSB ident, as loaded from the board

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -64,16 +64,16 @@ public:
     };
 
     typedef struct boardInfo_t {
-        uint8_t selectedProfile;
-        uint8_t previousProfile;
-        QString boardType;
-        QString versionNumber;
-        QString versionCodename;
+        uint8_t    selectedProfile;
+        uint8_t    previousProfile;
+        QByteArray boardType;
+        QByteArray versionNumber;
+        QByteArray versionCodename;
     } boardInfo_s;
 
     typedef struct tinyUSBtable_t {
-        QString tinyUSBid;
-        QString tinyUSBname;
+        uint16_t   tinyUSBid;
+        QByteArray tinyUSBname;
     } tinyUSBtable_s;
 
     typedef struct profilesTable_t {

--- a/src/appdebug.cpp
+++ b/src/appdebug.cpp
@@ -35,4 +35,5 @@ AppDebugWindow::~AppDebugWindow()
 void AppDebugWindow::AppendText(const QByteArray &text)
 {
     ui->text->appendPlainText(text);
+    ui->hex->insertPlainText(' ' + text.toHex(' ').toUpper());
 }

--- a/src/appdebug.cpp
+++ b/src/appdebug.cpp
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Serial info window for debugging.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "appdebug.h"
 #include "ui_appdebug.h"
 

--- a/src/appdebug.h
+++ b/src/appdebug.h
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Serial info window for debugging.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef APPDEBUG_H
 #define APPDEBUG_H
 

--- a/src/appdebug.ui
+++ b/src/appdebug.ui
@@ -17,7 +17,7 @@
    <iconset resource="../img/vectors.qrc">
     <normaloff>:/icon/icon.png</normaloff>:/icon/icon.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -44,9 +44,6 @@
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
-     <property name="documentTitle">
-      <string notr="true"/>
-     </property>
      <property name="undoRedoEnabled">
       <bool>false</bool>
      </property>
@@ -57,7 +54,32 @@
       <string notr="true"/>
      </property>
      <property name="textInteractionFlags">
-      <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
+      <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+     </property>
+     <property name="placeholderText">
+      <string notr="true"/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="hex">
+     <property name="font">
+      <font>
+       <family>Monospace</family>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="plainText">
+      <string notr="true"/>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextInteractionFlag::NoTextInteraction</set>
      </property>
      <property name="placeholderText">
       <string notr="true"/>

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -107,34 +107,27 @@ guiWindow::guiWindow(QWidget *parent)
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     // Setup test screen buttons
-    for(int i = 0; i < 16; i++) {
-        testLabel[i] = new QLabel;
+    for(int i = 0; i < 13; i++) {
+        testLabel << new QLabel(OF_Const::valuesNameList[i+1]);
 
-        // temperature sensor
-        if(i == 14) testLabel[i]->setText(OF_Const::valuesNameList[OF_Const::tempPin]);
-        // analog stick
-        else if(i == 15) testLabel[i]->setText("Analog Stick");
-        // every other standard input
-        else testLabel[i]->setText(OF_Const::valuesNameList[i+1]);
+        testLabel.at(i)->setEnabled(false);
+        testLabel.at(i)->setAlignment(Qt::AlignCenter);
+        testLabel.at(i)->setFrameStyle(QFrame::Box | QFrame::Raised);
 
-        testLabel[i]->setEnabled(false);
-        testLabel[i]->setAlignment(Qt::AlignCenter);
-        testLabel[i]->setFrameStyle(QFrame::Box | QFrame::Raised);
-
-        // analog stick
-        if(i == 15)      ui->buttonsTestLayout->addWidget(testLabel[i], 3, 3);
-        // temp sensor
-        else if(i == 14) ui->buttonsTestLayout->addWidget(testLabel[i], 3, 1);
         // third/second/first row of buttons
-        else if(i > 9)   ui->buttonsTestLayout->addWidget(testLabel[i], 2, i-10);
-        else if(i > 4)   ui->buttonsTestLayout->addWidget(testLabel[i], 1, i-5);
-        else             ui->buttonsTestLayout->addWidget(testLabel[i], 0, i);
+        if(i > 9)        ui->btnsLayout->addWidget(testLabel.at(i), 2, i-10);
+        else if(i > 4)   ui->btnsLayout->addWidget(testLabel.at(i), 1, i-5);
+        else             ui->btnsLayout->addWidget(testLabel.at(i), 0, i);
     }
 
-    ui->buttonsTestLayout->setRowMinimumHeight(0, 32);
-    ui->buttonsTestLayout->setRowMinimumHeight(1, 32);
-    ui->buttonsTestLayout->setRowMinimumHeight(2, 32);
-    ui->buttonsTestLayout->setRowMinimumHeight(3, 32);
+    // Setup analog stick viewer
+    ui->analogGfxView->setScene(&analogGfxScene);
+    analogGfxScene.setSceneRect(ui->analogGfxView->rect());
+    analogPos = analogGfxScene.addEllipse(analogGfxScene.sceneRect().center().x()-8,
+                                          analogGfxScene.sceneRect().center().y()-8,
+                                          16, 16,
+                                          QPen(QColor(255,100,0), 0), QBrush(QColor(255,125,0)));
+    analogPos->setTransform(QTransform::fromScale(analogGfxScene.sceneRect().width() / 256, analogGfxScene.sceneRect().height() / 256));
 
     // hiding tUSB elements by default since this can't be done from the off
     ui->tUSBLayoutAdvanced->setVisible(false);
@@ -865,9 +858,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         if(serial.port.isOpen())
             serial.Disconnect();
 
-        // reset temp/analog labels' stylesheets to neutral
-        testLabel[14]->setStyleSheet("");
-        testLabel[15]->setStyleSheet("");
+        // reset temp label stylesheet to neutral
+        ui->tmp36Label->setStyleSheet("");
     }
     serialActive = false;
 }
@@ -877,38 +869,32 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 void guiWindow::LabelsUpdate()
 {
     // because App_Common::inputsMap uses pin no. starting from 0
-    for(uint8_t i = 0; i < 16; i++) {
-        if(i < 14) {
-            if(App_Common::inputsMap.value(i) >= 0) {
-                testLabel[i]->setText(App_Common::testLabelNames.at(i));
-                testLabel[i]->setEnabled(true);
-            } else {
-                testLabel[i]->setText(App_Common::testLabelNames.at(i) + " (N/C)");
-                testLabel[i]->setEnabled(false);
-            }
-        } else if(i == 14) {
-            if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
-                testLabel[i]->setText("Temp Read...");
-                testLabel[i]->setEnabled(true);
-            } else {
-                testLabel[i]->setText("Temp (N/C)");
-                testLabel[i]->setEnabled(false);
-            }
-            testLabel[i]->setStyleSheet("");
-        } else if(i == 15) {
-            if(App_Common::inputsMap.value(OF_Const::analogX) >=0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0) {
-                testLabel[i]->setText("Analog");
-                testLabel[i]->setEnabled(true);
-            } else {
-                testLabel[i]->setText("Analog (N/C)");
-                testLabel[i]->setEnabled(false);
-            }
-            testLabel[i]->setStyleSheet("");
+    for(uint8_t i = 0; i < testLabel.count(); i++) {
+        testLabel.at(i)->setStyleSheet("");
+        if(App_Common::inputsMap.value(i) >= 0) {
+            testLabel.at(i)->setText(App_Common::testLabelNames.at(i));
+            testLabel.at(i)->setEnabled(true);
+        } else {
+            testLabel.at(i)->setText(App_Common::testLabelNames.at(i) + " (N/C)");
+            testLabel.at(i)->setEnabled(false);
         }
     }
+
+    ui->tmp36Label->setStyleSheet("");
+    if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
+        ui->tmp36Label->setText("Temperature Read...");
+        ui->tmp36Label->setEnabled(true);
+    } else {
+        ui->tmp36Label->setText("Temperature Sensor (N/C)");
+        ui->tmp36Label->setEnabled(false);
+    }
+
     if(App_Common::inputsMap.value(OF_Const::ledR) >= 0) ui->redLedTestBtn->setEnabled(true);   else ui->redLedTestBtn->setEnabled(false);
     if(App_Common::inputsMap.value(OF_Const::ledG) >= 0) ui->greenLedTestBtn->setEnabled(true); else ui->greenLedTestBtn->setEnabled(false);
     if(App_Common::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0)
+         ui->analogGroup->setEnabled(true),  ui->aPosLabel->clear();
+    else ui->analogGroup->setEnabled(false), ui->aPosLabel->setText("Not Connected");
 
     ui->boardLabel->setText(PrettifyName(App_Common::tinyUSBtable.tinyUSBname));
 }
@@ -1581,53 +1567,41 @@ void guiWindow::serialPort_readyRead()
             case (char)OF_Const::sBtnPressed:
             {
                 int btn = serial.port.read(1).at(0);
-                if(btn < 16)
-                    testLabel[btn]->setStyleSheet("background-color: #FF0000; font: bold");
+                if(btn < testLabel.count()) testLabel.at(btn)->setStyleSheet("background-color: #FF0000; font: bold");
                 break;
             }
             case (char)OF_Const::sBtnReleased:
             {
                 int btn = serial.port.read(1).at(0);
-                if(btn < 16)
-                    testLabel[btn]->setStyleSheet("");
+                if(btn < testLabel.count()) testLabel.at(btn)->setStyleSheet("");
                 break;
             }
             case (char)OF_Const::sTemperatureUpd:
             {
                 unsigned int temp = serial.port.read(1).at(0);
 
-                testLabel[14]->setText(QString("Temp: %1°C").arg(temp));
+                ui->tmp36Label->setText(QString("Temperature: %1°C").arg(temp));
 
-                if(temp > tempShutoff) {        testLabel[14]->setStyleSheet("color: white;      background-color: #FF0000; font: bold"); }
-                else if(temp > tempWarning) {   testLabel[14]->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold"); }
-                else {                          testLabel[14]->setStyleSheet("color: black;      background-color: #11D00A; font: bold"); }
+                if(temp > tempShutoff) {        ui->tmp36Label->setStyleSheet("color: white;      background-color: #FF0000; font: bold"); }
+                else if(temp > tempWarning) {   ui->tmp36Label->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold"); }
+                else {                          ui->tmp36Label->setStyleSheet("color: black;      background-color: #11D00A; font: bold"); }
 
                 break;
             }
             case (char)OF_Const::sAnalogPosUpd:
             {
-                // TODO: perhaps we should be using a small box area with a glyph depicting the aStick's coords instead of only showing cardinal directionality?
-                uint8_t analogDir = serial.port.read(1).at(0);
+                uint16_t oriPosX, oriPosY;
+                serial.port.read((char*)&oriPosX, 2);
+                serial.port.read((char*)&oriPosY, 2);
+                uint8_t posX = oriPosX/16;
+                uint8_t posY = oriPosY/16;
+                posX = ~posX;
+                posY = ~posY;
 
-                // analog stick moved
-                if(analogDir) {
-                    switch(analogDir) {
-                    case 1: testLabel[15]->setText("Analog 🡹"); break;
-                    case 2: testLabel[15]->setText("Analog 🡼"); break;
-                    case 3: testLabel[15]->setText("Analog 🡸"); break;
-                    case 4: testLabel[15]->setText("Analog 🡿"); break;
-                    case 5: testLabel[15]->setText("Analog 🡻"); break;
-                    case 6: testLabel[15]->setText("Analog 🡾"); break;
-                    case 7: testLabel[15]->setText("Analog 🡺"); break;
-                    case 8: testLabel[15]->setText("Analog 🡽"); break;
-                    }
+                analogPos->setRect(posX - 8, posY - 8, 16, 16);
+                ui->aPosLabel->setText(QString("%1 , %2").arg(oriPosX).arg(oriPosY));
 
-                    testLabel[15]->setStyleSheet("background-color: #FF0000; font: bold");
-                    // no analog direction
-                } else {
-                    testLabel[15]->setText("Analog");
-                    testLabel[15]->setStyleSheet("");
-                }
+                break;
             }
             case (char)OF_Const::sCurrentProf:
             {
@@ -1746,6 +1720,7 @@ void guiWindow::serialPort_SearchFinished()
                             ui->comPortSelector->addItem(newPort.portName()+" (" + newPort.description() + ')');
                 }
             // if ports list is cleared, assume no board can be connected.
+            // TODO: for whatever reason, this path specifically doesn't kick in under Windows VM?
             } else {
                 if(ui->comPortSelector->currentIndex() > 0)
                     statusBar()->showMessage("Current board has been disconnected.");

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -21,6 +21,7 @@
 #include "appabout.h"
 #include "appcommon.h"
 #include "ui_appmainwindow.h"
+#include "../boards/OpenFIREshared.h"
 
 #include <QGraphicsScene>
 #include <QMessageBox>
@@ -1942,6 +1943,12 @@ void guiWindow::on_tabWidget_currentChanged(int index)
 }
 
 
+void guiWindow::on_actionCompatible_Boards_triggered()
+{
+    boardsWindow.show();
+}
+
+
 void guiWindow::on_actionAbout_UI_triggered()
 {
     AppAbout *about = new AppAbout();
@@ -2027,4 +2034,3 @@ void guiWindow::on_actionDebug_Window_triggered()
 {
     debugWindow.show();
 }
-

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1170,6 +1170,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
         ui->rumbleFFToggle->setChecked(false);
         ui->solenoidSettingsBox->setEnabled(true);
         ui->solenoidTestBtn->setEnabled(true);
+        ui->solenoidFFBox->setEnabled(true);
     } else {
         ui->solenoidSettingsBox->setEnabled(false);
         ui->solenoidTestBtn->setEnabled(false);
@@ -1968,7 +1969,7 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
                 // import new maps
                 for(int i = 0; i < pinBoxes.count(); i++) {
                     if(!fileIn.atEnd()) {
-                        const int newIdx = fileIn.peek(1).toHex().toInt(nullptr, 16);
+                        const int newIdx = fileIn.read(1).toHex().toInt(nullptr, 16);
                         if(newIdx <= OF_Const::boardInputsCount)
                             pinBoxes.at(i)->setCurrentIndex(newIdx);
                     } else break;

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -787,20 +787,23 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->customPinsEnabled->setChecked(App_Common::boolSettings[OF_Const::customPins]);
 
             ui->rumbleToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumble]);
+            ui->rumbleSettingsBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]);
             ui->solenoidToggle->setChecked(App_Common::boolSettings_orig[OF_Const::solenoid]);
+            ui->solenoidSettingsBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]);
             ui->autofireToggle->setChecked(App_Common::boolSettings_orig[OF_Const::autofire]);
+            ui->autofireToggle->setEnabled((App_Common::boolSettings_orig[OF_Const::solenoid] || App_Common::boolSettings_orig[OF_Const::rumbleFF]));
             ui->simplePauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::simplePause]);
             ui->holdToPauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::holdToPause]);
             ui->commonAnodeToggle->setChecked(App_Common::boolSettings_orig[OF_Const::commonAnode]);
             ui->lowButtonsToggle->setChecked(App_Common::boolSettings_orig[OF_Const::lowButtonsMode]);
             ui->rumbleFFToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
+            ui->rumbleIntensityBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
@@ -1170,7 +1173,6 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
         ui->rumbleFFToggle->setChecked(false);
         ui->solenoidSettingsBox->setEnabled(true);
         ui->solenoidTestBtn->setEnabled(true);
-        ui->solenoidFFBox->setEnabled(true);
     } else {
         ui->solenoidSettingsBox->setEnabled(false);
         ui->solenoidTestBtn->setEnabled(false);

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1628,22 +1628,36 @@ void guiWindow::serialPort_readyRead()
                 DiffUpdate();
                 break;
             }
-            // This should eventually have its own child branches for different error types,
-            // but for now it's just for missing IR camera errors only
             case (char)OF_Const::sError:
-                if(caliWindow != nullptr)
-                    caliWindow->Shutdown();
-                serial.ShowError("Device Error: Camera not available!",
-                                 "<p>Data received from the board indicates that the camera is in a bad state.<br>"
-                                 "This can happen if, for example, the camera wires are crossed<br>"
-                                 "(data wire to clock pin, clock wire to data pin),<br>"
-                                 "or the camera pins are wired to a different component,<br>"
-                                 "such as a button or Force Feedback output.</p>"
-                                 "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
-                                 "if they should be mapped different GPIO;<br>"
-                                 "Otherwise, the camera wires must be resoldered to resolve this error.</p>"
-                                 "<p>IR Testing and Calibration will not be available while in this state.</p>",
-                                 QMessageBox::Critical);
+                switch(serial.port.read(1).at(0)) {
+                case (char)OF_Const::sErrCam:
+                    if(caliWindow != nullptr)
+                        caliWindow->Shutdown();
+                    serial.ShowError("Device Error: Camera not available!",
+                                     "<p>Data received from the board indicates that the camera is in a bad state.<br>"
+                                     "This can happen if, for example, the camera wires are crossed<br>"
+                                     "(data wire to clock pin, clock wire to data pin),<br>"
+                                     "or the camera pins are wired to a different component,<br>"
+                                     "such as a button or Force Feedback output.</p>"
+                                     "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
+                                     "if they should be mapped different GPIO;<br>"
+                                     "Otherwise, the camera wires must be resoldered to resolve this error.</p>"
+                                     "<p>IR Testing and Calibration will not be available while in this state.</p>",
+                                     QMessageBox::Critical);
+                    break;
+                case (char)OF_Const::sErrPeriphGeneric:
+                    serial.ShowError("Peripheral Device Error!",
+                                     "<p>Data received from the board indicates that an I2C peripheral device failed to initialize.<br>"
+                                     "This can happen if, for example, the peripheral's wires are crossed<br>"
+                                     "(data wire to clock pin, clock wire to data pin),<br>"
+                                     "or the pins for the peripheral are set to a different component,<br>"
+                                     "such as a button or Force Feedback output.</p>"
+                                     "<p>Confirm that the wires for the peripheral are connected to the correct <i>Peripheral I2C</i> pins<br>"
+                                     "in the <i>Boards Layout</i> tab.</p>",
+                                     QMessageBox::Critical);
+                    break;
+                default: break;
+                }
                 break;
             case (char)OF_Const::sCaliStageUpd:
                 if(caliWindow != nullptr)

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1428,7 +1428,7 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
     if(isChecked && !serialActive) {
         // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
         if(sender()->property("slot").toInt() != App_Common::board.selectedProfile) {
-            serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1));
+            serial.OneShotSend((char[]){(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt())}, 4);
             App_Common::board.selectedProfile = sender()->property("slot").toInt();
             DiffUpdate();
         }
@@ -1888,7 +1888,7 @@ void guiWindow::on_clearEepromBtn_clicked()
     messageBox.setDefaultButton(QMessageBox::Yes);
 
     if(messageBox.exec() == QMessageBox::Yes)
-        serial.OneShotSend("Xc");
+        serial.OneShotSend((char)OF_Const::sClearFlash);
     else ui->statusBar->showMessage("Clear operation canceled.", 3000);
 }
 
@@ -1896,27 +1896,29 @@ void guiWindow::on_clearEepromBtn_clicked()
 void guiWindow::on_baudResetBtn_clicked()
 {
     // No need for workarounds, bootloader reset is in the firmware now.
-    serial.OneShotSend("Xxx");
+    if(serial.OneShotSend((char[]){(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader})) {
 
 /* test stuff for potential app FW update functionality
-    // At least on my system, the Bootloader device takes ~7s to appear
-    QThread::msleep(7000);
-    // Class-ify this function, maybe.
-    QString picoPath;
-    foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
-        if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
-            picoPath = storageDevices.device();
-            qDebug() << "Found a Pico bootloader!";
-            break;
-        } else {
-            qDebug() << "nope";
+        // At least on my system, the Bootloader device takes ~7s to appear
+        QThread::msleep(7000);
+        // Class-ify this function, maybe.
+        QString picoPath;
+        foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
+            if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
+                picoPath = storageDevices.device();
+                qDebug() << "Found a Pico bootloader!";
+                break;
+            } else {
+                qDebug() << "nope";
+            }
         }
-    }
-    qDebug() << picoPath;
-    // QFile::copy("file", picoPath+"file");
+        qDebug() << picoPath;
+        // QFile::copy("file", picoPath+"file");
 */
-    ui->statusBar->showMessage("Board reset to bootloader.", 5000);
-    ui->comPortSelector->setCurrentIndex(0);
+
+        ui->statusBar->showMessage("Board reset to bootloader.", 5000);
+        ui->comPortSelector->setCurrentIndex(0);
+    }
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1074,14 +1074,14 @@ void guiWindow::colorBoxes_clicked()
 {
     QColor colorPick = QColorDialog::getColor(App_Common::profilesTable[sender()->property("slot").toInt()].color);
     if(colorPick.isValid()) {
-        int *red = new int;
-        int *green = new int;
-        int *blue = new int;
-        colorPick.getRgb(red, green, blue);
+        int red;
+        int green;
+        int blue;
+        colorPick.getRgb(&red, &green, &blue);
         uint32_t packedColor = 0;
-        packedColor |= *red << 16;
-        packedColor |= *green << 8;
-        packedColor |= *blue;
+        packedColor |= red << 16;
+        packedColor |= green << 8;
+        packedColor |= blue;
         App_Common::profilesTable[sender()->property("slot").toInt()].color = packedColor;
         color[sender()->property("slot").toInt()]->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
         DiffUpdate();

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -364,6 +364,37 @@ void guiWindow::PixelsDiff()
 }
 
 
+void guiWindow::NewCaliWindow(const int &type) {
+    if(caliWindow != nullptr)
+        caliWindow->Shutdown();
+
+    caliWindow = new AppCaliWindow(nullptr, type);
+    connect(caliWindow, &AppCaliWindow::WindowExiting, this, &guiWindow::CaliWindowExiting);
+
+    switch(type) {
+    case AppCaliWindow::modeCalibrate:
+        caliWindow->setProperty("profile", sender()->property("slot").toInt());
+        connect(caliWindow, &AppCaliWindow::CaliRequestToExit,  this, &guiWindow::CaliWindowRequestedExit);
+        break;
+    case AppCaliWindow::modeIRTest:
+        ui->buttonsTestArea->setEnabled(false);
+        ui->confirmButton->setEnabled(false);
+        ui->confirmButton->setText("[Disabled while in Test Mode]");
+        ui->pinsTab->setEnabled(false);
+        ui->settingsTab->setEnabled(false);
+        ui->profilesTab->setEnabled(false);
+        ui->feedbackTestsBox->setEnabled(false);
+        ui->dangerZoneBox->setEnabled(false);
+        break;
+    case AppCaliWindow::modeAlignment:
+    default:
+        break;
+    }
+
+    caliWindow->showFullScreen();
+}
+
+
 void guiWindow::on_confirmButton_clicked()
 {
     QMessageBox messageBox(QMessageBox::Information, "Commit Confirmation", "Are these settings okay?", QMessageBox::Yes | QMessageBox::No);
@@ -434,8 +465,8 @@ void guiWindow::aliveTimer_timeout()
 void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 {
     // Clear stale states if any
-    if(testMode)
-        if(caliWindow != nullptr)
+    if(caliWindow != nullptr)
+        if(caliWindow->GetWindowMode() != AppCaliWindow::modeAlignment)
             caliWindow->Shutdown();
 
     if(ui->comPortSelector->currentIndex() > 0) {
@@ -830,20 +861,9 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         if(serial.port.isOpen())
             serial.Disconnect();
 
-        // reset stuff
+        // reset temp/analog labels' stylesheets to neutral
         testLabel[14]->setStyleSheet("");
         testLabel[15]->setStyleSheet("");
-
-        // force disable test mode if it was set
-        if(testMode) {
-            testMode = false;
-            ui->buttonsTestArea->setEnabled(true);
-            ui->pinsTab->setEnabled(true);
-            ui->settingsTab->setEnabled(true);
-            ui->profilesTab->setEnabled(true);
-            ui->feedbackTestsBox->setEnabled(true);
-            ui->dangerZoneBox->setEnabled(true);
-        }
     }
     serialActive = false;
 }
@@ -1522,12 +1542,7 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
 
 void guiWindow::caliBtns_clicked()
 {
-    caliWindow = new AppCaliWindow(nullptr, AppCaliWindow::modeCalibrate);
-    caliWindow->setProperty("profile", sender()->property("slot").toInt());
-    connect(caliWindow, &AppCaliWindow::WindowExiting,      this, &guiWindow::CaliWindowExiting);
-    connect(caliWindow, &AppCaliWindow::CaliRequestToExit,  this, &guiWindow::CaliWindowRequestedExit);
-
-    caliWindow->showFullScreen();
+    NewCaliWindow(AppCaliWindow::modeCalibrate);
 
     serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1) +
                        "C" + // Calibrate byte
@@ -1542,15 +1557,7 @@ void guiWindow::serialPort_readyRead()
 {
     debugWindow.AppendText(serial.port.peek(serial.port.bytesAvailable()));
 
-    if(testMode) {
-        QString testBuffer = serial.port.readLine();
-
-        if(testBuffer.contains(',')) {
-            if(caliWindow != nullptr)
-                if(caliWindow->GetWindowMode() == AppCaliWindow::modeIRTest)
-                    caliWindow->TestModeDraw(testBuffer.remove("\r\n").split(',', Qt::SkipEmptyParts));
-        }
-    } else if(!serialActive) {
+    if(!serialActive) {
         while(!serial.port.atEnd()) {
             QString idleBuffer = serial.port.readLine();
 
@@ -1624,25 +1631,14 @@ void guiWindow::serialPort_readyRead()
                         caliWindow->CaliModeTextUpdate(idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed());
             }
 
-            else if(idleBuffer.contains("Entering Test Mode...")) {
-                if(caliWindow != nullptr)
-                    caliWindow->Shutdown();
+            else if(idleBuffer.startsWith("TM")) {
+                if(caliWindow != nullptr) {
+                    if(caliWindow->GetWindowMode() != AppCaliWindow::modeIRTest) {
+                        NewCaliWindow(AppCaliWindow::modeIRTest);
+                    }
+                } else NewCaliWindow(AppCaliWindow::modeIRTest);
 
-                caliWindow = new AppCaliWindow(nullptr, AppCaliWindow::modeIRTest);
-                connect(caliWindow, &AppCaliWindow::WindowExiting, this, &guiWindow::CaliWindowExiting);
-
-                caliWindow->showFullScreen();
-
-                testMode = true;
-
-                ui->buttonsTestArea->setEnabled(false);
-                ui->confirmButton->setEnabled(false);
-                ui->confirmButton->setText("[Disabled while in Test Mode]");
-                ui->pinsTab->setEnabled(false);
-                ui->settingsTab->setEnabled(false);
-                ui->profilesTab->setEnabled(false);
-                ui->feedbackTestsBox->setEnabled(false);
-                ui->dangerZoneBox->setEnabled(false);
+                caliWindow->TestModeDraw(idleBuffer.mid(2).split(',', Qt::SkipEmptyParts));
             }
 
             else if(idleBuffer.contains("Cleared! Please reset the board.")) {
@@ -1825,8 +1821,6 @@ void guiWindow::CaliWindowExiting(const int &mode,
     }
     case AppCaliWindow::modeIRTest:
         if(serial.OneShotSend("XT")) {
-            testMode = false;
-
             ui->buttonsTestArea->setEnabled(true);
             ui->pinsTab->setEnabled(true);
             ui->settingsTab->setEnabled(true);
@@ -1946,13 +1940,7 @@ void guiWindow::on_actionOpenFIRE_Serial_Usage_triggered()
 
 void guiWindow::on_actionOpen_IR_Emitter_Alignment_Assistant_triggered()
 {
-    if(caliWindow == nullptr) {
-        caliWindow = new AppCaliWindow(nullptr, AppCaliWindow::modeAlignment);
-        connect(caliWindow, &AppCaliWindow::WindowExiting, this, &guiWindow::CaliWindowExiting);
-        caliWindow->setAttribute(Qt::WA_DeleteOnClose);
-
-        caliWindow->showFullScreen();
-    }
+    NewCaliWindow(AppCaliWindow::modeAlignment);
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -802,7 +802,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
             ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
             ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs_orig[OF_Const::i2cOLED]);
-            // TODO: toggle for alt address here
+            ui->oledAltAddrsToggle->setChecked(App_Common::i2cOledPrefs[OF_Const::oledAltAddr]);
             ui->oledGroup->setEnabled(App_Common::inputsMap_orig.value(OF_Const::periphSCL) > -1 && App_Common::inputsMap_orig.value(OF_Const::periphSDA) > -1);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
@@ -1559,7 +1559,9 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 
 void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
 {
-    // TODO: add stuff
+    App_Common::i2cOledPrefs[OF_Const::oledAltAddr] = arg1;
+
+    DiffUpdate();
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1558,10 +1558,10 @@ void guiWindow::caliBtns_clicked()
 {
     NewCaliWindow(AppCaliWindow::modeCalibrate);
 
-    serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1) +
-                       "C" + // Calibrate byte
-                       "I" + QByteArray::number(App_Common::profilesTable.at(sender()->property("slot").toInt()).irSensitivity) +
-                       "L" + QByteArray::number(App_Common::profilesTable.at(sender()->property("slot").toInt()).layoutType));
+    serial.OneShotSend((char[]){(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt()),
+                                (char)OF_Const::sCaliStart,
+                                static_cast<char>(App_Common::profilesTable.at(sender()->property("slot").toInt()).irSensitivity +
+                                (App_Common::profilesTable.at(sender()->property("slot").toInt()).layoutType << 4))}, 4);
 }
 
 
@@ -1573,57 +1573,61 @@ void guiWindow::serialPort_readyRead()
 
     if(!serialActive) {
         while(serial.port.bytesAvailable()) {
-            QString idleBuffer = serial.port.readLine();
-
-            if(idleBuffer.contains("Pressed:")) {
-                int btn = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
+            switch(serial.port.read(1).at(0)) {
+            case OF_Const::sBtnPressed:
+            {
+                int btn = serial.port.read(1).at(0);
                 if(btn < 16)
                     testLabel[btn]->setStyleSheet("background-color: #FF0000; font: bold");
+                break;
             }
-
-            else if(idleBuffer.contains("Released:")) {
-                int btn = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
+            case OF_Const::sBtnReleased:
+            {
+                int btn = serial.port.read(1).at(0);
                 if(btn < 16)
                     testLabel[btn]->setStyleSheet("");
+                break;
             }
-
-            else if(idleBuffer.contains("Temperature:")) {
-                unsigned int temp = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
+            case OF_Const::sTemperatureUpd:
+            {
+                unsigned int temp = serial.port.read(1).at(0);
 
                 testLabel[14]->setText(QString("Temp: %1°C").arg(temp));
 
                 if(temp > tempShutoff) {        testLabel[14]->setStyleSheet("color: white;      background-color: #FF0000; font: bold"); }
                 else if(temp > tempWarning) {   testLabel[14]->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold"); }
                 else {                          testLabel[14]->setStyleSheet("color: black;      background-color: #11D00A; font: bold"); }
-            }
 
-            else if(idleBuffer.contains("Analog:")) {
+                break;
+            }
+            case OF_Const::sAnalogPosUpd:
+            {
                 // TODO: perhaps we should be using a small box area with a glyph depicting the aStick's coords instead of only showing cardinal directionality?
-                uint8_t analogDir = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
+                uint8_t analogDir = serial.port.read(1).at(0);
 
                 // analog stick moved
                 if(analogDir) {
                     switch(analogDir) {
-                        case 1: testLabel[15]->setText("Analog 🡹"); break;
-                        case 2: testLabel[15]->setText("Analog 🡼"); break;
-                        case 3: testLabel[15]->setText("Analog 🡸"); break;
-                        case 4: testLabel[15]->setText("Analog 🡿"); break;
-                        case 5: testLabel[15]->setText("Analog 🡻"); break;
-                        case 6: testLabel[15]->setText("Analog 🡾"); break;
-                        case 7: testLabel[15]->setText("Analog 🡺"); break;
-                        case 8: testLabel[15]->setText("Analog 🡽"); break;
+                    case 1: testLabel[15]->setText("Analog 🡹"); break;
+                    case 2: testLabel[15]->setText("Analog 🡼"); break;
+                    case 3: testLabel[15]->setText("Analog 🡸"); break;
+                    case 4: testLabel[15]->setText("Analog 🡿"); break;
+                    case 5: testLabel[15]->setText("Analog 🡻"); break;
+                    case 6: testLabel[15]->setText("Analog 🡾"); break;
+                    case 7: testLabel[15]->setText("Analog 🡺"); break;
+                    case 8: testLabel[15]->setText("Analog 🡽"); break;
                     }
 
                     testLabel[15]->setStyleSheet("background-color: #FF0000; font: bold");
-                // no analog direction
+                    // no analog direction
                 } else {
                     testLabel[15]->setText("Analog");
                     testLabel[15]->setStyleSheet("");
                 }
             }
-
-            else if(idleBuffer.contains("Profile: ")) {
-                uint8_t selection = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
+            case OF_Const::sCurrentProf:
+            {
+                uint8_t selection = serial.port.read(1).at(0);
 
                 if(selection != App_Common::board.selectedProfile) {
                     App_Common::board.selectedProfile = selection;
@@ -1631,34 +1635,39 @@ void guiWindow::serialPort_readyRead()
                 }
 
                 DiffUpdate();
+                break;
             }
-
-            else if(idleBuffer.contains("CalStage:")) {
+            case OF_Const::sCaliStageUpd:
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)
-                        caliWindow->CaliModeSet(idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt());
-            }
-
-            else if(idleBuffer.contains("CalUpd:")) {
+                        caliWindow->CaliModeSet(serial.port.read(1).at(0));
+                break;
+            case OF_Const::sCaliInfoUpd:
                 if(caliWindow != nullptr)
-                    if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)
-                        caliWindow->CaliModeTextUpdate(idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed());
-            }
-
-            else if(idleBuffer.startsWith("TM")) {
+                    if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate) {
+                        uint8_t type;
+                        serial.port.read((char*)&type, 1);
+                        caliWindow->CaliModeTextUpdate(type, serial.port.read(4).constData());
+                    }
+                break;
+            case OF_Const::sTestCoords:
                 if(caliWindow != nullptr) {
                     if(caliWindow->GetWindowMode() != AppCaliWindow::modeIRTest) {
                         NewCaliWindow(AppCaliWindow::modeIRTest);
                     }
                 } else NewCaliWindow(AppCaliWindow::modeIRTest);
 
-                caliWindow->TestModeDraw(idleBuffer.mid(2).split(',', Qt::SkipEmptyParts));
-            }
+                int coordsList[12];
+                for(int i = 0; i < sizeof(coordsList) / sizeof(int); i++)
+                    serial.port.read((char*)&coordsList[i], 4);
 
-            else if(idleBuffer.contains("Cleared! Please reset the board.")) {
+                caliWindow->TestModeDraw(coordsList);
+                break;
+            case OF_Const::sClearFlash:
                 ui->comPortSelector->setCurrentIndex(0);
                 QMessageBox::information(this, "Successfully reset board settings",
                                          "Please unplug the board and reinsert it into the PC.");
+                break;
             }
         }
     }
@@ -1751,42 +1760,42 @@ void guiWindow::serialPort_progressUpdate(const int &pos, const char *statusText
 
 void guiWindow::on_rumbleTestBtn_clicked()
 {
-    if(serial.OneShotSend("Xtr"))
+    if(serial.OneShotSend((char)OF_Const::sTestRumble))
         ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
 }
 
 
 void guiWindow::on_solenoidTestBtn_clicked()
 {
-    if(serial.OneShotSend("Xts"))
+    if(serial.OneShotSend((char)OF_Const::sTestSolenoid))
         ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
 }
 
 
 void guiWindow::on_redLedTestBtn_clicked()
 {
-    if(serial.OneShotSend("XtR"))
+    if(serial.OneShotSend((char)OF_Const::sTestLEDR))
         ui->statusBar->showMessage("Set LED to Red.", 2500);
 }
 
 
 void guiWindow::on_greenLedTestBtn_clicked()
 {
-    if(serial.OneShotSend("XtG"))
+    if(serial.OneShotSend((char)OF_Const::sTestLEDG))
         ui->statusBar->showMessage("Set LED to Green.", 2500);
 }
 
 
 void guiWindow::on_blueLedTestBtn_clicked()
 {
-    if(serial.OneShotSend("XtB"))
+    if(serial.OneShotSend((char)OF_Const::sTestLEDB))
         ui->statusBar->showMessage("Set LED to Blue.", 2500);
 }
 
 
 void guiWindow::on_testBtn_clicked()
 {
-    serial.OneShotSend("XT");
+    serial.OneShotSend((char)OF_Const::sIRTest);
 }
 
 
@@ -1835,7 +1844,7 @@ void guiWindow::CaliWindowExiting(const int &mode,
         break;
     }
     case AppCaliWindow::modeIRTest:
-        if(serial.OneShotSend("XT")) {
+        if(serial.OneShotSend((char)OF_Const::sIRTest)) {
             ui->buttonsTestArea->setEnabled(true);
             ui->pinsTab->setEnabled(true);
             ui->settingsTab->setEnabled(true);
@@ -1859,7 +1868,7 @@ void guiWindow::CaliWindowExiting(const int &mode,
 
 void guiWindow::CaliWindowRequestedExit()
 {
-    serial.OneShotSend("X");
+    serial.OneShotSend((char)OF_Const::serialTerminator);
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1542,7 +1542,15 @@ void guiWindow::serialPort_readyRead()
 {
     debugWindow.AppendText(serial.port.peek(serial.port.bytesAvailable()));
 
-    if(!serialActive) {
+    if(testMode) {
+        QString testBuffer = serial.port.readLine();
+
+        if(testBuffer.contains(',')) {
+            if(caliWindow != nullptr)
+                if(caliWindow->GetWindowMode() == AppCaliWindow::modeIRTest)
+                    caliWindow->TestModeDraw(testBuffer.remove("\r\n").split(',', Qt::SkipEmptyParts));
+        }
+    } else if(!serialActive) {
         while(!serial.port.atEnd()) {
             QString idleBuffer = serial.port.readLine();
 
@@ -1643,14 +1651,6 @@ void guiWindow::serialPort_readyRead()
                                          "Please unplug the board and reinsert it into the PC.");
             }
         }
-
-    } else if(testMode) {
-        QString testBuffer = serial.port.readLine();
-
-        if(testBuffer.contains(','))
-            if(caliWindow != nullptr)
-                if(caliWindow->GetWindowMode() == AppCaliWindow::modeIRTest)
-                    caliWindow->TestModeDraw(testBuffer.remove("\r\n").split(',', Qt::SkipEmptyParts));
     }
 }
 
@@ -1668,8 +1668,8 @@ void guiWindow::serialPort_SearchFinished()
                 for(const auto port : serial.currentPorts)
                     ui->comPortSelector->addItem(port.portName());
             }
-            // if comPort is filled
-            // TODO: find some way to add new items without removing
+        // if comPort is filled
+        // TODO: find some way to add new items without removing
         } else {
             if(serial.currentPorts.count()) {
                 // if no active comPort
@@ -1679,7 +1679,7 @@ void guiWindow::serialPort_SearchFinished()
 
                     for(const auto port : serial.currentPorts)
                         ui->comPortSelector->addItem(port.portName());
-                    // if comPort is active
+                // if comPort is active
                 } else {
                     // remove all other comPorts
                     int i = 1;
@@ -1704,7 +1704,7 @@ void guiWindow::serialPort_SearchFinished()
                     for(const auto port : serial.currentPorts)
                         ui->comPortSelector->addItem(port.portName());
                 }
-                // if ports list is cleared, assume no board can be connected.
+            // if ports list is cleared, assume no board can be connected.
             } else {
                 if(ui->comPortSelector->currentIndex() > 0)
                     statusBar()->showMessage("Current board has been disconnected.");
@@ -1775,9 +1775,6 @@ void guiWindow::on_blueLedTestBtn_clicked()
 
 void guiWindow::on_testBtn_clicked()
 {
-    // Pre-emptively put a sock in the readyRead signal
-    serialActive = true;
-
     serial.OneShotSend("XT");
 }
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1578,21 +1578,21 @@ void guiWindow::serialPort_readyRead()
     if(!serialActive) {
         while(serial.port.bytesAvailable()) {
             switch(serial.port.read(1).at(0)) {
-            case OF_Const::sBtnPressed:
+            case (char)OF_Const::sBtnPressed:
             {
                 int btn = serial.port.read(1).at(0);
                 if(btn < 16)
                     testLabel[btn]->setStyleSheet("background-color: #FF0000; font: bold");
                 break;
             }
-            case OF_Const::sBtnReleased:
+            case (char)OF_Const::sBtnReleased:
             {
                 int btn = serial.port.read(1).at(0);
                 if(btn < 16)
                     testLabel[btn]->setStyleSheet("");
                 break;
             }
-            case OF_Const::sTemperatureUpd:
+            case (char)OF_Const::sTemperatureUpd:
             {
                 unsigned int temp = serial.port.read(1).at(0);
 
@@ -1604,7 +1604,7 @@ void guiWindow::serialPort_readyRead()
 
                 break;
             }
-            case OF_Const::sAnalogPosUpd:
+            case (char)OF_Const::sAnalogPosUpd:
             {
                 // TODO: perhaps we should be using a small box area with a glyph depicting the aStick's coords instead of only showing cardinal directionality?
                 uint8_t analogDir = serial.port.read(1).at(0);
@@ -1629,7 +1629,7 @@ void guiWindow::serialPort_readyRead()
                     testLabel[15]->setStyleSheet("");
                 }
             }
-            case OF_Const::sCurrentProf:
+            case (char)OF_Const::sCurrentProf:
             {
                 uint8_t selection = serial.port.read(1).at(0);
 
@@ -1643,7 +1643,7 @@ void guiWindow::serialPort_readyRead()
             }
             // This should eventually have its own child branches for different error types,
             // but for now it's just for missing IR camera errors only
-            case OF_Const::sError:
+            case (char)OF_Const::sError:
                 if(caliWindow != nullptr)
                     caliWindow->Shutdown();
                 serial.ShowError("Device Error: Camera not available!",
@@ -1658,12 +1658,12 @@ void guiWindow::serialPort_readyRead()
                                  "<p>IR Testing and Calibration will not be available while in this state.</p>",
                                  QMessageBox::Critical);
                 break;
-            case OF_Const::sCaliStageUpd:
+            case (char)OF_Const::sCaliStageUpd:
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)
                         caliWindow->CaliModeSet(serial.port.read(1).at(0));
                 break;
-            case OF_Const::sCaliInfoUpd:
+            case (char)OF_Const::sCaliInfoUpd:
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate) {
                         uint8_t type;
@@ -1671,7 +1671,7 @@ void guiWindow::serialPort_readyRead()
                         caliWindow->CaliModeTextUpdate(type, serial.port.read(4).constData());
                     }
                 break;
-            case OF_Const::sTestCoords:
+            case (char)OF_Const::sTestCoords:
                 if(caliWindow != nullptr) {
                     if(caliWindow->GetWindowMode() != AppCaliWindow::modeIRTest) {
                         NewCaliWindow(AppCaliWindow::modeIRTest);
@@ -1684,7 +1684,7 @@ void guiWindow::serialPort_readyRead()
 
                 caliWindow->TestModeDraw(coordsList);
                 break;
-            case OF_Const::sClearFlash:
+            case (char)OF_Const::sClearFlash:
                 ui->comPortSelector->setCurrentIndex(0);
                 QMessageBox::information(this, "Successfully reset board settings",
                                          "Please unplug the board and reinsert it into the PC.");

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1008,22 +1008,27 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
 
     // update settings panel to reflect pins map changes and prevent illegal values/combinations
     if(App_Common::inputsMap.value(OF_Const::rumblePin) >= 0)
-        ui->rumbleToggle->setEnabled(true), ui->rumbleFFToggle->setEnabled(true);
+        ui->rumbleFFBox->setEnabled(true);
     else {
-        ui->rumbleToggle->setChecked(false),   ui->rumbleToggle->setEnabled(false),
-        ui->rumbleFFToggle->setChecked(false), ui->rumbleFFToggle->setEnabled(false);
+        ui->rumbleToggle->setChecked(false);
+        ui->rumbleFFToggle->setChecked(false);
+        ui->rumbleFFBox->setEnabled(false);
     }
 
     if(App_Common::inputsMap.value(OF_Const::solenoidPin) >= 0)
-        ui->solenoidToggle->setEnabled(true);
-    else ui->solenoidToggle->setChecked(false), ui->solenoidToggle->setEnabled(false);
+         ui->solenoidFFBox->setEnabled(true);
+    else ui->solenoidToggle->setChecked(false), ui->solenoidFFBox->setEnabled(false);
+
+    if(App_Common::inputsMap.value(OF_Const::rumblePin) >= 0 && App_Common::inputsMap.value(OF_Const::solenoidPin) >= 0)
+         ui->forceFeedbackBox->setEnabled(true);
+    else ui->forceFeedbackBox->setEnabled(false);
 
     if(App_Common::inputsMap.value(OF_Const::neoPixel) >= 0)
-        ui->neopixelGroupBox->setEnabled(true);
+         ui->neopixelGroupBox->setEnabled(true);
     else ui->neopixelGroupBox->setEnabled(false);
 
     if(App_Common::inputsMap.value(OF_Const::ledR) >= 0 && App_Common::inputsMap.value(OF_Const::ledG) >= 0 && App_Common::inputsMap.value(OF_Const::ledB) >= 0)
-        ui->commonAnodeToggle->setEnabled(true);
+         ui->commonAnodeToggle->setEnabled(true);
     else ui->commonAnodeToggle->setEnabled(false);
 
     DiffUpdate();
@@ -1094,20 +1099,18 @@ void guiWindow::on_customPinsEnabled_stateChanged(int arg1)
     else ui->customLayoutToolBtn->setEnabled(false);
 
     if(App_Common::inputsMap.value(OF_Const::solenoidPin) > OF_Const::btnUnmapped) {
-        ui->solenoidToggle->setEnabled(true);
+        ui->solenoidFFBox->setEnabled(true);
     } else {
         ui->solenoidToggle->setEnabled(false);
-        ui->solenoidToggle->setChecked(false);
+        ui->solenoidFFBox->setEnabled(false);
     }
 
     if(App_Common::inputsMap.value(OF_Const::rumblePin) > OF_Const::btnUnmapped) {
-        ui->rumbleToggle->setEnabled(true);
-        ui->rumbleFFToggle->setEnabled(true);
+        ui->rumbleFFBox->setEnabled(true);
     } else {
-        ui->rumbleToggle->setEnabled(false);
         ui->rumbleToggle->setChecked(false);
-        ui->rumbleFFToggle->setEnabled(false);
         ui->rumbleFFToggle->setChecked(false);
+        ui->rumbleFFBox->setEnabled(false);
     }
 
     DiffUpdate();
@@ -1138,24 +1141,23 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
 void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[OF_Const::rumble] = arg1;
-    if(!arg1) {
-        ui->rumbleFFToggle->setChecked(false);
-        ui->rumbleFFToggle->setEnabled(false);
-        ui->rumbleIntensityBox->setEnabled(false);
-        ui->rumbleLengthBox->setEnabled(false);
-        ui->rumbleTestBtn->setEnabled(false);
-    } else {
-        ui->rumbleFFToggle->setEnabled(true);
-        ui->rumbleIntensityBox->setEnabled(true);
-        ui->rumbleLengthBox->setEnabled(true);
+
+    if(arg1) {
+        ui->rumbleSettingsBox->setEnabled(true);
         ui->rumbleTestBtn->setEnabled(true);
+    } else {
+        ui->rumbleFFToggle->setChecked(false);
+        ui->rumbleSettingsBox->setEnabled(false);
+        ui->rumbleTestBtn->setEnabled(false);
     }
+
     if(!(arg1 && App_Common::boolSettings[OF_Const::rumbleFF]) && !App_Common::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
         ui->autofireToggle->setEnabled(true);
     }
+
     DiffUpdate();
 }
 
@@ -1163,24 +1165,23 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[OF_Const::solenoid] = arg1;
+
     if(arg1) {
         ui->rumbleFFToggle->setChecked(false);
-        ui->solenoidNormalIntervalBox->setEnabled(true);
-        ui->solenoidFastIntervalBox->setEnabled(true);
-        ui->solenoidHoldLengthBox->setEnabled(true);
+        ui->solenoidSettingsBox->setEnabled(true);
         ui->solenoidTestBtn->setEnabled(true);
     } else {
-        ui->solenoidNormalIntervalBox->setEnabled(false);
-        ui->solenoidFastIntervalBox->setEnabled(false);
-        ui->solenoidHoldLengthBox->setEnabled(false);
+        ui->solenoidSettingsBox->setEnabled(false);
         ui->solenoidTestBtn->setEnabled(false);
     }
+
     if(!arg1 && !(App_Common::boolSettings[OF_Const::rumble] && App_Common::boolSettings[OF_Const::rumbleFF])) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
         ui->autofireToggle->setEnabled(true);
     }
+
     DiffUpdate();
 }
 
@@ -1188,7 +1189,10 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 void guiWindow::on_autofireToggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[OF_Const::autofire] = arg1;
-    if(arg1) { ui->autofireWaitFactorBox->setEnabled(true); } else { ui->autofireWaitFactorBox->setEnabled(false); }
+
+    if(arg1) ui->autofireWaitFactorBox->setEnabled(true);
+    else     ui->autofireWaitFactorBox->setEnabled(false);
+
     DiffUpdate();
 }
 
@@ -1203,8 +1207,10 @@ void guiWindow::on_simplePauseToggle_stateChanged(int arg1)
 void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[OF_Const::holdToPause] = arg1;
-    if(arg1) { ui->holdToPauseLengthBox->setEnabled(true); }
-    else { ui->holdToPauseLengthBox->setEnabled(false); }
+
+    if(arg1) ui->holdToPauseLengthBox->setEnabled(true);
+    else     ui->holdToPauseLengthBox->setEnabled(false);
+
     DiffUpdate();
 }
 
@@ -1226,13 +1232,15 @@ void guiWindow::on_lowButtonsToggle_stateChanged(int arg1)
 void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[OF_Const::rumbleFF] = arg1;
-    if(arg1) { ui->solenoidToggle->setChecked(false); }
+    if(arg1) ui->solenoidToggle->setChecked(false);
+
     if(!(arg1 && App_Common::boolSettings[OF_Const::rumble]) && !App_Common::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
         ui->autofireToggle->setEnabled(true);
     }
+
     DiffUpdate();
 }
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -340,9 +340,9 @@ QString guiWindow::PrettifyName(QString name)
         name = "Unnamed Device";
 
     // append name of board to gun name string.
-    if(OF_Const::boardNames.contains(App_Common::board.boardType.toStdString()))
-         return name + " | " + OF_Const::boardNames[App_Common::board.boardType.toStdString()];
-    else return name + " | " + OF_Const::boardNames["generic"];
+    if(OF_Const::boardNames.count(App_Common::board.boardType.toStdString()))
+         return name + " | " + OF_Const::boardNames.at(App_Common::board.boardType.toStdString());
+    else return name + " | " + OF_Const::boardNames.at("generic");
 }
 
 
@@ -650,7 +650,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinBoxes.at(i)->setProperty("trackable", App_Common::trackPinbox);
                 pinBoxes.at(i)->installEventFilter(this);
                 // install items
-                pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
+                for(auto item : OF_Const::valuesNameList)
+                    pinBoxes.at(i)->addItem(item);
                 // clear out analog options for digital pins (< GPIO26)
                 // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
                 if(i < 26) {
@@ -666,6 +667,9 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                     SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
                     SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
                 }
+                // for now, disable unused "battery sensor" option.
+                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::battery+1, false);
+                // connect up combobox signal
                 connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
 
                 padding << new QWidget();
@@ -690,9 +694,9 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 ui->presetsBox->setHidden(false);
                 ui->presetsBox->setEnabled(true);
 
-                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Common::board.boardType.toStdString());
-                for(auto &entry : altPresets)
-                    ui->presetsBox->addItem(entry.name);
+                auto iter = OF_Const::boardsAltPresets.equal_range(App_Common::board.boardType.toStdString());
+                for(auto i = iter.first; i != iter.second; i++)
+                    ui->presetsBox->addItem(i->second.name);
             } else {
                 ui->presetsBox->setEnabled(false);
                 ui->presetsBox->setHidden(true);
@@ -704,33 +708,33 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             LabelsUpdate();
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(OF_Const::boardsBoxPositions.contains(App_Common::board.boardType.toStdString())) {
+            if(OF_Const::boardsBoxPositions.count(App_Common::board.boardType.toStdString())) {
                 QFile resource(":/boardPics/" + App_Common::board.boardType);
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < pinBoxes.count(); i++) {
-                    if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
+                    if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
                                                 1);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
+                    } else if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
                                                  0);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
+                    } else if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
                     }
                 }
             } else {
@@ -739,27 +743,27 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < pinBoxes.count(); i++) {
-                    if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
+                    if(OF_Const::boardsBoxPositions.at("generic").pin[i] & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posLeft,
                                                 1);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posRight) {
+                    } else if(OF_Const::boardsBoxPositions.at("generic").pin[i] & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posRight,
                                                  0);
-                    } else if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posMiddle) {
+                    } else if(OF_Const::boardsBoxPositions.at("generic").pin[i] & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.at("generic").pin[i] ^ OF_Const::posMiddle);
                     }
                 }
             }
@@ -1132,9 +1136,12 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
             pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // set pinboxes to alt preset values (and let the index changed signal handle the rest)
-        QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Common::board.boardType.toStdString());
+        auto preset = OF_Const::boardsAltPresets.equal_range(App_Common::board.boardType.toStdString()).first;
+        for(int i = 0; i < index; i++)
+            preset++;
+
         for(int i = 0; i < pinBoxes.count(); i++)
-            pinBoxes.at(i)->setCurrentIndex(altPresets.at(index).pin[i]+1);
+            pinBoxes.at(i)->setCurrentIndex(preset->second.pin[i]+1);
 
         DiffUpdate();
     }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -282,7 +282,7 @@ void guiWindow::DiffUpdate()
     if(memcmp(App_Common::i2cPeriphs[App_Common::dataCurrent], App_Common::i2cPeriphs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs)))
         settingsDiff++;
 
-    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs)))
+    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cOledPrefs)))
         settingsDiff++;
 
     for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1428,7 +1428,8 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
     if(isChecked && !serialActive) {
         // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
         if(sender()->property("slot").toInt() != App_Common::board.selectedProfile) {
-            serial.OneShotSend((char[]){(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt())}, 4);
+            char buf[] = {(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt())};
+            serial.OneShotSend(buf, 4);
             App_Common::board.selectedProfile = sender()->property("slot").toInt();
             DiffUpdate();
         }
@@ -1558,10 +1559,12 @@ void guiWindow::caliBtns_clicked()
 {
     NewCaliWindow(AppCaliWindow::modeCalibrate);
 
-    serial.OneShotSend((char[]){(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt()),
-                                (char)OF_Const::sCaliStart,
-                                static_cast<char>(App_Common::profilesTable.at(sender()->property("slot").toInt()).irSensitivity +
-                                (App_Common::profilesTable.at(sender()->property("slot").toInt()).layoutType << 4))}, 4);
+    char buf[] = {(char)OF_Const::sCaliProfile,
+                  static_cast<char>(sender()->property("slot").toInt()),
+                  (char)OF_Const::sCaliStart,
+                  static_cast<char>(App_Common::profilesTable.at(sender()->property("slot").toInt()).irSensitivity +
+                                    (App_Common::profilesTable.at(sender()->property("slot").toInt()).layoutType << 4))};
+    serial.OneShotSend(buf, 4);
 }
 
 
@@ -1896,7 +1899,7 @@ void guiWindow::on_clearEepromBtn_clicked()
 void guiWindow::on_baudResetBtn_clicked()
 {
     // No need for workarounds, bootloader reset is in the firmware now.
-    if(serial.OneShotSend((char[]){(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader})) {
+    if(char buf[] = {(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader}; serial.OneShotSend(buf)) {
 
 /* test stuff for potential app FW update functionality
         // At least on my system, the Bootloader device takes ~7s to appear

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -911,7 +911,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
     // and "prevMapping" to get previous index, as this method immediately overwrites what it was mapped to.
     // always remember to sync the change to "prevMapping" property at the end of its logic path!
 
-    /*
+    /* For debugging pinBoxes (too lazy to ifdef guard)
     if(index >= 0 && index <= App_Common::inputsMap.size()) {
         //printf("Requesting pinbox %d to set to %s\n", sender()->property("slot").toInt(), OF_Const::valuesNameList.at(index).toLocal8Bit().constData());
     } else printf("Oops! Seems like pinbox %d is trying to set itself to index %d, which is out of range!\n", sender()->property("slot").toInt(), index);
@@ -1666,7 +1666,7 @@ void guiWindow::serialPort_SearchFinished()
                 ui->comPortSelector->addItem("[Select a device]");
                 ui->comPortSelector->setCurrentIndex(0);
                 for(const auto port : serial.currentPorts)
-                    ui->comPortSelector->addItem(port.portName());
+                    ui->comPortSelector->addItem(port.portName()+" (" + port.description() + ')');
             }
         // if comPort is filled
         // TODO: find some way to add new items without removing
@@ -1677,8 +1677,8 @@ void guiWindow::serialPort_SearchFinished()
                     while(ui->comPortSelector->count() > 1)
                         ui->comPortSelector->removeItem(1);
 
-                    for(const auto port : serial.currentPorts)
-                        ui->comPortSelector->addItem(port.portName());
+                    for(const auto newPort : serial.currentPorts)
+                        ui->comPortSelector->addItem(newPort.portName()+" (" + newPort.description() + ')');
                 // if comPort is active
                 } else {
                     // remove all other comPorts
@@ -1692,8 +1692,8 @@ void guiWindow::serialPort_SearchFinished()
                     // check if current comPort is still in devices list
                     // TODO: probably a better way of doing this, meh
                     bool inList = false;
-                    for(const auto port : serial.currentPorts)
-                        if(ui->comPortSelector->currentText() == port.portName())
+                    for(const auto newPort : serial.currentPorts)
+                        if(ui->comPortSelector->currentText() == newPort.portName()+" (" + newPort.description() + ')')
                             inList = true;
                     if(!inList) {
                         statusBar()->showMessage("Current board has been disconnected.");
@@ -1701,8 +1701,9 @@ void guiWindow::serialPort_SearchFinished()
                     }
 
                     // append new items to list
-                    for(const auto port : serial.currentPorts)
-                        ui->comPortSelector->addItem(port.portName());
+                    for(const auto newPort : serial.currentPorts)
+                        if(ui->comPortSelector->currentText() != newPort.portName()+" (" + newPort.description() + ')')
+                            ui->comPortSelector->addItem(newPort.portName()+" (" + newPort.description() + ')');
                 }
             // if ports list is cleared, assume no board can be connected.
             } else {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1644,6 +1644,8 @@ void guiWindow::serialPort_readyRead()
             // This should eventually have its own child branches for different error types,
             // but for now it's just for missing IR camera errors only
             case OF_Const::sError:
+                if(caliWindow != nullptr)
+                    caliWindow->Shutdown();
                 serial.ShowError("Device Error: Camera not available!",
                                  "Data received from the board indicates that the camera is in a bad state.\n"
                                  "This can happen if, for example, the camera wires are crossed\n"

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -416,6 +416,13 @@ void guiWindow::on_confirmButton_clicked()
                    App_Common::settingsTable[App_Common::dataCurrent],
                    sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
+            memcpy(App_Common::i2cPeriphs[App_Common::dataOrig],
+                   App_Common::i2cPeriphs[App_Common::dataCurrent],
+                   sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent]));
+            memcpy(App_Common::i2cOledPrefs[App_Common::dataOrig],
+                   App_Common::i2cOledPrefs[App_Common::dataCurrent],
+                   sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent]));
+
             App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
             App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
             App_Common::board.previousProfile = App_Common::board.selectedProfile;

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -75,10 +75,10 @@ guiWindow::guiWindow(QWidget *parent)
     aliveTimer.start(ALIVE_TIMER);
     aliveTimer_timeout();
 
-#if defined(OFAPP_VERSION) & defined(OFAPP_CODENAME)
-    this->setWindowTitle("OpenFIRE App - " + OFAPP_CODENAME + " [v" + OFAPP_VERSION + ']');
+#if defined(OFAPP_GITHASH)
+    this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + '-' + QString(OFAPP_GITHASH) + ']');
 #else
-    this->setWindowTitle("OpenFIRE App - Tokinomiya [v3.0-dev]");
+    this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + ']');
 #endif // OFAPP_VERSION
 
     // get all fixed interactable elements marked to use event filter for hover stuff:

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1892,9 +1892,7 @@ void guiWindow::on_clearEepromBtn_clicked()
 
 void guiWindow::on_baudResetBtn_clicked()
 {
-    // The py script had this backwards. huh.
-    serial.port.setBaudRate(QSerialPort::Baud1200);
-    serial.port.setDataTerminalReady(false);
+    serial.RebootToBootldr();
 
 /* test stuff for potential app FW update functionality
     // At least on my system, the Bootloader device takes ~7s to appear

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1997,7 +1997,7 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
     if(!path.isEmpty()) {
         QFile fileOut(path);
         if(fileOut.open(QFile::WriteOnly)) {
-            fileOut.write(QString("%1\n").arg(App_Common::board.boardType).toLocal8Bit());
+            fileOut.write(App_Common::board.boardType + '\n');
 
             for(int i = 0; i < pinBoxes.count(); i++)
                 fileOut.putChar(pinBoxes.at(i)->currentIndex());

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1647,15 +1647,15 @@ void guiWindow::serialPort_readyRead()
                 if(caliWindow != nullptr)
                     caliWindow->Shutdown();
                 serial.ShowError("Device Error: Camera not available!",
-                                 "Data received from the board indicates that the camera is in a bad state.\n"
-                                 "This can happen if, for example, the camera wires are crossed\n"
-                                 "(data wire to clock pin, clock wire to data pin),\n"
-                                 "or the camera pins are wired to a different component,\n"
-                                 "such as a button or Force Feedback output.\n\n"
-                                 "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
-                                 "if they should be mapped different GPIO;\n"
-                                 "Otherwise, the camera wires must be resoldered to resolve this error.\n\n"
-                                 "IR Testing and Calibration will not be available while in this state.",
+                                 "<p>Data received from the board indicates that the camera is in a bad state.<br>"
+                                 "This can happen if, for example, the camera wires are crossed<br>"
+                                 "(data wire to clock pin, clock wire to data pin),<br>"
+                                 "or the camera pins are wired to a different component,<br>"
+                                 "such as a button or Force Feedback output.</p>"
+                                 "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
+                                 "if they should be mapped different GPIO;<br>"
+                                 "Otherwise, the camera wires must be resoldered to resolve this error.</p>"
+                                 "<p>IR Testing and Calibration will not be available while in this state.</p>",
                                  QMessageBox::Critical);
                 break;
             case OF_Const::sCaliStageUpd:

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -520,7 +520,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                                               "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
                 connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
 
-                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Common::profilesTable.at(i).profName));
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(QString(App_Common::profilesTable.at(i).profName)));
                 if(i == App_Common::board.selectedProfile)
                     selectedProfile.at(i)->setChecked(true);
                 selectedProfile.at(i)->setFont(QFont("Monospace"));
@@ -1063,7 +1063,7 @@ void guiWindow::renameBoxes_clicked()
 
     if(!newLabel.isEmpty()) {
         selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()).arg(newLabel.left(15)));
-        App_Common::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15);
+        App_Common::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15).toLocal8Bit();
     }
 
     DiffUpdate();

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -260,20 +260,15 @@ void guiWindow::DiffUpdate()
 {
     int settingsDiff = 0;
 
-    if(App_Common::boolSettings_orig[OF_Const::customPins] != App_Common::boolSettings[OF_Const::customPins])
+    if(memcmp(App_Common::boolSettings, App_Common::boolSettings_orig, sizeof(App_Common::boolSettings)))
         settingsDiff++;
 
     if(App_Common::boolSettings[OF_Const::customPins])
         if(App_Common::inputsMap_orig != App_Common::inputsMap)
             settingsDiff++;
 
-    for(uint8_t i = 1; i < OF_Const::boolTypesCount; i++)
-        if(App_Common::boolSettings_orig[i] != App_Common::boolSettings[i])
-            settingsDiff++;
-
-    for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-        if(App_Common::settingsTable_orig[i] != App_Common::settingsTable[i])
-            settingsDiff++;
+    if(memcmp(App_Common::settingsTable, App_Common::settingsTable_orig, sizeof(App_Common::settingsTable)))
+        settingsDiff++;
 
     if(App_Common::tinyUSBtable_orig.tinyUSBid != App_Common::tinyUSBtable.tinyUSBid)
         settingsDiff++;
@@ -282,6 +277,9 @@ void guiWindow::DiffUpdate()
         settingsDiff++;
 
     if(App_Common::board.selectedProfile != App_Common::board.previousProfile)
+        settingsDiff++;
+
+    if(memcmp(App_Common::i2cPeriphs, App_Common::i2cPeriphs_orig, sizeof(App_Common::i2cPeriphs)))
         settingsDiff++;
 
     for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
@@ -803,6 +801,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidFastInterval]);
             ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
             ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
+            ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs_orig[OF_Const::i2cOLED]);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
@@ -1025,6 +1024,10 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
     if(App_Common::inputsMap.value(OF_Const::ledR) >= 0 && App_Common::inputsMap.value(OF_Const::ledG) >= 0 && App_Common::inputsMap.value(OF_Const::ledB) >= 0)
          ui->commonAnodeToggle->setEnabled(true);
     else ui->commonAnodeToggle->setEnabled(false);
+
+    if(App_Common::inputsMap.value(OF_Const::periphSDA) >= 0 && App_Common::inputsMap.value(OF_Const::periphSCL))
+         ui->i2cGroup->setEnabled(true);
+    else ui->i2cGroup->setEnabled(false);
 
     DiffUpdate();
 }
@@ -1542,6 +1545,15 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
         DiffUpdate();
     }
 }
+
+
+void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
+{
+    App_Common::i2cPeriphs[OF_Const::i2cOLED] = arg1;
+
+    DiffUpdate();
+}
+
 
 void guiWindow::caliBtns_clicked()
 {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1641,8 +1641,20 @@ void guiWindow::serialPort_readyRead()
                 DiffUpdate();
                 break;
             }
-            // placeholder in case board generates an error outside of saving
+            // This should eventually have its own child branches for different error types,
+            // but for now it's just for missing IR camera errors only
             case OF_Const::sError:
+                serial.ShowError("Device Error: Camera not available!",
+                                 "Data received from the board indicates that the camera is in a bad state.\n"
+                                 "This can happen if, for example, the camera wires are crossed\n"
+                                 "(data wire to clock pin, clock wire to data pin),\n"
+                                 "or the camera pins are wired to a different component,\n"
+                                 "such as a button or Force Feedback output.\n\n"
+                                 "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
+                                 "if they should be mapped different GPIO;\n"
+                                 "Otherwise, the camera wires must be resoldered to resolve this error.\n\n"
+                                 "IR Testing and Calibration will not be available while in this state.",
+                                 QMessageBox::Critical);
                 break;
             case OF_Const::sCaliStageUpd:
                 if(caliWindow != nullptr)

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -802,7 +802,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->solenoidHoldLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
             ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
 
-            ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+            ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
             ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDcount]);
             ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDstatic]);
@@ -810,7 +810,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
             ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
 
-            switch(App_Common::tinyUSBtable.tinyUSBid.toInt()) {
+            switch(App_Common::tinyUSBtable.tinyUSBid) {
             case 1:
                 ui->tUSB_p1->setChecked(true);
                 ui->tUSBLayoutAdvanced->setVisible(false);
@@ -1297,9 +1297,9 @@ void guiWindow::on_autofireWaitFactorBox_valueChanged(int arg1)
 void guiWindow::on_tUSB_p1_toggled(bool checked)
 {
     if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = "1";
+        App_Common::tinyUSBtable.tinyUSBid = 1;
         App_Common::tinyUSBtable.tinyUSBname = "FIRECon P1";
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
@@ -1310,9 +1310,9 @@ void guiWindow::on_tUSB_p1_toggled(bool checked)
 void guiWindow::on_tUSB_p2_toggled(bool checked)
 {
     if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = "2";
+        App_Common::tinyUSBtable.tinyUSBid = 2;
         App_Common::tinyUSBtable.tinyUSBname = "FIRECon P2";
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
@@ -1323,9 +1323,9 @@ void guiWindow::on_tUSB_p2_toggled(bool checked)
 void guiWindow::on_tUSB_p3_toggled(bool checked)
 {
     if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = "3";
+        App_Common::tinyUSBtable.tinyUSBid = 3;
         App_Common::tinyUSBtable.tinyUSBname = "FIRECon P3";
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
@@ -1336,9 +1336,9 @@ void guiWindow::on_tUSB_p3_toggled(bool checked)
 void guiWindow::on_tUSB_p4_toggled(bool checked)
 {
     if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = "4";
+        App_Common::tinyUSBtable.tinyUSBid = 4;
         App_Common::tinyUSBtable.tinyUSBname = "FIRECon P4";
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
@@ -1348,7 +1348,7 @@ void guiWindow::on_tUSB_p4_toggled(bool checked)
 
 void guiWindow::on_productIdInput_valueChanged(int arg1)
 {
-    App_Common::tinyUSBtable.tinyUSBid = QString::number(arg1);
+    App_Common::tinyUSBtable.tinyUSBid = arg1;
     if(ui->productNameInput->text().isEmpty()) {
         switch(arg1) {
         case 1:
@@ -1394,7 +1394,7 @@ void guiWindow::on_productNameInput_textEdited(const QString &arg1)
     } else {
         if(!ui->productNameInput->styleSheet().isEmpty())
             ui->productNameInput->setStyleSheet("");
-        App_Common::tinyUSBtable.tinyUSBname = arg1;
+        App_Common::tinyUSBtable.tinyUSBname = arg1.toLocal8Bit();
         DiffUpdate();
     }
 }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1572,7 +1572,7 @@ void guiWindow::serialPort_readyRead()
     debugWindow.AppendText(serial.port.peek(serial.port.bytesAvailable()));
 
     if(!serialActive) {
-        while(!serial.port.atEnd()) {
+        while(serial.port.bytesAvailable()) {
             QString idleBuffer = serial.port.readLine();
 
             if(idleBuffer.contains("Pressed:")) {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1641,6 +1641,9 @@ void guiWindow::serialPort_readyRead()
                 DiffUpdate();
                 break;
             }
+            // placeholder in case board generates an error outside of saving
+            case OF_Const::sError:
+                break;
             case OF_Const::sCaliStageUpd:
                 if(caliWindow != nullptr)
                     if(caliWindow->GetWindowMode() == AppCaliWindow::modeCalibrate)

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -108,7 +108,7 @@ guiWindow::guiWindow(QWidget *parent)
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     // Setup test screen buttons
-    for(int i = 0; i < 13; i++) {
+    for(int i = 0; i < 14; i++) {
         testLabel << new QLabel(OF_Const::valuesNameList[i+1]);
 
         testLabel.at(i)->setEnabled(false);
@@ -888,10 +888,10 @@ void guiWindow::LabelsUpdate()
     for(uint8_t i = 0; i < testLabel.count(); i++) {
         testLabel.at(i)->setStyleSheet("");
         if(App_Common::inputsMap.value(i) >= 0) {
-            testLabel.at(i)->setText(App_Common::testLabelNames.at(i));
+            testLabel.at(i)->setText(OF_Const::valuesNameList[i+1]);
             testLabel.at(i)->setEnabled(true);
         } else {
-            testLabel.at(i)->setText(App_Common::testLabelNames.at(i) + " (N/C)");
+            testLabel.at(i)->setText(QByteArray(OF_Const::valuesNameList[i+1]) + " (N/C)");
             testLabel.at(i)->setEnabled(false);
         }
     }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -802,6 +802,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
             ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
             ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs_orig[OF_Const::i2cOLED]);
+            // TODO: toggle for alt address here
+            ui->oledGroup->setEnabled(App_Common::inputsMap_orig.value(OF_Const::periphSCL) > -1 && App_Common::inputsMap_orig.value(OF_Const::periphSDA) > -1);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
@@ -1552,6 +1554,12 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
     App_Common::i2cPeriphs[OF_Const::i2cOLED] = arg1;
 
     DiffUpdate();
+}
+
+
+void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
+{
+    // TODO: add stuff
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1916,30 +1916,30 @@ void guiWindow::on_clearEepromBtn_clicked()
 
 void guiWindow::on_baudResetBtn_clicked()
 {
-    // No need for workarounds, bootloader reset is in the firmware now.
-    if(char buf[] = {(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader}; serial.OneShotSend(buf, 2)) {
+    // The py script had this backwards. huh.
+    serial.port.setBaudRate(QSerialPort::Baud1200);
+    serial.port.setDataTerminalReady(false);
 
 /* test stuff for potential app FW update functionality
-        // At least on my system, the Bootloader device takes ~7s to appear
-        QThread::msleep(7000);
-        // Class-ify this function, maybe.
-        QString picoPath;
-        foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
-            if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
-                picoPath = storageDevices.device();
-                qDebug() << "Found a Pico bootloader!";
-                break;
-            } else {
-                qDebug() << "nope";
-            }
+    // At least on my system, the Bootloader device takes ~7s to appear
+    QThread::msleep(7000);
+    // Class-ify this function, maybe.
+    QString picoPath;
+    foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
+        if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
+            picoPath = storageDevices.device();
+            qDebug() << "Found a Pico bootloader!";
+            break;
+        } else {
+            qDebug() << "nope";
         }
-        qDebug() << picoPath;
-        // QFile::copy("file", picoPath+"file");
+    }
+    qDebug() << picoPath;
+    // QFile::copy("file", picoPath+"file");
 */
 
-        ui->statusBar->showMessage("Board reset to bootloader.", 5000);
-        ui->comPortSelector->setCurrentIndex(0);
-    }
+    ui->statusBar->showMessage("Board reset to bootloader.", 5000);
+    ui->comPortSelector->setCurrentIndex(0);
 }
 
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -208,13 +208,13 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
 void guiWindow::BoxesUpdate()
 {
     // enabling custom pins
-    if(App_Common::boolSettings[OF_Const::customPins]) {
+    if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]) {
         // enable pinboxes
         for(int i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setEnabled(true);
 
         // if the custom pins setting *grabbed from the gun* has been set
-        if(App_Common::boolSettings_orig[OF_Const::customPins]) {
+        if(App_Common::boolSettings[App_Common::dataOrig][OF_Const::customPins]) {
             // reset pinboxes
             for(int i = 0; i < pinBoxes.count(); i++)
                 pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
@@ -260,14 +260,14 @@ void guiWindow::DiffUpdate()
 {
     int settingsDiff = 0;
 
-    if(memcmp(App_Common::boolSettings, App_Common::boolSettings_orig, sizeof(App_Common::boolSettings)))
+    if(memcmp(App_Common::boolSettings[App_Common::dataCurrent], App_Common::boolSettings[App_Common::dataOrig], sizeof(App_Common::boolSettings)))
         settingsDiff++;
 
-    if(App_Common::boolSettings[OF_Const::customPins])
+    if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins])
         if(App_Common::inputsMap_orig != App_Common::inputsMap)
             settingsDiff++;
 
-    if(memcmp(App_Common::settingsTable, App_Common::settingsTable_orig, sizeof(App_Common::settingsTable)))
+    if(memcmp(App_Common::settingsTable[App_Common::dataCurrent], App_Common::settingsTable[App_Common::dataOrig], sizeof(App_Common::settingsTable)))
         settingsDiff++;
 
     if(App_Common::tinyUSBtable_orig.tinyUSBid != App_Common::tinyUSBtable.tinyUSBid)
@@ -279,7 +279,10 @@ void guiWindow::DiffUpdate()
     if(App_Common::board.selectedProfile != App_Common::board.previousProfile)
         settingsDiff++;
 
-    if(memcmp(App_Common::i2cPeriphs, App_Common::i2cPeriphs_orig, sizeof(App_Common::i2cPeriphs)))
+    if(memcmp(App_Common::i2cPeriphs[App_Common::dataCurrent], App_Common::i2cPeriphs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs)))
+        settingsDiff++;
+
+    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs)))
         settingsDiff++;
 
     for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
@@ -341,11 +344,11 @@ QString guiWindow::PrettifyName(QString name)
 
 void guiWindow::PixelsDiff()
 {
-    if( App_Common::settingsTable[OF_Const::customLEDcount]  == App_Common::settingsTable_orig[OF_Const::customLEDcount]  &&
-        App_Common::settingsTable[OF_Const::customLEDstatic] == App_Common::settingsTable_orig[OF_Const::customLEDstatic] &&
-        App_Common::settingsTable[OF_Const::customLEDcolor1] == App_Common::settingsTable_orig[OF_Const::customLEDcolor1] &&
-        App_Common::settingsTable[OF_Const::customLEDcolor2] == App_Common::settingsTable_orig[OF_Const::customLEDcolor2] &&
-        App_Common::settingsTable[OF_Const::customLEDcolor3] == App_Common::settingsTable_orig[OF_Const::customLEDcolor3]) {
+    if( App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcount]  == App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcount]  &&
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDstatic] == App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDstatic] &&
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor1] == App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor1] &&
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor2] == App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor2] &&
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor3] == App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor3]) {
         ui->pixelChangeNotice->setVisible(false);
     } else {
         ui->pixelChangeNotice->setVisible(true);
@@ -400,16 +403,18 @@ void guiWindow::on_confirmButton_clicked()
             statusBar()->showMessage("Sent settings successfully!", 5000);
 
             // sync settings
-            for(int i = 0; i < OF_Const::boolTypesCount; i++)
-                App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
+            memcpy(App_Common::boolSettings[App_Common::dataOrig],
+                   App_Common::boolSettings[App_Common::dataCurrent],
+                   sizeof(App_Common::boolSettings[App_Common::dataOrig]));
 
-            if(App_Common::boolSettings_orig[OF_Const::customPins])
+            if(App_Common::boolSettings[App_Common::dataOrig][OF_Const::customPins])
                 App_Common::inputsMap_orig = App_Common::inputsMap;
             else for(int i = 0; i < App_Common::inputsMap.size(); i++)
                     App_Common::inputsMap_orig[i] = -1;
 
-            for(int i = 0; i < OF_Const::settingsTypesCount; i++)
-                App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
+            memcpy(App_Common::settingsTable[App_Common::dataOrig],
+                   App_Common::settingsTable[App_Common::dataCurrent],
+                   sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
             App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
             App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
@@ -781,37 +786,37 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             }
 
             ui->tabWidget->setEnabled(true);
-            ui->customPinsEnabled->setChecked(App_Common::boolSettings[OF_Const::customPins]);
+            ui->customPinsEnabled->setChecked(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]);
 
-            ui->rumbleToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumble]);
-            ui->rumbleSettingsBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]);
-            ui->solenoidToggle->setChecked(App_Common::boolSettings_orig[OF_Const::solenoid]);
-            ui->solenoidSettingsBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]);
-            ui->autofireToggle->setChecked(App_Common::boolSettings_orig[OF_Const::autofire]);
-            ui->autofireToggle->setEnabled((App_Common::boolSettings_orig[OF_Const::solenoid] || App_Common::boolSettings_orig[OF_Const::rumbleFF]));
-            ui->simplePauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::simplePause]);
-            ui->holdToPauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::holdToPause]);
-            ui->commonAnodeToggle->setChecked(App_Common::boolSettings_orig[OF_Const::commonAnode]);
-            ui->lowButtonsToggle->setChecked(App_Common::boolSettings_orig[OF_Const::lowButtonsMode]);
-            ui->rumbleFFToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
-            ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs_orig[OF_Const::i2cOLED]);
-            ui->oledAltAddrsToggle->setChecked(App_Common::i2cOledPrefs[OF_Const::oledAltAddr]);
+            ui->rumbleToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::rumble]);
+            ui->rumbleSettingsBox->setEnabled(App_Common::boolSettings[App_Common::dataOrig][OF_Const::rumble]);
+            ui->solenoidToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::solenoid]);
+            ui->solenoidSettingsBox->setEnabled(App_Common::boolSettings[App_Common::dataOrig][OF_Const::solenoid]);
+            ui->autofireToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::autofire]);
+            ui->autofireToggle->setEnabled((App_Common::boolSettings[App_Common::dataOrig][OF_Const::solenoid] || App_Common::boolSettings[App_Common::dataOrig][OF_Const::rumbleFF]));
+            ui->simplePauseToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::simplePause]);
+            ui->holdToPauseToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::holdToPause]);
+            ui->commonAnodeToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::commonAnode]);
+            ui->lowButtonsToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::lowButtonsMode]);
+            ui->rumbleFFToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::rumbleFF]);
+            ui->rumbleIntensityBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings[App_Common::dataOrig][OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::autofireWaitFactor]);
+            ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs[App_Common::dataOrig][OF_Const::i2cOLED]);
+            ui->oledAltAddrsToggle->setChecked(App_Common::i2cOledPrefs[App_Common::dataOrig][OF_Const::oledAltAddr]);
             ui->oledGroup->setEnabled(App_Common::inputsMap_orig.value(OF_Const::periphSCL) > -1 && App_Common::inputsMap_orig.value(OF_Const::periphSDA) > -1);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-            ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDcount]);
-            ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDstatic]);
-            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
+            ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcount]);
+            ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDstatic]);
+            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
 
             switch(App_Common::tinyUSBtable.tinyUSBid) {
             case 1:
@@ -1091,7 +1096,7 @@ void guiWindow::colorBoxes_clicked()
 
 void guiWindow::on_customPinsEnabled_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::customPins] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins] = arg1;
     BoxesUpdate();
 
     if(arg1)
@@ -1143,7 +1148,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
 
 void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::rumble] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumble] = arg1;
 
     if(arg1) {
         ui->rumbleSettingsBox->setEnabled(true);
@@ -1154,7 +1159,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
         ui->rumbleTestBtn->setEnabled(false);
     }
 
-    if(!(arg1 && App_Common::boolSettings[OF_Const::rumbleFF]) && !App_Common::boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumbleFF]) && !App_Common::boolSettings[App_Common::dataCurrent][OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1167,7 +1172,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 
 void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::solenoid] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::solenoid] = arg1;
 
     if(arg1) {
         ui->rumbleFFToggle->setChecked(false);
@@ -1178,7 +1183,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
         ui->solenoidTestBtn->setEnabled(false);
     }
 
-    if(!arg1 && !(App_Common::boolSettings[OF_Const::rumble] && App_Common::boolSettings[OF_Const::rumbleFF])) {
+    if(!arg1 && !(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumble] && App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumbleFF])) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1191,7 +1196,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 
 void guiWindow::on_autofireToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::autofire] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::autofire] = arg1;
 
     if(arg1) ui->autofireWaitFactorBox->setEnabled(true);
     else     ui->autofireWaitFactorBox->setEnabled(false);
@@ -1202,14 +1207,14 @@ void guiWindow::on_autofireToggle_stateChanged(int arg1)
 
 void guiWindow::on_simplePauseToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::simplePause] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::simplePause] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::holdToPause] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::holdToPause] = arg1;
 
     if(arg1) ui->holdToPauseLengthBox->setEnabled(true);
     else     ui->holdToPauseLengthBox->setEnabled(false);
@@ -1220,24 +1225,24 @@ void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 
 void guiWindow::on_commonAnodeToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::commonAnode] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::commonAnode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_lowButtonsToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::lowButtonsMode] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::lowButtonsMode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 {
-    App_Common::boolSettings[OF_Const::rumbleFF] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumbleFF] = arg1;
     if(arg1) ui->solenoidToggle->setChecked(false);
 
-    if(!(arg1 && App_Common::boolSettings[OF_Const::rumble]) && !App_Common::boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Common::boolSettings[App_Common::dataCurrent][OF_Const::rumble]) && !App_Common::boolSettings[App_Common::dataCurrent][OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1250,49 +1255,49 @@ void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 
 void guiWindow::on_rumbleIntensityBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::rumbleStrength] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::rumbleStrength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleLengthBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::rumbleInterval] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::rumbleInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseLengthBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::holdToPauseLength] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::holdToPauseLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidNormalIntervalBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::solenoidNormalInterval] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::solenoidNormalInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidFastIntervalBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::solenoidFastInterval] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::solenoidFastInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidHoldLengthBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::solenoidHoldLength] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::solenoidHoldLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_autofireWaitFactorBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::autofireWaitFactor] = arg1;
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::autofireWaitFactor] = arg1;
     DiffUpdate();
 }
 
@@ -1432,8 +1437,8 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
 
 void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 {
-    App_Common::settingsTable[OF_Const::customLEDcount] = arg1;
-    if(arg1 < App_Common::settingsTable[OF_Const::customLEDstatic]) {
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcount] = arg1;
+    if(arg1 < App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDstatic]) {
         ui->customLEDstaticSpinbox->setValue(arg1);
     }
 
@@ -1446,10 +1451,10 @@ void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 {
-    if(arg1 > App_Common::settingsTable[OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable[OF_Const::customLEDcount]); }
-    else { App_Common::settingsTable[OF_Const::customLEDstatic] = arg1; }
+    if(arg1 > App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcount]); }
+    else { App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDstatic] = arg1; }
     if(OF_Const::customLEDstatic) {
-        switch(App_Common::settingsTable[OF_Const::customLEDstatic]) {
+        switch(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDstatic]) {
         case 1:
             ui->customLEDstaticBtn1->setEnabled(true);
             ui->customLEDstaticBtn2->setEnabled(false);
@@ -1482,7 +1487,7 @@ void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticBtn1_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor1]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor1]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1492,7 +1497,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Common::settingsTable[OF_Const::customLEDcolor1] = packedColor;
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor1] = packedColor;
         ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1505,7 +1510,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
 
 void guiWindow::on_customLEDstaticBtn2_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor2]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor2]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1515,7 +1520,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Common::settingsTable[OF_Const::customLEDcolor2] = packedColor;
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor2] = packedColor;
         ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1528,7 +1533,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
 
 void guiWindow::on_customLEDstaticBtn3_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor3]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor3]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1538,7 +1543,7 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Common::settingsTable[OF_Const::customLEDcolor3] = packedColor;
+        App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcolor3] = packedColor;
         ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1551,7 +1556,7 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
 
 void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 {
-    App_Common::i2cPeriphs[OF_Const::i2cOLED] = arg1;
+    App_Common::i2cPeriphs[App_Common::dataCurrent][OF_Const::i2cOLED] = arg1;
 
     DiffUpdate();
 }
@@ -1559,7 +1564,7 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 
 void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
 {
-    App_Common::i2cOledPrefs[OF_Const::oledAltAddr] = arg1;
+    App_Common::i2cOledPrefs[App_Common::dataCurrent][OF_Const::oledAltAddr] = arg1;
 
     DiffUpdate();
 }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -260,14 +260,14 @@ void guiWindow::DiffUpdate()
 {
     int settingsDiff = 0;
 
-    if(memcmp(App_Common::boolSettings[App_Common::dataCurrent], App_Common::boolSettings[App_Common::dataOrig], sizeof(App_Common::boolSettings)))
+    if(memcmp(App_Common::boolSettings[App_Common::dataCurrent], App_Common::boolSettings[App_Common::dataOrig], sizeof(App_Common::boolSettings[App_Common::dataCurrent])))
         settingsDiff++;
 
     if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins])
         if(App_Common::inputsMap_orig != App_Common::inputsMap)
             settingsDiff++;
 
-    if(memcmp(App_Common::settingsTable[App_Common::dataCurrent], App_Common::settingsTable[App_Common::dataOrig], sizeof(App_Common::settingsTable)))
+    if(memcmp(App_Common::settingsTable[App_Common::dataCurrent], App_Common::settingsTable[App_Common::dataOrig], sizeof(App_Common::settingsTable[App_Common::dataCurrent])))
         settingsDiff++;
 
     if(App_Common::tinyUSBtable_orig.tinyUSBid != App_Common::tinyUSBtable.tinyUSBid)
@@ -279,10 +279,10 @@ void guiWindow::DiffUpdate()
     if(App_Common::board.selectedProfile != App_Common::board.previousProfile)
         settingsDiff++;
 
-    if(memcmp(App_Common::i2cPeriphs[App_Common::dataCurrent], App_Common::i2cPeriphs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs)))
+    if(memcmp(App_Common::i2cPeriphs[App_Common::dataCurrent], App_Common::i2cPeriphs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent])))
         settingsDiff++;
 
-    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cOledPrefs)))
+    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent])))
         settingsDiff++;
 
     for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
@@ -867,6 +867,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
         // reset temp label stylesheet to neutral
         ui->tmp36Label->setStyleSheet("");
+        ui->confirmButton->setEnabled(false);
+        ui->confirmButton->setText("[Currently Not Connected]");
     }
     serialActive = false;
 }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1634,7 +1634,6 @@ void guiWindow::serialPort_readyRead()
                 caliWindow->showFullScreen();
 
                 testMode = true;
-                serialActive = true;
 
                 ui->buttonsTestArea->setEnabled(false);
                 ui->confirmButton->setEnabled(false);
@@ -1834,8 +1833,6 @@ void guiWindow::CaliWindowExiting(const int &mode,
             ui->profilesTab->setEnabled(true);
             ui->feedbackTestsBox->setEnabled(true);
             ui->dangerZoneBox->setEnabled(true);
-
-            serialActive = false;
         }
         break;
     case AppCaliWindow::modeAlignment:

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -34,6 +34,7 @@
 #include <QColorDialog>
 #include <QInputDialog>
 #include <QDesktopServices>
+#include <QFontDatabase>
 #include <QUrl>
 
 guiWindow::guiWindow(QWidget *parent)
@@ -520,10 +521,10 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                                               "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
                 connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
 
-                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(QString(App_Common::profilesTable.at(i).profName)));
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(QString(App_Common::profilesTable.at(i).profName.constData())));
                 if(i == App_Common::board.selectedProfile)
                     selectedProfile.at(i)->setChecked(true);
-                selectedProfile.at(i)->setFont(QFont("Monospace"));
+                selectedProfile.at(i)->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
                 selectedProfile.at(i)->setProperty("slot", i);
                 connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -226,7 +226,9 @@ void guiWindow::BoxesUpdate()
 
             // set pinboxes to copied values (pinbox index is off by 1)
             for(int i = 0; i < App_Common::inputsMap_orig.count(); i++)
-                if(App_Common::inputsMap_orig.value(i) > OF_Const::btnUnmapped && App_Common::inputsMap_orig.value(i) < pinBoxes.count())
+                if(App_Common::inputsMap_orig.value(i) > OF_Const::btnUnmapped &&
+                   App_Common::inputsMap_orig.value(i) < pinBoxes.count() &&
+                   i < OF_Const::boardInputsCount)
                     pinBoxes.at(App_Common::inputsMap_orig.value(i))->setCurrentIndex(i+1);
 
         // else, if the board *was using default maps* before switching to custom (no need to re-set pinboxes)
@@ -235,13 +237,10 @@ void guiWindow::BoxesUpdate()
             App_Common::inputsMap = App_Common::inputsMap_orig;
 
             // copy presets to inputs map
-            if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString())) {
-                for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i] > OF_Const::btnUnmapped) {
+            if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
+                for(int i = 0; i < pinBoxes.count(); i++)
+                    if(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i] > OF_Const::btnUnmapped)
                         App_Common::inputsMap[OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i]] = i;
-                    }
-                }
-            }
         }
 
         return;
@@ -249,17 +248,13 @@ void guiWindow::BoxesUpdate()
     // disabling custom pins, reset to presets
     } else {
         // reset inputs map, as it's not even referenced when custom pins are disabled
-        for(int i = 0; i < PINS_COUNT; i++)
+        for(int i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setEnabled(false), pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
-        // copy preset layout to pinboxes
+        // if available, copy preset layout to pinboxes
         if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
-            for(int i = 0; i < PINS_COUNT; i++)
+            for(int i = 0; i < pinBoxes.count(); i++)
                 pinBoxes.at(i)->setCurrentIndex(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i]+1);
-
-        // generics don't come with mappings
-        else for(int i = 0; i < PINS_COUNT; i++)
-            pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         return;
     }
@@ -714,7 +709,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
-                for(int i = 0; i < PINS_COUNT; i++) {
+                for(int i = 0; i < pinBoxes.count(); i++) {
                     if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
                                                 OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
@@ -743,7 +738,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
-                for(int i = 0; i < PINS_COUNT; i++) {
+                for(int i = 0; i < pinBoxes.count(); i++) {
                     if(OF_Const::boardsBoxPositions.value("generic").pin[i] & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
                                                 OF_Const::boardsBoxPositions.value("generic").pin[i] ^ OF_Const::posLeft,
@@ -1127,12 +1122,12 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
             ui->customPinsEnabled->setChecked(true);
 
         // clear pinBoxes to be safe
-        for(uint8_t i = 0; i < PINS_COUNT; i++)
+        for(uint8_t i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // set pinboxes to alt preset values (and let the index changed signal handle the rest)
         QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Common::board.boardType.toStdString());
-        for(int i = 0; i < PINS_COUNT; i++)
+        for(int i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setCurrentIndex(altPresets.at(index).pin[i]+1);
 
         DiffUpdate();
@@ -1958,14 +1953,17 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
             if(fileIn.readLine().trimmed() == App_Common::board.boardType) {
                 ui->customPinsEnabled->setChecked(true);
                 // clear current mapping
-                for(int i = 0; i < PINS_COUNT; i++)
+                for(int i = 0; i < pinBoxes.count(); i++)
                     pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
                 // import new maps
-                for(int i = 0; i < PINS_COUNT; i++)
-                    if(!fileIn.atEnd())
-                        pinBoxes.at(i)->setCurrentIndex(fileIn.read(1).toHex().toInt(nullptr, 16));
-                    else break;
+                for(int i = 0; i < pinBoxes.count(); i++) {
+                    if(!fileIn.atEnd()) {
+                        const int newIdx = fileIn.peek(1).toHex().toInt(nullptr, 16);
+                        if(newIdx <= OF_Const::boardInputsCount)
+                            pinBoxes.at(i)->setCurrentIndex(newIdx);
+                    } else break;
+                }
 
                 fileIn.close();
                 ui->statusBar->showMessage("Successfully imported custom layout!", 5000);
@@ -1989,7 +1987,7 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
         if(fileOut.open(QFile::WriteOnly)) {
             fileOut.write(QString("%1\n").arg(App_Common::board.boardType).toLocal8Bit());
 
-            for(int i = 0; i < PINS_COUNT; i++)
+            for(int i = 0; i < pinBoxes.count(); i++)
                 fileOut.putChar(pinBoxes.at(i)->currentIndex());
 
             fileOut.close();

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1,5 +1,7 @@
 /*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
-    Copyright (C) 2024  Team OpenFIRE
+    Main interface.
+
+    Copyright (C) 2025  Team OpenFIRE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,7 +19,7 @@
 
 #include "appmainwindow.h"
 #include "appabout.h"
-#include "constants.h"
+#include "appcommon.h"
 #include "ui_appmainwindow.h"
 
 #include <QGraphicsScene>
@@ -28,7 +30,6 @@
 #include <QProcess>
 //#include <QStorageInfo>
 #include <QtConcurrentRun>
-#include <QDebug>
 #include <QFileDialog>
 #include <QColorDialog>
 #include <QInputDialog>
@@ -173,7 +174,7 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
 {
     if(event->type() == QEvent::Enter) {
         switch(object->property("trackable").toInt()) {
-        case App_Const::trackPinbox:
+        case App_Common::trackPinbox:
         {
             // Copy and modify board pic array to change opacity of selected pin element, if existing.
             highlightBoardPic = origBoardPicFile;
@@ -184,19 +185,19 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
             boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
             break;
         }
-        case App_Const::trackSettingsItem:
+        case App_Common::trackSettingsItem:
             ui->settingsDescBox->setTitle(object->property("accessibleName").toString());
             ui->settingsDescText->setText(object->property("whatsThis").toString());
             break;
-        case App_Const::trackProfileItem:
+        case App_Common::trackProfileItem:
             ui->profilesDescBox->setTitle(object->property("accessibleName").toString());
             ui->profilesDescText->setText(object->property("whatsThis").toString());
             break;
-        case App_Const::trackTestItem:
+        case App_Common::trackTestItem:
             break;
         }
     } else if(event->type() == QEvent::Leave) {
-        if(object->property("trackable").toInt() == App_Const::trackPinbox) {
+        if(object->property("trackable").toInt() == App_Common::trackPinbox) {
             boardPic.load(origBoardPicFile);
             boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
         }
@@ -212,32 +213,32 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
 void guiWindow::BoxesUpdate()
 {
     // enabling custom pins
-    if(App_Const::boolSettings[OF_Const::customPins]) {
+    if(App_Common::boolSettings[OF_Const::customPins]) {
         // enable pinboxes
         for(int i = 0; i < pinBoxes.count(); i++)
             pinBoxes.at(i)->setEnabled(true);
 
         // if the custom pins setting *grabbed from the gun* has been set
-        if(App_Const::boolSettings_orig[OF_Const::customPins]) {
+        if(App_Common::boolSettings_orig[OF_Const::customPins]) {
             // reset pinboxes
             for(int i = 0; i < pinBoxes.count(); i++)
                 pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
             // set pinboxes to copied values (pinbox index is off by 1)
-            for(int i = 0; i < App_Const::inputsMap_orig.count(); i++)
-                if(App_Const::inputsMap_orig.value(i) > OF_Const::btnUnmapped && App_Const::inputsMap_orig.value(i) < pinBoxes.count())
-                    pinBoxes.at(App_Const::inputsMap_orig.value(i))->setCurrentIndex(i+1);
+            for(int i = 0; i < App_Common::inputsMap_orig.count(); i++)
+                if(App_Common::inputsMap_orig.value(i) > OF_Const::btnUnmapped && App_Common::inputsMap_orig.value(i) < pinBoxes.count())
+                    pinBoxes.at(App_Common::inputsMap_orig.value(i))->setCurrentIndex(i+1);
 
         // else, if the board *was using default maps* before switching to custom (no need to re-set pinboxes)
         } else {
             // copy original map, which clears this map (as boards using defaults comes with no actual map instated)
-            App_Const::inputsMap = App_Const::inputsMap_orig;
+            App_Common::inputsMap = App_Common::inputsMap_orig;
 
             // copy presets to inputs map
-            if(OF_Const::boardsPresetsMap.count(App_Const::board.boardType.toStdString())) {
+            if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString())) {
                 for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsPresetsMap.at(App_Const::board.boardType.toStdString()).pin[i] > OF_Const::btnUnmapped) {
-                        App_Const::inputsMap[OF_Const::boardsPresetsMap.at(App_Const::board.boardType.toStdString()).pin[i]] = i;
+                    if(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i] > OF_Const::btnUnmapped) {
+                        App_Common::inputsMap[OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i]] = i;
                     }
                 }
             }
@@ -252,9 +253,9 @@ void guiWindow::BoxesUpdate()
             pinBoxes.at(i)->setEnabled(false), pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // copy preset layout to pinboxes
-        if(OF_Const::boardsPresetsMap.count(App_Const::board.boardType.toStdString()))
+        if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
             for(int i = 0; i < PINS_COUNT; i++)
-                pinBoxes.at(i)->setCurrentIndex(OF_Const::boardsPresetsMap.at(App_Const::board.boardType.toStdString()).pin[i]+1);
+                pinBoxes.at(i)->setCurrentIndex(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).pin[i]+1);
 
         // generics don't come with mappings
         else for(int i = 0; i < PINS_COUNT; i++)
@@ -269,62 +270,62 @@ void guiWindow::DiffUpdate()
 {
     int settingsDiff = 0;
 
-    if(App_Const::boolSettings_orig[OF_Const::customPins] != App_Const::boolSettings[OF_Const::customPins])
+    if(App_Common::boolSettings_orig[OF_Const::customPins] != App_Common::boolSettings[OF_Const::customPins])
         settingsDiff++;
 
-    if(App_Const::boolSettings[OF_Const::customPins])
-        if(App_Const::inputsMap_orig != App_Const::inputsMap)
+    if(App_Common::boolSettings[OF_Const::customPins])
+        if(App_Common::inputsMap_orig != App_Common::inputsMap)
             settingsDiff++;
 
     for(uint8_t i = 1; i < OF_Const::boolTypesCount; i++)
-        if(App_Const::boolSettings_orig[i] != App_Const::boolSettings[i])
+        if(App_Common::boolSettings_orig[i] != App_Common::boolSettings[i])
             settingsDiff++;
 
     for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-        if(App_Const::settingsTable_orig[i] != App_Const::settingsTable[i])
+        if(App_Common::settingsTable_orig[i] != App_Common::settingsTable[i])
             settingsDiff++;
 
-    if(App_Const::tinyUSBtable_orig.tinyUSBid != App_Const::tinyUSBtable.tinyUSBid)
+    if(App_Common::tinyUSBtable_orig.tinyUSBid != App_Common::tinyUSBtable.tinyUSBid)
         settingsDiff++;
 
-    if(App_Const::tinyUSBtable_orig.tinyUSBname != App_Const::tinyUSBtable.tinyUSBname)
+    if(App_Common::tinyUSBtable_orig.tinyUSBname != App_Common::tinyUSBtable.tinyUSBname)
         settingsDiff++;
 
-    if(App_Const::board.selectedProfile != App_Const::board.previousProfile)
+    if(App_Common::board.selectedProfile != App_Common::board.previousProfile)
         settingsDiff++;
 
-    for(uint8_t i = 0; i < App_Const::profilesTable.count(); i++) {
-        if(App_Const::profilesTable_orig[i].profName != App_Const::profilesTable[i].profName)
+    for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
+        if(App_Common::profilesTable_orig[i].profName != App_Common::profilesTable[i].profName)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].topOffset != App_Const::profilesTable[i].topOffset)
+        if(App_Common::profilesTable_orig[i].topOffset != App_Common::profilesTable[i].topOffset)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].bottomOffset != App_Const::profilesTable[i].bottomOffset)
+        if(App_Common::profilesTable_orig[i].bottomOffset != App_Common::profilesTable[i].bottomOffset)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].leftOffset != App_Const::profilesTable[i].leftOffset)
+        if(App_Common::profilesTable_orig[i].leftOffset != App_Common::profilesTable[i].leftOffset)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].rightOffset != App_Const::profilesTable[i].rightOffset)
+        if(App_Common::profilesTable_orig[i].rightOffset != App_Common::profilesTable[i].rightOffset)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].TLled != App_Const::profilesTable[i].TLled)
+        if(App_Common::profilesTable_orig[i].TLled != App_Common::profilesTable[i].TLled)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].TRled != App_Const::profilesTable[i].TRled)
+        if(App_Common::profilesTable_orig[i].TRled != App_Common::profilesTable[i].TRled)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].irSensitivity != App_Const::profilesTable[i].irSensitivity)
+        if(App_Common::profilesTable_orig[i].irSensitivity != App_Common::profilesTable[i].irSensitivity)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].runMode != App_Const::profilesTable[i].runMode)
+        if(App_Common::profilesTable_orig[i].runMode != App_Common::profilesTable[i].runMode)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].layoutType != App_Const::profilesTable[i].layoutType)
+        if(App_Common::profilesTable_orig[i].layoutType != App_Common::profilesTable[i].layoutType)
             settingsDiff++;
 
-        if(App_Const::profilesTable_orig[i].color != App_Const::profilesTable[i].color)
+        if(App_Common::profilesTable_orig[i].color != App_Common::profilesTable[i].color)
             settingsDiff++;
     }
 
@@ -344,19 +345,19 @@ QString guiWindow::PrettifyName(QString name)
         name = "Unnamed Device";
 
     // append name of board to gun name string.
-    if(OF_Const::boardNames.contains(App_Const::board.boardType.toStdString()))
-         return name + " | " + OF_Const::boardNames[App_Const::board.boardType.toStdString()];
+    if(OF_Const::boardNames.contains(App_Common::board.boardType.toStdString()))
+         return name + " | " + OF_Const::boardNames[App_Common::board.boardType.toStdString()];
     else return name + " | " + OF_Const::boardNames["generic"];
 }
 
 
 void guiWindow::PixelsDiff()
 {
-    if( App_Const::settingsTable[OF_Const::customLEDcount]  == App_Const::settingsTable_orig[OF_Const::customLEDcount]  &&
-        App_Const::settingsTable[OF_Const::customLEDstatic] == App_Const::settingsTable_orig[OF_Const::customLEDstatic] &&
-        App_Const::settingsTable[OF_Const::customLEDcolor1] == App_Const::settingsTable_orig[OF_Const::customLEDcolor1] &&
-        App_Const::settingsTable[OF_Const::customLEDcolor2] == App_Const::settingsTable_orig[OF_Const::customLEDcolor2] &&
-        App_Const::settingsTable[OF_Const::customLEDcolor3] == App_Const::settingsTable_orig[OF_Const::customLEDcolor3]) {
+    if( App_Common::settingsTable[OF_Const::customLEDcount]  == App_Common::settingsTable_orig[OF_Const::customLEDcount]  &&
+        App_Common::settingsTable[OF_Const::customLEDstatic] == App_Common::settingsTable_orig[OF_Const::customLEDstatic] &&
+        App_Common::settingsTable[OF_Const::customLEDcolor1] == App_Common::settingsTable_orig[OF_Const::customLEDcolor1] &&
+        App_Common::settingsTable[OF_Const::customLEDcolor2] == App_Common::settingsTable_orig[OF_Const::customLEDcolor2] &&
+        App_Common::settingsTable[OF_Const::customLEDcolor3] == App_Common::settingsTable_orig[OF_Const::customLEDcolor3]) {
         ui->pixelChangeNotice->setVisible(false);
     } else {
         ui->pixelChangeNotice->setVisible(true);
@@ -412,26 +413,26 @@ void guiWindow::on_confirmButton_clicked()
 
             // sync settings
             for(int i = 0; i < OF_Const::boolTypesCount; i++)
-                App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
+                App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
 
-            if(App_Const::boolSettings_orig[OF_Const::customPins])
-                App_Const::inputsMap_orig = App_Const::inputsMap;
-            else for(int i = 0; i < App_Const::inputsMap.size(); i++)
-                    App_Const::inputsMap_orig[i] = -1;
+            if(App_Common::boolSettings_orig[OF_Const::customPins])
+                App_Common::inputsMap_orig = App_Common::inputsMap;
+            else for(int i = 0; i < App_Common::inputsMap.size(); i++)
+                    App_Common::inputsMap_orig[i] = -1;
 
             for(int i = 0; i < OF_Const::settingsTypesCount; i++)
-                App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
+                App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
 
-            App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
-            App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
-            App_Const::board.previousProfile = App_Const::board.selectedProfile;
+            App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
+            App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
+            App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
-            for(uint8_t i = 0; i < App_Const::profilesTable.count(); i++) {
-                App_Const::profilesTable_orig[i].irSensitivity = App_Const::profilesTable[i].irSensitivity;
-                App_Const::profilesTable_orig[i].runMode = App_Const::profilesTable[i].runMode;
-                App_Const::profilesTable_orig[i].layoutType = App_Const::profilesTable[i].layoutType;
-                App_Const::profilesTable_orig[i].color = App_Const::profilesTable[i].color;
-                App_Const::profilesTable_orig[i].profName = App_Const::profilesTable[i].profName;
+            for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
+                App_Common::profilesTable_orig[i].irSensitivity = App_Common::profilesTable[i].irSensitivity;
+                App_Common::profilesTable_orig[i].runMode = App_Common::profilesTable[i].runMode;
+                App_Common::profilesTable_orig[i].layoutType = App_Common::profilesTable[i].layoutType;
+                App_Common::profilesTable_orig[i].color = App_Common::profilesTable[i].color;
+                App_Common::profilesTable_orig[i].profName = App_Common::profilesTable[i].profName;
             }
 
             // Reflect new names in UI
@@ -507,7 +508,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             caliBtn.clear();
 
             int caliBtnRow;
-            for(uint8_t i = 0; i < App_Const::profilesTable.size(); i++) {
+            for(uint8_t i = 0; i < App_Common::profilesTable.size(); i++) {
                 caliBtnRow = i/4;
 
                 // create new assets for this profile
@@ -517,34 +518,34 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 renameBtn.at(i)->setIcon(QIcon(":/icon/edit.png"));
                 renameBtn.at(i)->installEventFilter(this);
                 renameBtn.at(i)->setProperty("slot", i);
-                renameBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                renameBtn.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
                 renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
                                               "<p>Aside from differentiating between different profiles for different displays, "
                                               "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
                 connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
 
-                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Const::profilesTable.at(i).profName));
-                if(i == App_Const::board.selectedProfile)
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Common::profilesTable.at(i).profName));
+                if(i == App_Common::board.selectedProfile)
                     selectedProfile.at(i)->setChecked(true);
                 selectedProfile.at(i)->setFont(QFont("Monospace"));
                 selectedProfile.at(i)->setProperty("slot", i);
                 connect(selectedProfile.at(i), &QRadioButton::toggled, this, &guiWindow::selectedProfile_isChecked);
 
-                topOffset       << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).topOffset      ));
-                bottomOffset    << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).bottomOffset   ));
-                leftOffset      << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).leftOffset     ));
-                rightOffset     << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).rightOffset    ));
-                TLled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TLled          ));
-                TRled           << new QLabel(QString("%1").arg(App_Const::profilesTable.at(i).TRled          ));
+                topOffset       << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).topOffset      ));
+                bottomOffset    << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).bottomOffset   ));
+                leftOffset      << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).leftOffset     ));
+                rightOffset     << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).rightOffset    ));
+                TLled           << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).TLled          ));
+                TRled           << new QLabel(QString("%1").arg(App_Common::profilesTable.at(i).TRled          ));
 
                 irSens << new QComboBox();
                 irSens.at(i)->addItems({"Default", "Higher", "Highest"});
-                irSens.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).irSensitivity);
+                irSens.at(i)->setCurrentIndex(App_Common::profilesTable.at(i).irSensitivity);
                 irSens.at(i)->installEventFilter(this);
                 irSens.at(i)->setProperty("slot", i);
-                irSens.at(i)->setProperty("type", App_Const::pBoxIRsens);
-                irSens.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                irSens.at(i)->setProperty("type", App_Common::pBoxIRsens);
+                irSens.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
                 irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
                                            "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
@@ -556,11 +557,11 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
                 runMode << new QComboBox();
                 runMode.at(i)->addItems({"Normal", "1-Frame Avg", "2-Frame Avg"});
-                runMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).runMode);
+                runMode.at(i)->setCurrentIndex(App_Common::profilesTable.at(i).runMode);
                 runMode.at(i)->installEventFilter(this);
                 runMode.at(i)->setProperty("slot", i);
-                runMode.at(i)->setProperty("type", App_Const::pBoxRunMode);
-                runMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                runMode.at(i)->setProperty("type", App_Common::pBoxRunMode);
+                runMode.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
                 runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
                                             "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
@@ -571,11 +572,11 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
                 layoutMode << new QComboBox();
                 layoutMode.at(i)->addItems({"Square", "Diamond"});
-                layoutMode.at(i)->setCurrentIndex(App_Const::profilesTable.at(i).layoutType);
+                layoutMode.at(i)->setCurrentIndex(App_Common::profilesTable.at(i).layoutType);
                 layoutMode.at(i)->installEventFilter(this);
                 layoutMode.at(i)->setProperty("slot", i);
-                layoutMode.at(i)->setProperty("type", App_Const::pBoxLayout);
-                layoutMode.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                layoutMode.at(i)->setProperty("type", App_Common::pBoxLayout);
+                layoutMode.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
                 layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
                                                "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
@@ -591,10 +592,10 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
                 color << new QPushButton();
                 color.at(i)->setFixedWidth(32);
-                color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Const::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
+                color.at(i)->setStyleSheet(QString("background-color: #%1").arg(App_Common::profilesTable.at(i).color, 6, 16, QLatin1Char('0')));
                 color.at(i)->installEventFilter(this);
                 color.at(i)->setProperty("slot", i);
-                color.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                color.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
                 color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
                                           "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
@@ -604,7 +605,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
                 caliBtn.at(i)->installEventFilter(this);
                 caliBtn.at(i)->setProperty("slot", i);
-                caliBtn.at(i)->setProperty("trackable", App_Const::trackProfileItem);
+                caliBtn.at(i)->setProperty("trackable", App_Common::trackProfileItem);
                 caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
                 caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
                 connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
@@ -651,7 +652,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinBoxes.at(i)->setProperty("slot", i);
                 pinBoxes.at(i)->setProperty("prevMapping", OF_Const::btnUnmapped+1);
-                pinBoxes.at(i)->setProperty("trackable", App_Const::trackPinbox);
+                pinBoxes.at(i)->setProperty("trackable", App_Common::trackPinbox);
                 pinBoxes.at(i)->installEventFilter(this);
                 // install items
                 pinBoxes.at(i)->addItems(OF_Const::valuesNameList);
@@ -685,16 +686,16 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
             }
 
-            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Const::board.versionNumber, App_Const::board.versionCodename));
+            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Common::board.versionNumber, App_Common::board.versionCodename));
 
             // update presets box if this board has any
             ui->presetsBox->clear();
 
-            if(OF_Const::boardsAltPresets.count(App_Const::board.boardType.toStdString())) {
+            if(OF_Const::boardsAltPresets.count(App_Common::board.boardType.toStdString())) {
                 ui->presetsBox->setHidden(false);
                 ui->presetsBox->setEnabled(true);
 
-                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
+                QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Common::board.boardType.toStdString());
                 for(auto &entry : altPresets)
                     ui->presetsBox->addItem(entry.name);
             } else {
@@ -708,33 +709,33 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             LabelsUpdate();
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(OF_Const::boardsBoxPositions.contains(App_Const::board.boardType.toStdString())) {
-                QFile resource(":/boardPics/" + App_Const::board.boardType);
+            if(OF_Const::boardsBoxPositions.contains(App_Common::board.boardType.toStdString())) {
+                QFile resource(":/boardPics/" + App_Common::board.boardType);
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < PINS_COUNT; i++) {
-                    if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
+                    if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
+                                                OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posLeft,
                                                 1);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
+                    } else if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
+                                                 OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posRight,
                                                  0);
-                    } else if(OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
+                    } else if(OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     OF_Const::boardsBoxPositions.value(App_Const::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
+                                                     OF_Const::boardsBoxPositions.value(App_Common::board.boardType.toStdString()).pin[i] ^ OF_Const::posMiddle);
                     }
                 }
             } else {
@@ -788,33 +789,33 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             }
 
             ui->tabWidget->setEnabled(true);
-            ui->customPinsEnabled->setChecked(App_Const::boolSettings[OF_Const::customPins]);
+            ui->customPinsEnabled->setChecked(App_Common::boolSettings[OF_Const::customPins]);
 
-            ui->rumbleToggle->setChecked(App_Const::boolSettings_orig[OF_Const::rumble]);
-            ui->solenoidToggle->setChecked(App_Const::boolSettings_orig[OF_Const::solenoid]);
-            ui->autofireToggle->setChecked(App_Const::boolSettings_orig[OF_Const::autofire]);
-            ui->simplePauseToggle->setChecked(App_Const::boolSettings_orig[OF_Const::simplePause]);
-            ui->holdToPauseToggle->setChecked(App_Const::boolSettings_orig[OF_Const::holdToPause]);
-            ui->commonAnodeToggle->setChecked(App_Const::boolSettings_orig[OF_Const::commonAnode]);
-            ui->lowButtonsToggle->setChecked(App_Const::boolSettings_orig[OF_Const::lowButtonsMode]);
-            ui->rumbleFFToggle->setChecked(App_Const::boolSettings_orig[OF_Const::rumbleFF]);
-            ui->rumbleIntensityBox->setEnabled(App_Const::boolSettings_orig[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Const::settingsTable_orig[OF_Const::rumbleStrength]);
-            ui->rumbleLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::rumbleInterval]);
-            ui->holdToPauseLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::holdToPauseLength]);
-            ui->solenoidNormalIntervalBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidNormalInterval]);
-            ui->solenoidFastIntervalBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidFastInterval]);
-            ui->solenoidHoldLengthBox->setEnabled(App_Const::boolSettings_orig[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::solenoidHoldLength]);
-            ui->autofireWaitFactorBox->setEnabled(App_Const::boolSettings_orig[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Const::settingsTable_orig[OF_Const::autofireWaitFactor]);
+            ui->rumbleToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumble]);
+            ui->solenoidToggle->setChecked(App_Common::boolSettings_orig[OF_Const::solenoid]);
+            ui->autofireToggle->setChecked(App_Common::boolSettings_orig[OF_Const::autofire]);
+            ui->simplePauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::simplePause]);
+            ui->holdToPauseToggle->setChecked(App_Common::boolSettings_orig[OF_Const::holdToPause]);
+            ui->commonAnodeToggle->setChecked(App_Common::boolSettings_orig[OF_Const::commonAnode]);
+            ui->lowButtonsToggle->setChecked(App_Common::boolSettings_orig[OF_Const::lowButtonsMode]);
+            ui->rumbleFFToggle->setChecked(App_Common::boolSettings_orig[OF_Const::rumbleFF]);
+            ui->rumbleIntensityBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]),          ui->rumbleIntensityBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleStrength]);
+            ui->rumbleLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::rumble]),             ui->rumbleLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::rumbleInterval]);
+            ui->holdToPauseLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::holdToPause]),   ui->holdToPauseLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::holdToPauseLength]);
+            ui->solenoidNormalIntervalBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]), ui->solenoidNormalIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidNormalInterval]);
+            ui->solenoidFastIntervalBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]),   ui->solenoidFastIntervalBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidFastInterval]);
+            ui->solenoidHoldLengthBox->setEnabled(App_Common::boolSettings_orig[OF_Const::solenoid]),     ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::solenoidHoldLength]);
+            ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings_orig[OF_Const::autofire]),     ui->autofireWaitFactorBox->setValue(App_Common::settingsTable_orig[OF_Const::autofireWaitFactor]);
 
-            ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-            ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
-            ui->neopixelStrandLengthBox->setValue(App_Const::settingsTable_orig[OF_Const::customLEDcount]);
-            ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable_orig[OF_Const::customLEDstatic]);
-            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
-            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Const::settingsTable_orig[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
+            ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+            ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+            ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDcount]);
+            ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable_orig[OF_Const::customLEDstatic]);
+            ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor2], 6, 16, QLatin1Char('0')));
+            ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable_orig[OF_Const::customLEDcolor3], 6, 16, QLatin1Char('0')));
 
-            switch(App_Const::tinyUSBtable.tinyUSBid.toInt()) {
+            switch(App_Common::tinyUSBtable.tinyUSBid.toInt()) {
             case 1:
                 ui->tUSB_p1->setChecked(true);
                 ui->tUSBLayoutAdvanced->setVisible(false);
@@ -872,18 +873,18 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 // Only runs either on initial load or save
 void guiWindow::LabelsUpdate()
 {
-    // because App_Const::inputsMap uses pin no. starting from 0
+    // because App_Common::inputsMap uses pin no. starting from 0
     for(uint8_t i = 0; i < 16; i++) {
         if(i < 14) {
-            if(App_Const::inputsMap.value(i) >= 0) {
-                testLabel[i]->setText(App_Const::testLabelNames.at(i));
+            if(App_Common::inputsMap.value(i) >= 0) {
+                testLabel[i]->setText(App_Common::testLabelNames.at(i));
                 testLabel[i]->setEnabled(true);
             } else {
-                testLabel[i]->setText(App_Const::testLabelNames.at(i) + " (N/C)");
+                testLabel[i]->setText(App_Common::testLabelNames.at(i) + " (N/C)");
                 testLabel[i]->setEnabled(false);
             }
         } else if(i == 14) {
-            if(App_Const::inputsMap.value(OF_Const::tempPin) >= 0) {
+            if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
                 testLabel[i]->setText("Temp Read...");
                 testLabel[i]->setEnabled(true);
             } else {
@@ -892,7 +893,7 @@ void guiWindow::LabelsUpdate()
             }
             testLabel[i]->setStyleSheet("");
         } else if(i == 15) {
-            if(App_Const::inputsMap.value(OF_Const::analogX) >=0 && App_Const::inputsMap.value(OF_Const::analogY) >= 0) {
+            if(App_Common::inputsMap.value(OF_Const::analogX) >=0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0) {
                 testLabel[i]->setText("Analog");
                 testLabel[i]->setEnabled(true);
             } else {
@@ -902,11 +903,11 @@ void guiWindow::LabelsUpdate()
             testLabel[i]->setStyleSheet("");
         }
     }
-    if(App_Const::inputsMap.value(OF_Const::ledR) >= 0) ui->redLedTestBtn->setEnabled(true);   else ui->redLedTestBtn->setEnabled(false);
-    if(App_Const::inputsMap.value(OF_Const::ledG) >= 0) ui->greenLedTestBtn->setEnabled(true); else ui->greenLedTestBtn->setEnabled(false);
-    if(App_Const::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::ledR) >= 0) ui->redLedTestBtn->setEnabled(true);   else ui->redLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::ledG) >= 0) ui->greenLedTestBtn->setEnabled(true); else ui->greenLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
 
-    ui->boardLabel->setText(PrettifyName(App_Const::tinyUSBtable.tinyUSBname));
+    ui->boardLabel->setText(PrettifyName(App_Common::tinyUSBtable.tinyUSBname));
 }
 
 void guiWindow::pinBoxes_currentIndexChanged(int index)
@@ -916,7 +917,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
     // always remember to sync the change to "prevMapping" property at the end of its logic path!
 
     /*
-    if(index >= 0 && index <= App_Const::inputsMap.size()) {
+    if(index >= 0 && index <= App_Common::inputsMap.size()) {
         //printf("Requesting pinbox %d to set to %s\n", sender()->property("slot").toInt(), OF_Const::valuesNameList.at(index).toLocal8Bit().constData());
     } else printf("Oops! Seems like pinbox %d is trying to set itself to index %d, which is out of range!\n", sender()->property("slot").toInt(), index);
     //*/
@@ -928,7 +929,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
     // if it's being set to 0 (unmapped), unmap this pin without question.
     if(index <= 0) {
         if(sender()->property("prevMapping").toInt() > OF_Const::btnUnmapped+1) {
-            App_Const::inputsMap[sender()->property("prevMapping").toInt()-1] = OF_Const::btnUnmapped;
+            App_Common::inputsMap[sender()->property("prevMapping").toInt()-1] = OF_Const::btnUnmapped;
             sender()->setProperty("prevMapping", OF_Const::btnUnmapped+1);
         }
 
@@ -938,95 +939,95 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
 
         // unmap pinbox's previous function, if mapped to any
         if(sender()->property("prevMapping").toInt() > OF_Const::btnUnmapped+1)
-            App_Const::inputsMap[sender()->property("prevMapping").toInt()-1] = OF_Const::btnUnmapped;
+            App_Common::inputsMap[sender()->property("prevMapping").toInt()-1] = OF_Const::btnUnmapped;
 
         // Remove whatever pin mapping that this function belonged to, if it was mapped
         // (making sure we don't disable the pin trying to be set)
-        if(App_Const::inputsMap.value(btnRequest)  > OF_Const::btnUnmapped &&
-           App_Const::inputsMap.value(btnRequest) != sender()->property("slot").toInt())
-            pinBoxes.at(App_Const::inputsMap.value(btnRequest))->setCurrentIndex(OF_Const::btnUnmapped+1);
+        if(App_Common::inputsMap.value(btnRequest)  > OF_Const::btnUnmapped &&
+           App_Common::inputsMap.value(btnRequest) != sender()->property("slot").toInt())
+            pinBoxes.at(App_Common::inputsMap.value(btnRequest))->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if function is I2C, check for other things
         if(btnRequest == OF_Const::camSDA) {
             // if it's mapped, check that cam clock pin isn't mapped to the opposite I2C channel
-            if(App_Const::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Const::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
+            if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
+               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pin mappings.", 10000);
             // check that peripheral data isn't mapped to this I2C channel
-            } else if(App_Const::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Const::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
+            } else if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
+                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
                 // channels matched, unmap peripheral data
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral Data.", 10000);
             }
         } else if(btnRequest == OF_Const::camSCL) {
             // if it's mapped, check that cam clock pin isn't mapped to the opposite I2C channel
-            if(App_Const::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Const::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
+            if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
+               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pin mappings.", 10000);
             // check that peripheral clock isn't mapped to this I2C channel
-            } else if(App_Const::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Const::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
+            } else if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
+                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
                 // channels matched, unmap peripheral clock
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera and Peripheral Clock pins clashed! Please remap Peripheral Clock.", 10000);
             }
         } else if(btnRequest == OF_Const::periphSDA) {
             // if it's mapped, check that current peripheral clock pin isn't mapped to the opposite I2C channel
-            if(App_Const::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Const::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
+            if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
+               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pin mappings.", 10000);
             // check that cam data isn't mapped to this I2C channel
-            } else if(App_Const::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Const::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
+            } else if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
+                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
                 // channels matched, unmap cam data
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera Data.", 10000);
             }
         } else if(btnRequest == OF_Const::periphSCL) {
             // if it's mapped, check that current peripheral data pin isn't mapped to the opposite I2C channel
-            if(App_Const::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Const::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
+            if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
+               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pin mappings.", 10000);
             // check that cam clock isn't mapped to this I2C channel
-            } else if(App_Const::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Const::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
+            } else if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
+                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
                 // channels matched, unmap cam clock
-                pinBoxes.at(App_Const::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
                 ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera Clock.", 10000);
             }
         }
 
         // Then map the thing, and sync this change to the property value
-        App_Const::inputsMap[btnRequest] = sender()->property("slot").toInt();
+        App_Common::inputsMap[btnRequest] = sender()->property("slot").toInt();
         sender()->setProperty("prevMapping", index);
     }
 
     // update settings panel to reflect pins map changes and prevent illegal values/combinations
-    if(App_Const::inputsMap.value(OF_Const::rumblePin) >= 0)
+    if(App_Common::inputsMap.value(OF_Const::rumblePin) >= 0)
         ui->rumbleToggle->setEnabled(true), ui->rumbleFFToggle->setEnabled(true);
     else {
         ui->rumbleToggle->setChecked(false),   ui->rumbleToggle->setEnabled(false),
         ui->rumbleFFToggle->setChecked(false), ui->rumbleFFToggle->setEnabled(false);
     }
 
-    if(App_Const::inputsMap.value(OF_Const::solenoidPin) >= 0)
+    if(App_Common::inputsMap.value(OF_Const::solenoidPin) >= 0)
         ui->solenoidToggle->setEnabled(true);
     else ui->solenoidToggle->setChecked(false), ui->solenoidToggle->setEnabled(false);
 
-    if(App_Const::inputsMap.value(OF_Const::neoPixel) >= 0)
+    if(App_Common::inputsMap.value(OF_Const::neoPixel) >= 0)
         ui->neopixelGroupBox->setEnabled(true);
     else ui->neopixelGroupBox->setEnabled(false);
 
-    if(App_Const::inputsMap.value(OF_Const::ledR) >= 0 && App_Const::inputsMap.value(OF_Const::ledG) >= 0 && App_Const::inputsMap.value(OF_Const::ledB) >= 0)
+    if(App_Common::inputsMap.value(OF_Const::ledR) >= 0 && App_Common::inputsMap.value(OF_Const::ledG) >= 0 && App_Common::inputsMap.value(OF_Const::ledB) >= 0)
         ui->commonAnodeToggle->setEnabled(true);
     else ui->commonAnodeToggle->setEnabled(false);
 
@@ -1036,14 +1037,14 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
 void guiWindow::profileBoxes_activated(int index)
 {
     switch(sender()->property("type").toInt()) {
-    case App_Const::pBoxIRsens:
-        App_Const::profilesTable[sender()->property("slot").toInt()].irSensitivity = index;
+    case App_Common::pBoxIRsens:
+        App_Common::profilesTable[sender()->property("slot").toInt()].irSensitivity = index;
         break;
-    case App_Const::pBoxRunMode:
-        App_Const::profilesTable[sender()->property("slot").toInt()].runMode = index;
+    case App_Common::pBoxRunMode:
+        App_Common::profilesTable[sender()->property("slot").toInt()].runMode = index;
         break;
-    case App_Const::pBoxLayout:
-        App_Const::profilesTable[sender()->property("slot").toInt()].layoutType = index;
+    case App_Common::pBoxLayout:
+        App_Common::profilesTable[sender()->property("slot").toInt()].layoutType = index;
         break;
     default:
         break;
@@ -1062,7 +1063,7 @@ void guiWindow::renameBoxes_clicked()
 
     if(!newLabel.isEmpty()) {
         selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()).arg(newLabel.left(15)));
-        App_Const::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15);
+        App_Common::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15);
     }
 
     DiffUpdate();
@@ -1071,7 +1072,7 @@ void guiWindow::renameBoxes_clicked()
 
 void guiWindow::colorBoxes_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Const::profilesTable[sender()->property("slot").toInt()].color);
+    QColor colorPick = QColorDialog::getColor(App_Common::profilesTable[sender()->property("slot").toInt()].color);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1081,7 +1082,7 @@ void guiWindow::colorBoxes_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Const::profilesTable[sender()->property("slot").toInt()].color = packedColor;
+        App_Common::profilesTable[sender()->property("slot").toInt()].color = packedColor;
         color[sender()->property("slot").toInt()]->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
         DiffUpdate();
     }
@@ -1090,21 +1091,21 @@ void guiWindow::colorBoxes_clicked()
 
 void guiWindow::on_customPinsEnabled_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::customPins] = arg1;
+    App_Common::boolSettings[OF_Const::customPins] = arg1;
     BoxesUpdate();
 
     if(arg1)
         ui->customLayoutToolBtn->setEnabled(true);
     else ui->customLayoutToolBtn->setEnabled(false);
 
-    if(App_Const::inputsMap.value(OF_Const::solenoidPin) > OF_Const::btnUnmapped) {
+    if(App_Common::inputsMap.value(OF_Const::solenoidPin) > OF_Const::btnUnmapped) {
         ui->solenoidToggle->setEnabled(true);
     } else {
         ui->solenoidToggle->setEnabled(false);
         ui->solenoidToggle->setChecked(false);
     }
 
-    if(App_Const::inputsMap.value(OF_Const::rumblePin) > OF_Const::btnUnmapped) {
+    if(App_Common::inputsMap.value(OF_Const::rumblePin) > OF_Const::btnUnmapped) {
         ui->rumbleToggle->setEnabled(true);
         ui->rumbleFFToggle->setEnabled(true);
     } else {
@@ -1130,7 +1131,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
             pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // set pinboxes to alt preset values (and let the index changed signal handle the rest)
-        QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Const::board.boardType.toStdString());
+        QList<OF_Const::boardAltPresetsMap_t> altPresets = OF_Const::boardsAltPresets.values(App_Common::board.boardType.toStdString());
         for(int i = 0; i < PINS_COUNT; i++)
             pinBoxes.at(i)->setCurrentIndex(altPresets.at(index).pin[i]+1);
 
@@ -1141,7 +1142,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
 
 void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::rumble] = arg1;
+    App_Common::boolSettings[OF_Const::rumble] = arg1;
     if(!arg1) {
         ui->rumbleFFToggle->setChecked(false);
         ui->rumbleFFToggle->setEnabled(false);
@@ -1154,7 +1155,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
         ui->rumbleLengthBox->setEnabled(true);
         ui->rumbleTestBtn->setEnabled(true);
     }
-    if(!(arg1 && App_Const::boolSettings[OF_Const::rumbleFF]) && !App_Const::boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Common::boolSettings[OF_Const::rumbleFF]) && !App_Common::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1166,7 +1167,7 @@ void guiWindow::on_rumbleToggle_stateChanged(int arg1)
 
 void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::solenoid] = arg1;
+    App_Common::boolSettings[OF_Const::solenoid] = arg1;
     if(arg1) {
         ui->rumbleFFToggle->setChecked(false);
         ui->solenoidNormalIntervalBox->setEnabled(true);
@@ -1179,7 +1180,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
         ui->solenoidHoldLengthBox->setEnabled(false);
         ui->solenoidTestBtn->setEnabled(false);
     }
-    if(!arg1 && !(App_Const::boolSettings[OF_Const::rumble] && App_Const::boolSettings[OF_Const::rumbleFF])) {
+    if(!arg1 && !(App_Common::boolSettings[OF_Const::rumble] && App_Common::boolSettings[OF_Const::rumbleFF])) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1191,7 +1192,7 @@ void guiWindow::on_solenoidToggle_stateChanged(int arg1)
 
 void guiWindow::on_autofireToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::autofire] = arg1;
+    App_Common::boolSettings[OF_Const::autofire] = arg1;
     if(arg1) { ui->autofireWaitFactorBox->setEnabled(true); } else { ui->autofireWaitFactorBox->setEnabled(false); }
     DiffUpdate();
 }
@@ -1199,14 +1200,14 @@ void guiWindow::on_autofireToggle_stateChanged(int arg1)
 
 void guiWindow::on_simplePauseToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::simplePause] = arg1;
+    App_Common::boolSettings[OF_Const::simplePause] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::holdToPause] = arg1;
+    App_Common::boolSettings[OF_Const::holdToPause] = arg1;
     if(arg1) { ui->holdToPauseLengthBox->setEnabled(true); }
     else { ui->holdToPauseLengthBox->setEnabled(false); }
     DiffUpdate();
@@ -1215,23 +1216,23 @@ void guiWindow::on_holdToPauseToggle_stateChanged(int arg1)
 
 void guiWindow::on_commonAnodeToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::commonAnode] = arg1;
+    App_Common::boolSettings[OF_Const::commonAnode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_lowButtonsToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::lowButtonsMode] = arg1;
+    App_Common::boolSettings[OF_Const::lowButtonsMode] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 {
-    App_Const::boolSettings[OF_Const::rumbleFF] = arg1;
+    App_Common::boolSettings[OF_Const::rumbleFF] = arg1;
     if(arg1) { ui->solenoidToggle->setChecked(false); }
-    if(!(arg1 && App_Const::boolSettings[OF_Const::rumble]) && !App_Const::boolSettings[OF_Const::solenoid]) {
+    if(!(arg1 && App_Common::boolSettings[OF_Const::rumble]) && !App_Common::boolSettings[OF_Const::solenoid]) {
         ui->autofireToggle->setChecked(false);
         ui->autofireToggle->setEnabled(false);
     } else {
@@ -1243,49 +1244,49 @@ void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
 
 void guiWindow::on_rumbleIntensityBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::rumbleStrength] = arg1;
+    App_Common::settingsTable[OF_Const::rumbleStrength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_rumbleLengthBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::rumbleInterval] = arg1;
+    App_Common::settingsTable[OF_Const::rumbleInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_holdToPauseLengthBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::holdToPauseLength] = arg1;
+    App_Common::settingsTable[OF_Const::holdToPauseLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidNormalIntervalBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::solenoidNormalInterval] = arg1;
+    App_Common::settingsTable[OF_Const::solenoidNormalInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidFastIntervalBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::solenoidFastInterval] = arg1;
+    App_Common::settingsTable[OF_Const::solenoidFastInterval] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_solenoidHoldLengthBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::solenoidHoldLength] = arg1;
+    App_Common::settingsTable[OF_Const::solenoidHoldLength] = arg1;
     DiffUpdate();
 }
 
 
 void guiWindow::on_autofireWaitFactorBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::autofireWaitFactor] = arg1;
+    App_Common::settingsTable[OF_Const::autofireWaitFactor] = arg1;
     DiffUpdate();
 }
 
@@ -1293,10 +1294,10 @@ void guiWindow::on_autofireWaitFactorBox_valueChanged(int arg1)
 void guiWindow::on_tUSB_p1_toggled(bool checked)
 {
     if(checked) {
-        App_Const::tinyUSBtable.tinyUSBid = "1";
-        App_Const::tinyUSBtable.tinyUSBname = "FIRECon P1";
-        ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-        ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+        App_Common::tinyUSBtable.tinyUSBid = "1";
+        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P1";
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
     }
@@ -1306,10 +1307,10 @@ void guiWindow::on_tUSB_p1_toggled(bool checked)
 void guiWindow::on_tUSB_p2_toggled(bool checked)
 {
     if(checked) {
-        App_Const::tinyUSBtable.tinyUSBid = "2";
-        App_Const::tinyUSBtable.tinyUSBname = "FIRECon P2";
-        ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-        ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+        App_Common::tinyUSBtable.tinyUSBid = "2";
+        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P2";
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
     }
@@ -1319,10 +1320,10 @@ void guiWindow::on_tUSB_p2_toggled(bool checked)
 void guiWindow::on_tUSB_p3_toggled(bool checked)
 {
     if(checked) {
-        App_Const::tinyUSBtable.tinyUSBid = "3";
-        App_Const::tinyUSBtable.tinyUSBname = "FIRECon P3";
-        ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-        ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+        App_Common::tinyUSBtable.tinyUSBid = "3";
+        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P3";
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
     }
@@ -1332,10 +1333,10 @@ void guiWindow::on_tUSB_p3_toggled(bool checked)
 void guiWindow::on_tUSB_p4_toggled(bool checked)
 {
     if(checked) {
-        App_Const::tinyUSBtable.tinyUSBid = "4";
-        App_Const::tinyUSBtable.tinyUSBname = "FIRECon P4";
-        ui->productIdInput->setValue(App_Const::tinyUSBtable.tinyUSBid.toInt());
-        ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+        App_Common::tinyUSBtable.tinyUSBid = "4";
+        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P4";
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid.toInt());
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
         DiffUpdate();
     }
@@ -1344,7 +1345,7 @@ void guiWindow::on_tUSB_p4_toggled(bool checked)
 
 void guiWindow::on_productIdInput_valueChanged(int arg1)
 {
-    App_Const::tinyUSBtable.tinyUSBid = QString::number(arg1);
+    App_Common::tinyUSBtable.tinyUSBid = QString::number(arg1);
     if(ui->productNameInput->text().isEmpty()) {
         switch(arg1) {
         case 1:
@@ -1385,12 +1386,12 @@ void guiWindow::on_productNameInput_textEdited(const QString &arg1)
     }
 
     if(badInput) {
-        ui->productNameInput->setText(App_Const::tinyUSBtable.tinyUSBname);
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
         ui->productNameInput->setStyleSheet("color: red");
     } else {
         if(!ui->productNameInput->styleSheet().isEmpty())
             ui->productNameInput->setStyleSheet("");
-        App_Const::tinyUSBtable.tinyUSBname = arg1;
+        App_Common::tinyUSBtable.tinyUSBname = arg1;
         DiffUpdate();
     }
 }
@@ -1413,9 +1414,9 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
     // apparently we get two signals at once? So just filter for the on.
     if(isChecked && !serialActive) {
         // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
-        if(sender()->property("slot").toInt() != App_Const::board.selectedProfile) {
+        if(sender()->property("slot").toInt() != App_Common::board.selectedProfile) {
             serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1));
-            App_Const::board.selectedProfile = sender()->property("slot").toInt();
+            App_Common::board.selectedProfile = sender()->property("slot").toInt();
             DiffUpdate();
         }
     }
@@ -1424,8 +1425,8 @@ void guiWindow::selectedProfile_isChecked(bool isChecked)
 
 void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 {
-    App_Const::settingsTable[OF_Const::customLEDcount] = arg1;
-    if(arg1 < App_Const::settingsTable[OF_Const::customLEDstatic]) {
+    App_Common::settingsTable[OF_Const::customLEDcount] = arg1;
+    if(arg1 < App_Common::settingsTable[OF_Const::customLEDstatic]) {
         ui->customLEDstaticSpinbox->setValue(arg1);
     }
 
@@ -1438,10 +1439,10 @@ void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 {
-    if(arg1 > App_Const::settingsTable[OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(App_Const::settingsTable[OF_Const::customLEDcount]); }
-    else { App_Const::settingsTable[OF_Const::customLEDstatic] = arg1; }
+    if(arg1 > App_Common::settingsTable[OF_Const::customLEDcount]) { ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable[OF_Const::customLEDcount]); }
+    else { App_Common::settingsTable[OF_Const::customLEDstatic] = arg1; }
     if(OF_Const::customLEDstatic) {
-        switch(App_Const::settingsTable[OF_Const::customLEDstatic]) {
+        switch(App_Common::settingsTable[OF_Const::customLEDstatic]) {
         case 1:
             ui->customLEDstaticBtn1->setEnabled(true);
             ui->customLEDstaticBtn2->setEnabled(false);
@@ -1474,7 +1475,7 @@ void guiWindow::on_customLEDstaticSpinbox_valueChanged(int arg1)
 
 void guiWindow::on_customLEDstaticBtn1_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor1]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor1]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1484,7 +1485,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Const::settingsTable[OF_Const::customLEDcolor1] = packedColor;
+        App_Common::settingsTable[OF_Const::customLEDcolor1] = packedColor;
         ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1497,7 +1498,7 @@ void guiWindow::on_customLEDstaticBtn1_clicked()
 
 void guiWindow::on_customLEDstaticBtn2_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor2]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor2]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1507,7 +1508,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Const::settingsTable[OF_Const::customLEDcolor2] = packedColor;
+        App_Common::settingsTable[OF_Const::customLEDcolor2] = packedColor;
         ui->customLEDstaticBtn2->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1520,7 +1521,7 @@ void guiWindow::on_customLEDstaticBtn2_clicked()
 
 void guiWindow::on_customLEDstaticBtn3_clicked()
 {
-    QColor colorPick = QColorDialog::getColor(App_Const::settingsTable[OF_Const::customLEDcolor3]);
+    QColor colorPick = QColorDialog::getColor(App_Common::settingsTable[OF_Const::customLEDcolor3]);
     if(colorPick.isValid()) {
         int *red = new int;
         int *green = new int;
@@ -1530,7 +1531,7 @@ void guiWindow::on_customLEDstaticBtn3_clicked()
         packedColor |= *red << 16;
         packedColor |= *green << 8;
         packedColor |= *blue;
-        App_Const::settingsTable[OF_Const::customLEDcolor3] = packedColor;
+        App_Common::settingsTable[OF_Const::customLEDcolor3] = packedColor;
         ui->customLEDstaticBtn3->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
 
         // show NeoPixel notice if values are updated
@@ -1546,8 +1547,8 @@ void guiWindow::caliBtns_clicked()
 
     serial.OneShotSend("XC" + QByteArray::number(sender()->property("slot").toInt()+1) +
                        "C" + // Calibrate byte
-                       "I" + QByteArray::number(App_Const::profilesTable.at(sender()->property("slot").toInt()).irSensitivity) +
-                       "L" + QByteArray::number(App_Const::profilesTable.at(sender()->property("slot").toInt()).layoutType));
+                       "I" + QByteArray::number(App_Common::profilesTable.at(sender()->property("slot").toInt()).irSensitivity) +
+                       "L" + QByteArray::number(App_Common::profilesTable.at(sender()->property("slot").toInt()).layoutType));
 }
 
 
@@ -1611,8 +1612,8 @@ void guiWindow::serialPort_readyRead()
             else if(idleBuffer.contains("Profile: ")) {
                 uint8_t selection = idleBuffer.mid(idleBuffer.indexOf(' ')).trimmed().toInt();
 
-                if(selection != App_Const::board.selectedProfile) {
-                    App_Const::board.selectedProfile = selection;
+                if(selection != App_Common::board.selectedProfile) {
+                    App_Common::board.selectedProfile = selection;
                     selectedProfile[selection]->setChecked(true);
                 }
 
@@ -1794,22 +1795,22 @@ void guiWindow::CaliWindowExiting(const int &mode,
             topRightLedNew >= 0 && topRightLedNew < 32768) {
             uint8_t selection = caliWindow->property("profile").toInt();
 
-            App_Const::profilesTable[selection].topOffset = topOffsetNew;
+            App_Common::profilesTable[selection].topOffset = topOffsetNew;
             topOffset[selection]->setText(QString::number(topOffsetNew));
 
-            App_Const::profilesTable[selection].bottomOffset = bottomOffsetNew;
+            App_Common::profilesTable[selection].bottomOffset = bottomOffsetNew;
             bottomOffset[selection]->setText(QString::number(bottomOffsetNew));
 
-            App_Const::profilesTable[selection].leftOffset = leftOffsetNew;
+            App_Common::profilesTable[selection].leftOffset = leftOffsetNew;
             leftOffset[selection]->setText(QString::number(leftOffsetNew));
 
-            App_Const::profilesTable[selection].rightOffset = rightOffsetNew;
+            App_Common::profilesTable[selection].rightOffset = rightOffsetNew;
             rightOffset[selection]->setText(QString::number(rightOffsetNew));
 
-            App_Const::profilesTable[selection].TLled = topLeftLedNew;
+            App_Common::profilesTable[selection].TLled = topLeftLedNew;
             TLled[selection]->setText(QString::number(topLeftLedNew));
 
-            App_Const::profilesTable[selection].TRled = topRightLedNew;
+            App_Common::profilesTable[selection].TRled = topRightLedNew;
             TRled[selection]->setText(QString::number(topRightLedNew));
 
             DiffUpdate();
@@ -1954,7 +1955,7 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
     if(!path.isEmpty()) {
         QFile fileIn(path);
         if(fileIn.open(QFile::ReadOnly)) {
-            if(fileIn.readLine().trimmed() == App_Const::board.boardType) {
+            if(fileIn.readLine().trimmed() == App_Common::board.boardType) {
                 ui->customPinsEnabled->setChecked(true);
                 // clear current mapping
                 for(int i = 0; i < PINS_COUNT; i++)
@@ -1986,7 +1987,7 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
     if(!path.isEmpty()) {
         QFile fileOut(path);
         if(fileOut.open(QFile::WriteOnly)) {
-            fileOut.write(QString("%1\n").arg(App_Const::board.boardType).toLocal8Bit());
+            fileOut.write(QString("%1\n").arg(App_Common::board.boardType).toLocal8Bit());
 
             for(int i = 0; i < PINS_COUNT; i++)
                 fileOut.putChar(pinBoxes.at(i)->currentIndex());

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1062,7 +1062,7 @@ void guiWindow::renameBoxes_clicked()
                                              QString("Set name for Calibration Profile %1").arg(sender()->property("slot").toInt()+1));
 
     if(!newLabel.isEmpty()) {
-        selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()).arg(newLabel.left(15)));
+        selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()+1).arg(newLabel.left(15)));
         App_Common::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15).toLocal8Bit();
     }
 

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -79,7 +79,7 @@ guiWindow::guiWindow(QWidget *parent)
     this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + '-' + QString(OFAPP_GITHASH) + ']');
 #else
     this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + ']');
-#endif // OFAPP_VERSION
+#endif // OFAPP_GITHASH
 
     // get all fixed interactable elements marked to use event filter for hover stuff:
     for(const auto child : this->findChildren<QPushButton*>())

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1917,7 +1917,7 @@ void guiWindow::on_clearEepromBtn_clicked()
 void guiWindow::on_baudResetBtn_clicked()
 {
     // No need for workarounds, bootloader reset is in the firmware now.
-    if(char buf[] = {(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader}; serial.OneShotSend(buf)) {
+    if(char buf[] = {(char)OF_Const::sGotoBootloader, (char)OF_Const::sGotoBootloader}; serial.OneShotSend(buf, 2)) {
 
 /* test stuff for potential app FW update functionality
         // At least on my system, the Bootloader device takes ~7s to appear

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -20,9 +20,6 @@
 #ifndef APPMAINWINDOW_H
 #define APPMAINWINDOW_H
 
-// Maximum amount of GPIO that the RP2040 microcontroller has available
-#define PINS_COUNT 30
-
 // Interval of the aliveTimer object that probes the board to ensure it's connected
 #define ALIVE_TIMER 5000
 
@@ -30,7 +27,8 @@
 #include "appcali.h"
 #include "appdebug.h"
 #include "appserial.h"
-#include "../boards/OpenFIREshared.h"
+#include "apppreviewer.h"
+
 #include <QMainWindow>
 #include <QSerialPort>
 #include <QFuture>
@@ -167,6 +165,8 @@ private slots:
 
     void serialPort_progressUpdate(const int &, const char* = nullptr);
 
+    void on_actionCompatible_Boards_triggered();
+
     void on_actionOpenFIRE_Documentation_triggered();
 
     void on_actionOpenFIRE_Serial_Usage_triggered();
@@ -192,8 +192,10 @@ private:
     /// @details    Only one of these should be up at a time
     AppCaliWindow *caliWindow = nullptr;
 
-    /// @brief      Debug window pointer
-    /// @details    Only one of these should be up at a time
+    /// @brief      Boards previewer window
+    AppBoardsPreviewer boardsWindow;
+
+    /// @brief      Serial debug window
     AppDebugWindow debugWindow;
 
     /// @brief      Macro for making new CaliWindows

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -194,6 +194,11 @@ private:
     /// @details    Only one of these should be up at a time
     AppDebugWindow debugWindow;
 
+    /// @brief      Macro for making new CaliWindows
+    /// @param      int
+    ///             CaliWindow type (should be one of AppCaliWindow::AppCaliStates_e
+    void NewCaliWindow(const int &);
+
     /// @brief      Mass update all pinboxes with certain sets of values
     /// @details    Used when toggling custom pins, initial load, and setting presets
     void BoxesUpdate();
@@ -236,9 +241,6 @@ private:
     /// @brief      Temperature thresholds (which should be a customizable setting in the settingsTable)
     uint8_t tempWarning = 35;
     uint8_t tempShutoff = 42;
-
-    /// @brief      Indicator if the test window is activated (to block potentially sending noise)
-    bool testMode = false;
 
     /// @brief      Timer that probes the board if it's still plugged in
     /// @details    Timer interval is provided in ms by ALIVE_TIMER

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -141,6 +141,8 @@ private slots:
 
     void on_i2cOLEDtoggle_stateChanged(int arg1);
 
+    void on_oledAltAddrsToggle_stateChanged(int arg1);
+
     void on_tinyUSBLayoutToggle_stateChanged(int arg1);
 
     void on_tUSB_p1_toggled(bool checked);

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -271,7 +271,11 @@ private:
     QVector<QWidget*> padding;
 
     /// @brief      Test "Buttons" in the test screen representing each button
-    QLabel *testLabel[16];
+    QVector<QLabel*> testLabel;
+
+    /// @brief      Analog stick graphic view
+    QGraphicsScene analogGfxScene;
+    QGraphicsEllipseItem* analogPos;
 
     /// @brief      Objects that makes up the elements of the profiles tab
     QVector<QRadioButton*> selectedProfile;

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -238,6 +238,7 @@ private:
     QFuture<bool> serialSearchFuture;
     QFutureWatcher<bool> serialSearchWatcher;
 
+    // Flag that's set during I/O operations so that the readyRead signal doesn't interfere and absorb RX buffer mid-method.
     bool serialActive = false;
 
     /// @brief      Temperature thresholds (which should be a customizable setting in the settingsTable)

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -1,5 +1,7 @@
 /*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
-    Copyright (C) 2024  Team OpenFIRE
+    Main interface.
+
+    Copyright (C) 2025  Team OpenFIRE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,7 +26,7 @@
 // Interval of the aliveTimer object that probes the board to ensure it's connected
 #define ALIVE_TIMER 5000
 
-#include "constants.h"
+#include "appcommon.h"
 #include "appcali.h"
 #include "appdebug.h"
 #include "appserial.h"

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -139,6 +139,8 @@ private slots:
 
     void on_customLEDstaticBtn3_clicked();
 
+    void on_i2cOLEDtoggle_stateChanged(int arg1);
+
     void on_tinyUSBLayoutToggle_stateChanged(int arg1);
 
     void on_tUSB_p1_toggled(bool checked);

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -10,11 +10,11 @@
     <x>0</x>
     <y>0</y>
     <width>980</width>
-    <height>720</height>
+    <height>820</height>
    </rect>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../img/vectors.qrc">
     <normaloff>:/icon/icon.png</normaloff>:/icon/icon.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -145,7 +145,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>458</height>
+             <height>558</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -281,12 +281,12 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
+             <y>-477</y>
              <width>924</width>
-             <height>1015</height>
+             <height>1084</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,1,0">
+           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,1,0">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -1059,6 +1059,28 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="i2cGroup">
+              <property name="title">
+               <string>I2C Peripherals</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_17">
+               <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="i2cOLEDtoggle">
+                 <property name="whatsThis">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>I2C OLED Display Toggle</string>
+                 </property>
+                 <property name="text">
+                  <string>Enable OLED Display (SSD1306 128x64)</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>
@@ -1427,7 +1449,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>351</height>
+             <height>423</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -2063,6 +2085,8 @@
    </property>
   </action>
  </widget>
- <resources/>
+ <resources>
+  <include location="../img/vectors.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -1980,10 +1980,13 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <addaction name="actionCompatible_Boards"/>
     <addaction name="actionOpen_IR_Emitter_Alignment_Assistant"/>
     <addaction name="separator"/>
+    <addaction name="actionOpenFIRE_on_the_Web"/>
     <addaction name="actionOpenFIRE_Documentation"/>
     <addaction name="actionOpenFIRE_Serial_Usage"/>
+    <addaction name="separator"/>
     <addaction name="actionDebug_Window"/>
    </widget>
    <addaction name="menuHelp"/>
@@ -2001,7 +2004,7 @@
   </action>
   <action name="actionOpenFIRE_Documentation">
    <property name="text">
-    <string>&amp;OpenFIRE Documentation...</string>
+    <string>&amp;OpenFIRE Documentation on the Repo...</string>
    </property>
    <property name="shortcut">
     <string>Alt+D</string>
@@ -2009,7 +2012,7 @@
   </action>
   <action name="actionOpenFIRE_Serial_Usage">
    <property name="text">
-    <string>OpenFIRE &amp;Serial Usage Docs...</string>
+    <string>OpenFIRE &amp;Serial Usage Docs on the Wiki...</string>
    </property>
    <property name="shortcut">
     <string>Alt+S</string>
@@ -2039,6 +2042,24 @@
   <action name="actionDebug_Window">
    <property name="text">
     <string>Debug Window</string>
+   </property>
+  </action>
+  <action name="actionOpenFIRE_on_the_Web">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>OpenFIRE on the Web</string>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>8</pointsize>
+    </font>
+   </property>
+  </action>
+  <action name="actionCompatible_Boards">
+   <property name="text">
+    <string>View Compatible Boards</string>
    </property>
   </action>
  </widget>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -281,9 +281,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-477</y>
+             <y>0</y>
              <width>924</width>
-             <height>1084</height>
+             <height>1153</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,1,0">
@@ -1067,7 +1067,7 @@
                <item alignment="Qt::AlignmentFlag::AlignHCenter">
                 <widget class="QCheckBox" name="i2cOLEDtoggle">
                  <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE:&lt;/span&gt; Because this device does not communicate back to the board, the firmware has no way of knowing whether the device successfully initialized or not. If the display is connected properly, but does &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; seem to power on on startup/after syncing settings, then try the &lt;span style=&quot; font-style:italic;&quot;&gt;Use Alternative Device Address&lt;/span&gt; setting before attempting to rewire the device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="accessibleName">
                   <string>I2C OLED Display Toggle</string>
@@ -1075,6 +1075,34 @@
                  <property name="text">
                   <string>Enable OLED Display (SSD1306 128x64)</string>
                  </property>
+                 <property name="trackable" stdset="0">
+                  <UInt>1</UInt>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="oledGroup">
+                 <property name="title">
+                  <string>SSD1306 OLED Display</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_11">
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                   <widget class="QCheckBox" name="oledAltAddrsToggle">
+                    <property name="whatsThis">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the display doesn't seem to power on when &lt;span style=&quot; font-style:italic;&quot;&gt;Enable OLED Display&lt;/span&gt; is set on startup/after syncing settings to the device (and you have confirmed that it is wired correctly), enabling this will try a different start address.&lt;/p&gt;&lt;p&gt;The firmware's display component normally defaults to I2C address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3C&lt;/span&gt;, but some 128x64 screens may have device address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3D&lt;/span&gt; instead, which this setting will inform the firmware to try instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>I2C OLED Device Alternate Address Toggle</string>
+                    </property>
+                    <property name="text">
+                     <string>Use Alternative Device Address</string>
+                    </property>
+                    <property name="trackable" stdset="0">
+                     <UInt>1</UInt>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -283,10 +283,10 @@
              <x>0</x>
              <y>0</y>
              <width>924</width>
-             <height>691</height>
+             <height>1015</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,1,0">
+           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,1,0">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -300,372 +300,409 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QGroupBox" name="TogglesGroup">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>120</height>
-               </size>
-              </property>
+             <widget class="QGroupBox" name="forceFeedbackBox">
               <property name="title">
-               <string>Toggles</string>
+               <string>Force Feedback</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_8">
-               <item>
-                <layout class="QHBoxLayout" name="TogglesTop">
-                 <item>
-                  <spacer name="horizontalSpacer_6">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="rumbleToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the rumble motor is enabled.&lt;/p&gt;&lt;p&gt;Under normal conditions, the rumble motor will actuate when shooting offscreen &lt;span style=&quot; font-style:italic;&quot;&gt;(i.e. when the cursor is at the edge of the display)&lt;/span&gt;, and can also provide feedback in various sections of the Pause Menu interface.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Rumble Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Rumble Enabled</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="solenoidToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the solenoid is enabled.&lt;/p&gt;&lt;p&gt;Under normal circumstances, the solenoid actuates when shooting at the display; the &amp;quot;engaged&amp;quot; duration is set in &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Interval&lt;/span&gt;. When depressed for the length of &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length&lt;/span&gt;, the solenoid will fire rapidly for as long as the trigger is held, with &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval&lt;/span&gt; determining state of the &amp;quot;engaged&amp;quot; duration and pause between engagements calculated by &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval * Autofire Wait Factor.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Note that the &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; setting conflicts with solenoid functionality, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Solenoid Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Solenoid Enabled</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="autofireToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable for rapid solenoid feedback while the trigger is pressed.&lt;/p&gt;&lt;p&gt;When enabled, the solenoid will always fire off automatically, as if the trigger has been held when using normal solenoid force feedback.&lt;/p&gt;&lt;p&gt;Note: if &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; is enabled, this option will provide continuous rumble motor feedback instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Autofire Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Autofire Enabled</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <string>1</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_7">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
+              <layout class="QGridLayout" name="gridLayout_3">
+               <item row="4" column="0">
+                <widget class="QGroupBox" name="rumbleFFBox">
+                 <property name="title">
+                  <string>Rumble</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_5">
+                  <item row="1" column="0">
+                   <widget class="QGroupBox" name="rumbleSettingsBox">
+                    <property name="title">
+                     <string/>
+                    </property>
+                    <property name="flat">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_10">
+                     <item row="2" column="0">
+                      <widget class="QLabel" name="label_3">
+                       <property name="text">
+                        <string>Rumble Intensity:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="1">
+                      <widget class="QSpinBox" name="rumbleIntensityBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the intensity of rumble force feedback events. Scales from 0 (disabled) to 255 (maximum).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Rumble Intensity Amount</string>
+                       </property>
+                       <property name="frame">
+                        <bool>true</bool>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> / 255</string>
+                       </property>
+                       <property name="maximum">
+                        <number>255</number>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="2">
+                      <widget class="QLabel" name="label_4">
+                       <property name="text">
+                        <string>Rumble Length:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="3">
+                      <widget class="QSpinBox" name="rumbleLengthBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When Rumble is enabled, this setting determines the length of how long the rumble motor is activated when pulling the trigger offscreen, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Length of Rumble Events</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="maximum">
+                        <number>9999</number>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0" colspan="4" alignment="Qt::AlignmentFlag::AlignHCenter">
+                      <widget class="QCheckBox" name="rumbleFFToggle">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the rumble motor will be used for onscreen trigger feedback; taking the place of the solenoid feedback, rather than using the default off-screen motor feedback. Naturally, this requires &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; to be enabled.&lt;/p&gt;&lt;p&gt;Note that &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; takes priority over this setting, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Rumble-based Force Feedback Toggle</string>
+                       </property>
+                       <property name="text">
+                        <string>Use Rumble as primary Force Feedback</string>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                   <widget class="QCheckBox" name="rumbleToggle">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="whatsThis">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the rumble motor is enabled.&lt;/p&gt;&lt;p&gt;Under normal conditions, the rumble motor will actuate when shooting offscreen &lt;span style=&quot; font-style:italic;&quot;&gt;(i.e. when the cursor is at the edge of the display)&lt;/span&gt;, and can also provide feedback in various sections of the Pause Menu interface.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Rumble Toggle</string>
+                    </property>
+                    <property name="text">
+                     <string>Rumble Enabled</string>
+                    </property>
+                    <property name="trackable" stdset="0">
+                     <number>1</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
                </item>
-               <item>
-                <layout class="QHBoxLayout" name="TogglesMiddle">
-                 <item>
-                  <spacer name="horizontalSpacer_4">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="rumbleFFToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the rumble motor will be used for onscreen trigger feedback; taking the place of the solenoid feedback, rather than using the default off-screen motor feedback. Naturally, this requires &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; to be enabled.&lt;/p&gt;&lt;p&gt;Note that &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; takes priority over this setting, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Rumble-based Force Feedback Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Rumble FF</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="simplePauseToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how Pause Mode functions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode will use a scrolling menu layout - navigate by using &lt;span style=&quot; font-style:italic;&quot;&gt;Button A/B&lt;/span&gt; to select, and press Trigger to activate.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Menu options are activated with hotkeys.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns with less than two sub buttons, but &lt;span style=&quot; font-weight:700;&quot;&gt;requires an LED or OLED Display for visual feedback!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Simple Pause Menu Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Simple Pause Menu</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="holdToPauseToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how to trigger Pause Mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode can be activated by holding &lt;span style=&quot; font-style:italic;&quot;&gt;Trigger&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;while no IR points are visible.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Mode can be activated by pressing the Pause Mode hotkey (Button C + Select).&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons.&lt;/span&gt; Note that regardless of setting, Pause Mode can always be accessed by pressing the Home Button (if set).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Pause Mode Hold-to-Activate Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Hold to Pause Enabled</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_5">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="autofireToggle">
+                 <property name="toolTip">
+                  <string/>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable for rapid solenoid feedback while the trigger is pressed.&lt;/p&gt;&lt;p&gt;When enabled, the solenoid will always fire off automatically, as if the trigger has been held when using normal solenoid force feedback.&lt;/p&gt;&lt;p&gt;Note: if &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; is enabled, this option will provide continuous rumble motor feedback instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Autofire Toggle</string>
+                 </property>
+                 <property name="text">
+                  <string>Autofire Enabled</string>
+                 </property>
+                 <property name="trackable" stdset="0">
+                  <string>1</string>
+                 </property>
+                </widget>
                </item>
-               <item>
-                <layout class="QHBoxLayout" name="TogglesBottom">
-                 <item>
-                  <spacer name="horizontalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="commonAnodeToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the 4-pin RGB LED module uses a &lt;span style=&quot; font-style:italic;&quot;&gt;Common Anode&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Common Cathode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enable&lt;/span&gt; if your 4-pin LED is a Common Anode type (with common connected to 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disable&lt;/span&gt; if your 4-pin LED is a Common Cathode (with common connected to GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>4-Pin RGB LED Common Anode Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>RGB Common Anode</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="lowButtonsToggle">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; behaves during normal use.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled, &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; will perform different functions when aiming off-screen, instead actuating the functions of &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; respectively.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; all buttons will perform the same functions, regardless of aiming off-screen or not.&lt;/p&gt;&lt;p&gt;Enabled is recommended for lightguns &lt;span style=&quot; font-weight:700;&quot;&gt;with two or less sub buttons.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Low Buttons Mode Toggle</string>
-                   </property>
-                   <property name="text">
-                    <string>Low Buttons Mode</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_3">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
+               <item row="1" column="0">
+                <widget class="QGroupBox" name="solenoidFFBox">
+                 <property name="title">
+                  <string>Solenoid</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout">
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                   <widget class="QCheckBox" name="solenoidToggle">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="whatsThis">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the solenoid is enabled.&lt;/p&gt;&lt;p&gt;Under normal circumstances, the solenoid actuates when shooting at the display; the &amp;quot;engaged&amp;quot; duration is set in &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Interval&lt;/span&gt;. When depressed for the length of &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length&lt;/span&gt;, the solenoid will fire rapidly for as long as the trigger is held, with &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval&lt;/span&gt; determining state of the &amp;quot;engaged&amp;quot; duration and pause between engagements calculated by &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval * Autofire Wait Factor.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Note that the &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; setting conflicts with solenoid functionality, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Solenoid Toggle</string>
+                    </property>
+                    <property name="text">
+                     <string>Solenoid Enabled</string>
+                    </property>
+                    <property name="trackable" stdset="0">
+                     <number>1</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QGroupBox" name="solenoidSettingsBox">
+                    <property name="title">
+                     <string/>
+                    </property>
+                    <property name="flat">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_8">
+                     <item row="1" column="1">
+                      <widget class="QSpinBox" name="solenoidFastIntervalBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time between solenoid activations when the trigger is held in &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; mode (or after holding the trigger for &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length),&lt;/span&gt; in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 30 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Autofire Solenoid Engagement Length</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QLabel" name="label_9">
+                       <property name="text">
+                        <string>Solenoid Hold-to-Autofire Length:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_7">
+                       <property name="text">
+                        <string>Solenoid ON Normal Length:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="solenoidNormalIntervalBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Normal Solenoid Engagement Length</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="label_8">
+                       <property name="text">
+                        <string>Solenoid ON Fast Length:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QSpinBox" name="solenoidHoldLengthBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Solenoid Trigger Hold to Autofire Length</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="maximum">
+                        <number>9999</number>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QLabel" name="label_10">
+                       <property name="text">
+                        <string>Autofire Wait Factor:</string>
+                       </property>
+                       <property name="textFormat">
+                        <enum>Qt::TextFormat::PlainText</enum>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       </property>
+                       <property name="wordWrap">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="3">
+                      <widget class="QSpinBox" name="autofireWaitFactorBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the multiplier that's applied to the interval between solenoid activations when &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is enabled.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 3(x)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Autofire Wait Factor</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="showGroupSeparator" stdset="0">
+                        <bool>false</bool>
+                       </property>
+                       <property name="suffix">
+                        <string>x</string>
+                       </property>
+                       <property name="minimum">
+                        <number>2</number>
+                       </property>
+                       <property name="maximum">
+                        <number>4</number>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
                </item>
               </layout>
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="SettingsGroup">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
+             <widget class="QGroupBox" name="lightingBox">
               <property name="title">
-               <string>Setting Values</string>
+               <string>Lighting</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
-               <item row="1" column="2">
-                <widget class="QLabel" name="label_8">
-                 <property name="text">
-                  <string>Solenoid Fast Interval:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QSpinBox" name="solenoidFastIntervalBox">
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="commonAnodeToggle">
                  <property name="toolTip">
                   <string/>
                  </property>
                  <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time between solenoid activations when the trigger is held in &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; mode (or after holding the trigger for &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length),&lt;/span&gt; in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 30 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the 4-pin RGB LED module uses a &lt;span style=&quot; font-style:italic;&quot;&gt;Common Anode&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Common Cathode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enable&lt;/span&gt; if your 4-pin LED is a Common Anode type (with common connected to 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disable&lt;/span&gt; if your 4-pin LED is a Common Cathode (with common connected to GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Autofire Solenoid Engagement Length</string>
+                  <string>4-Pin RGB LED Common Anode Toggle</string>
                  </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="suffix">
-                  <string> ms</string>
-                 </property>
-                 <property name="trackable" stdset="0">
-                  <number>1</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="label_9">
                  <property name="text">
-                  <string>Solenoid Hold Length:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_3">
-                 <property name="text">
-                  <string>Rumble Intensity:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QSpinBox" name="rumbleIntensityBox">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the intensity of rumble force feedback events. Scales from 0 (disabled) to 255 (maximum).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Rumble Intensity Amount</string>
-                 </property>
-                 <property name="frame">
-                  <bool>true</bool>
-                 </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="suffix">
-                  <string> / 255</string>
-                 </property>
-                 <property name="maximum">
-                  <number>255</number>
+                  <string>4-Pin RGB Common Anode</string>
                  </property>
                  <property name="trackable" stdset="0">
                   <number>1</number>
@@ -673,129 +710,244 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="label_4">
-                 <property name="text">
-                  <string>Rumble Length:</string>
+                <widget class="QGroupBox" name="neopixelGroupBox">
+                 <property name="title">
+                  <string>NeoPixels</string>
                  </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
+                 <layout class="QGridLayout" name="gridLayout_9">
+                  <item row="1" column="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QPushButton" name="customLEDstaticBtn1">
+                      <property name="font">
+                       <font>
+                        <bold>true</bold>
+                        <underline>false</underline>
+                        <kerning>false</kerning>
+                       </font>
+                      </property>
+                      <property name="whatsThis">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="accessibleName">
+                       <string>First NeoPixel Static Color</string>
+                      </property>
+                      <property name="text">
+                       <string>Static Color 1</string>
+                      </property>
+                      <property name="trackable" stdset="0">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="customLEDstaticBtn2">
+                      <property name="font">
+                       <font>
+                        <bold>true</bold>
+                       </font>
+                      </property>
+                      <property name="whatsThis">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="accessibleName">
+                       <string>Second NeoPixel Static Color</string>
+                      </property>
+                      <property name="text">
+                       <string>Static Color 2</string>
+                      </property>
+                      <property name="trackable" stdset="0">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="customLEDstaticBtn3">
+                      <property name="font">
+                       <font>
+                        <bold>true</bold>
+                       </font>
+                      </property>
+                      <property name="whatsThis">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                      </property>
+                      <property name="accessibleName">
+                       <string>Third NeoPixel Static Color</string>
+                      </property>
+                      <property name="text">
+                       <string>Static Color 3</string>
+                      </property>
+                      <property name="trackable" stdset="0">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QSpinBox" name="customLEDstaticSpinbox">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="whatsThis">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Amount of NeoPixels using Static Colors</string>
+                    </property>
+                    <property name="suffix">
+                     <string> Pixel(s)</string>
+                    </property>
+                    <property name="prefix">
+                     <string>First </string>
+                    </property>
+                    <property name="maximum">
+                     <number>3</number>
+                    </property>
+                    <property name="trackable" stdset="0">
+                     <number>1</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>Static NeoPixels: </string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0" rowspan="2">
+                   <spacer name="horizontalSpacer_3">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="4" rowspan="2">
+                   <spacer name="horizontalSpacer_4">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="3">
+                   <widget class="QSpinBox" name="neopixelStrandLengthBox">
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="whatsThis">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs are in the NeoPixel chain. More than one NeoPixel can be daisychained together, starting from the Pixel that's directly connected to &lt;span style=&quot; font-style:italic;&quot;&gt;NeoPixel Pin.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>NeoPixel Strand Length</string>
+                    </property>
+                    <property name="buttonSymbols">
+                     <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                    </property>
+                    <property name="correctionMode">
+                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                    </property>
+                    <property name="suffix">
+                     <string> Pixel(s)</string>
+                    </property>
+                    <property name="prefix">
+                     <string/>
+                    </property>
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>100</number>
+                    </property>
+                    <property name="trackable" stdset="0">
+                     <number>1</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1" colspan="2">
+                   <widget class="QLabel" name="label">
+                    <property name="text">
+                     <string>NeoPixel Strand Length: </string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0" colspan="5">
+                   <widget class="QLabel" name="pixelChangeNotice">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="font">
+                     <font>
+                      <italic>true</italic>
+                     </font>
+                    </property>
+                    <property name="text">
+                     <string>Changes to NeoPixel settings may require a power cycle to update properly!</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
-               <item row="1" column="1">
-                <widget class="QSpinBox" name="rumbleLengthBox">
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="inputBox">
+              <property name="title">
+               <string>Input</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_7">
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="lowButtonsToggle">
                  <property name="toolTip">
                   <string/>
                  </property>
                  <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When Rumble is enabled, this setting determines the length of how long the rumble motor is activated when pulling the trigger offscreen, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; behaves during normal use.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled, &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; will perform different functions when aiming off-screen, instead actuating the functions of &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; respectively.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; all buttons will perform the same functions, regardless of aiming off-screen or not.&lt;/p&gt;&lt;p&gt;Enabled is recommended for lightguns &lt;span style=&quot; font-weight:700;&quot;&gt;with two or less sub buttons.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Length of Rumble Events</string>
+                  <string>Low Buttons Mode Toggle</string>
                  </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="suffix">
-                  <string> ms</string>
-                 </property>
-                 <property name="maximum">
-                  <number>9999</number>
+                 <property name="text">
+                  <string>Low Buttons Mode</string>
                  </property>
                  <property name="trackable" stdset="0">
                   <number>1</number>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="3">
-                <widget class="QSpinBox" name="solenoidNormalIntervalBox">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Normal Solenoid Engagement Length</string>
-                 </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="suffix">
-                  <string> ms</string>
-                 </property>
-                 <property name="trackable" stdset="0">
-                  <number>1</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QSpinBox" name="solenoidHoldLengthBox">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Solenoid Trigger Hold to Autofire Length</string>
-                 </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="suffix">
-                  <string> ms</string>
-                 </property>
-                 <property name="maximum">
-                  <number>9999</number>
-                 </property>
-                 <property name="trackable" stdset="0">
-                  <number>1</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_5">
-                 <property name="text">
-                  <string>Hold-to-Pause Length:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_7">
-                 <property name="text">
-                  <string>Solenoid Interval:</string>
-                 </property>
-                 <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="uiuxBox">
+              <property name="title">
+               <string>UI and UX</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_6">
+               <item row="1" column="3">
                 <widget class="QSpinBox" name="holdToPauseLengthBox">
                  <property name="toolTip">
                   <string/>
@@ -823,10 +975,23 @@
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
-                <widget class="QLabel" name="label_10">
+               <item row="1" column="4">
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="2">
+                <widget class="QLabel" name="label_5">
                  <property name="text">
-                  <string>Autofire Wait Factor:</string>
+                  <string>Hold-to-Pause Length:</string>
                  </property>
                  <property name="textFormat">
                   <enum>Qt::TextFormat::PlainText</enum>
@@ -839,268 +1004,54 @@
                  </property>
                 </widget>
                </item>
-               <item row="3" column="2">
-                <widget class="QSpinBox" name="autofireWaitFactorBox">
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="holdToPauseToggle">
                  <property name="toolTip">
                   <string/>
                  </property>
                  <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the multiplier that's applied to the interval between solenoid activations when &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is enabled.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 3(x)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how to trigger Pause Mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode can be activated by holding &lt;span style=&quot; font-style:italic;&quot;&gt;Trigger&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;while no IR points are visible.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Mode can be activated by pressing the Pause Mode hotkey (Button C + Select).&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons.&lt;/span&gt; Note that regardless of setting, Pause Mode can always be accessed by pressing the Home Button (if set).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Autofire Wait Factor</string>
+                  <string>Pause Mode Hold-to-Activate Toggle</string>
                  </property>
-                 <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                 </property>
-                 <property name="showGroupSeparator" stdset="0">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string>x</string>
-                 </property>
-                 <property name="minimum">
-                  <number>2</number>
-                 </property>
-                 <property name="maximum">
-                  <number>4</number>
+                 <property name="text">
+                  <string>Hold to Pause Enabled</string>
                  </property>
                  <property name="trackable" stdset="0">
                   <number>1</number>
                  </property>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="neopixelGroupBox">
-              <property name="title">
-               <string>NeoPixels</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_11">
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <item>
-                  <spacer name="horizontalSpacer_10">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label">
-                   <property name="text">
-                    <string>NeoPixel Strand Length: </string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="neopixelStrandLengthBox">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs are in the NeoPixel chain. More than one NeoPixel can be daisychained together, starting from the Pixel that's directly connected to &lt;span style=&quot; font-style:italic;&quot;&gt;NeoPixel Pin.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>NeoPixel Strand Length</string>
-                   </property>
-                   <property name="buttonSymbols">
-                    <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                   </property>
-                   <property name="correctionMode">
-                    <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                   </property>
-                   <property name="suffix">
-                    <string> Pixel(s)</string>
-                   </property>
-                   <property name="prefix">
-                    <string/>
-                   </property>
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>100</number>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_11">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                 <item>
-                  <spacer name="horizontalSpacer_12">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_2">
-                   <property name="text">
-                    <string>Static NeoPixels: </string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="customLEDstaticSpinbox">
-                   <property name="toolTip">
-                    <string/>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Amount of NeoPixels using Static Colors</string>
-                   </property>
-                   <property name="suffix">
-                    <string> Pixel(s)</string>
-                   </property>
-                   <property name="prefix">
-                    <string>First </string>
-                   </property>
-                   <property name="maximum">
-                    <number>3</number>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="customLEDstaticBtn1">
-                   <property name="font">
-                    <font>
-                     <bold>true</bold>
-                     <underline>false</underline>
-                     <kerning>false</kerning>
-                    </font>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>First NeoPixel Static Color</string>
-                   </property>
-                   <property name="text">
-                    <string>Static Color 1</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="customLEDstaticBtn2">
-                   <property name="font">
-                    <font>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Second NeoPixel Static Color</string>
-                   </property>
-                   <property name="text">
-                    <string>Static Color 2</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="customLEDstaticBtn3">
-                   <property name="font">
-                    <font>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="whatsThis">
-                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won't be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                   </property>
-                   <property name="accessibleName">
-                    <string>Third NeoPixel Static Color</string>
-                   </property>
-                   <property name="text">
-                    <string>Static Color 3</string>
-                   </property>
-                   <property name="trackable" stdset="0">
-                    <number>1</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_13">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QLabel" name="pixelChangeNotice">
-                 <property name="enabled">
-                  <bool>false</bool>
+               <item row="1" column="0">
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
-                 <property name="font">
-                  <font>
-                   <italic>true</italic>
-                  </font>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="1" colspan="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <widget class="QCheckBox" name="simplePauseToggle">
+                 <property name="toolTip">
+                  <string/>
+                 </property>
+                 <property name="whatsThis">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how Pause Mode functions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode will use a scrolling menu layout - navigate by using &lt;span style=&quot; font-style:italic;&quot;&gt;Button A/B&lt;/span&gt; to select, and press Trigger to activate.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Menu options are activated with hotkeys.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns with less than two sub buttons, but &lt;span style=&quot; font-weight:700;&quot;&gt;requires an LED or OLED Display for visual feedback!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Simple Pause Menu Toggle</string>
                  </property>
                  <property name="text">
-                  <string>Changes to NeoPixel settings may require a power cycle to update properly!</string>
+                  <string>Simple Pause Menu</string>
                  </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 <property name="trackable" stdset="0">
+                  <number>1</number>
                  </property>
                 </widget>
                </item>
@@ -1121,7 +1072,7 @@
              </spacer>
             </item>
             <item>
-             <widget class="QGroupBox" name="tinyUSBGroupboxNew">
+             <widget class="QGroupBox" name="tinyUSBGroupbox">
               <property name="title">
                <string>TinyUSB Identifier</string>
               </property>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowIcon">
-   <iconset resource="../img/vectors.qrc">
+   <iconset>
     <normaloff>:/icon/icon.png</normaloff>:/icon/icon.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -1724,9 +1724,120 @@
         <item>
          <widget class="QGroupBox" name="buttonsTestArea">
           <property name="title">
-           <string>Buttons Tester</string>
+           <string>Inputs Test</string>
           </property>
-          <layout class="QGridLayout" name="buttonsTestLayout"/>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QGroupBox" name="btnsGroup">
+             <property name="title">
+              <string>Buttons</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_11" stretch="3,1">
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QGridLayout" name="btnsLayout"/>
+              </item>
+              <item>
+               <widget class="QLabel" name="tmp36Label">
+                <property name="frameShape">
+                 <enum>QFrame::Shape::Box</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Shadow::Raised</enum>
+                </property>
+                <property name="text">
+                 <string>Temperature Sensor (N/A)</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="analogGroup">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Analog Stick</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,1">
+              <property name="spacing">
+               <number>4</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="aPosLabel">
+                <property name="font">
+                 <font>
+                  <italic>true</italic>
+                 </font>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGraphicsView" name="analogGfxView">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>256</width>
+                  <height>256</height>
+                 </size>
+                </property>
+                <property name="verticalScrollBarPolicy">
+                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+                </property>
+                <property name="horizontalScrollBarPolicy">
+                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+                </property>
+                <property name="interactive">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>
@@ -1931,8 +2042,6 @@
    </property>
   </action>
  </widget>
- <resources>
-  <include location="../img/vectors.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Boards preview window.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "apppreviewer.h"
 #include "ui_apppreviewer.h"
 #include "appcommon.h"

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -1,0 +1,137 @@
+#include "apppreviewer.h"
+#include "ui_apppreviewer.h"
+#include "appcommon.h"
+#include "../boards/OpenFIREshared.h"
+
+#include <QSvgRenderer>
+#include <QFile>
+
+AppBoardsPreviewer::AppBoardsPreviewer(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::AppBoardsPreviewer)
+{
+    ui->setupUi(this);
+
+    //boldFont.setBold(true);
+    boldFont.setPointSize(12);
+
+    // Add center board pic above the Sub Pins layout
+    ui->PinsCenter->insertWidget(0, &boardPic, 1);
+    boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    for(auto &item : OF_Const::boardNames)
+        if(strcmp(item.first.data(), "generic"))
+            ui->boardSelector->addItem(item.second);
+}
+
+AppBoardsPreviewer::~AppBoardsPreviewer()
+{
+    delete ui;
+}
+
+bool AppBoardsPreviewer::eventFilter(QObject* object, QEvent* event)
+{
+    if(event->type() == QEvent::Enter) {
+        // Copy and modify board pic array to change opacity of selected pin element, if existing.
+        highlightBoardPic = origBoardPicFile;
+        highlightBoardPic.replace(QString("id=\"OF_pin%1\"\nstyle=\"opacity:0").arg(object->property("slot").toInt()),
+                                  QString("id=\"OF_pin%1\"\nstyle=\"opacity:1").arg(object->property("slot").toInt()));
+
+        boardPic.load(highlightBoardPic.toLocal8Bit());
+        boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+    } else if(event->type() == QEvent::Leave) {
+        boardPic.load(origBoardPicFile);
+        boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+    }
+
+    return QWidget::eventFilter(object, event);
+}
+
+void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1)
+{
+    for(auto &board : OF_Const::boardNames) {
+        if(!strcmp(board.second, arg1.toLocal8Bit().constData())) {
+            // Clears old board layout items
+            if(pinDefaultFunc.count()) {
+                for(uint8_t i = 0; i < pinDefaultFunc.count(); i++)
+                    delete pinDefaultFunc.at(i);
+                for(uint8_t i = 0; i < padding.count(); i++)
+                    delete padding.at(i);
+                for(uint8_t i = 0; i < pinLabel.count(); i++)
+                    delete pinLabel.at(i);
+
+                pinDefaultFunc.clear();
+                padding.clear();
+                pinLabel.clear();
+            }
+
+            for(uint8_t i = 0; i < PINS_COUNT; i++) {
+                pinDefaultFunc << new QLabel();
+                pinDefaultFunc.at(i)->setFont(boldFont);
+                pinDefaultFunc.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinDefaultFunc.at(i)->setProperty("slot", i);
+                pinDefaultFunc.at(i)->installEventFilter(this);
+
+                padding << new QWidget();
+                padding.at(i)->setMinimumHeight(25);
+
+                // I2C channel coloring
+                if(i & 0b0000010)
+                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+
+                pinLabel.at(i)->setEnabled(false);
+                pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
+            }
+
+            // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
+            QFile resource(QString(":/boardPics/%1").arg(board.first.data()));
+            resource.open(QIODevice::ReadOnly);
+            origBoardPicFile = resource.readAll();
+
+            for(int i = 0; i < pinDefaultFunc.count(); i++) {
+                if(OF_Const::boardsBoxPositions.at(board.first).pin[i] & OF_Const::posLeft) {
+                    ui->PinsLeft->addWidget(pinDefaultFunc.at(i),
+                                            OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posLeft, 0, Qt::AlignRight);
+                    ui->PinsLeft->addWidget(pinLabel.at(i),
+                                            OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posLeft, 1);
+                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).pin[i]+1]);
+                } else if(OF_Const::boardsBoxPositions.at(board.first).pin[i] & OF_Const::posRight) {
+                    ui->PinsRight->addWidget(pinDefaultFunc.at(i),
+                                             OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posRight, 1);
+                    ui->PinsRight->addWidget(pinLabel.at(i),
+                                             OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posRight, 0);
+                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).pin[i]+1]);
+                } else if(OF_Const::boardsBoxPositions.at(board.first).pin[i] & OF_Const::posMiddle) {
+                    ui->PinsCenterSub->addWidget(pinDefaultFunc.at(i), 1,
+                                                 OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posMiddle, Qt::AlignCenter);
+                    ui->PinsCenterSub->addWidget(pinLabel.at(i), 0,
+                                                 OF_Const::boardsBoxPositions.at(board.first).pin[i] ^ OF_Const::posMiddle, Qt::AlignCenter);
+                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).pin[i]+1]);
+                }
+            }
+
+            // aspect ratio hint needs to be set every time a new asset is loaded
+            boardPic.load(origBoardPicFile);
+            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+
+            int prevPadCount;
+            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
+                ui->PinsLeft->setRowMinimumHeight(i, 28);
+                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                    prevPadCount = padCount;
+                }
+            }
+            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
+                ui->PinsRight->setRowMinimumHeight(i, 28);
+                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
+                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
+                    padCount++;
+                }
+            }
+        }
+    }
+}

--- a/src/apppreviewer.h
+++ b/src/apppreviewer.h
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Boards preview window.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef APPPREVIEWER_H
 #define APPPREVIEWER_H
 

--- a/src/apppreviewer.h
+++ b/src/apppreviewer.h
@@ -1,0 +1,46 @@
+#ifndef APPPREVIEWER_H
+#define APPPREVIEWER_H
+
+#include <QDialog>
+#include <QSvgWidget>
+#include <QComboBox>
+#include <QLabel>
+
+namespace Ui {
+class AppBoardsPreviewer;
+}
+
+class AppBoardsPreviewer : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit AppBoardsPreviewer(QWidget *parent = nullptr);
+    ~AppBoardsPreviewer();
+
+private slots:
+    void on_boardSelector_currentTextChanged(const QString &arg1);
+
+private:
+    Ui::AppBoardsPreviewer *ui;
+
+    bool eventFilter(QObject* object, QEvent* event) override;
+
+    /// @brief      Macro font to enable bold
+    QFont boldFont;
+
+    /// @brief      Renderer that makes up the centerpiece of the board view tab
+    QSvgWidget boardPic;
+
+    /// @brief      Current board picture's byte array representation
+    /// @details    Used to quickly copy/modify for board view highlights
+    QByteArray origBoardPicFile;
+    QString highlightBoardPic;
+
+    /// @brief      Objects that makes up the elements of the board view tab
+    QVector<QLabel*> pinDefaultFunc;
+    QVector<QLabel*> pinLabel;
+    QVector<QWidget*> padding;
+};
+
+#endif // APPPREVIEWER_H

--- a/src/apppreviewer.ui
+++ b/src/apppreviewer.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AppBoardsPreviewer</class>
+ <widget class="QDialog" name="AppBoardsPreviewer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Boards Previewer</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../img/vectors.qrc">
+    <normaloff>:/icon/icon.png</normaloff>:/icon/icon.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+   <item>
+    <layout class="QHBoxLayout" name="selectorLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="boardSelector">
+       <property name="placeholderText">
+        <string>Click Here to Select a Board</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="PinsLayout">
+     <item>
+      <layout class="QGridLayout" name="PinsLeft"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="PinsCenter">
+       <item>
+        <layout class="QGridLayout" name="PinsCenterSub"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="PinsRight"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../img/vectors.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -123,11 +123,9 @@ bool AppSerial::GetSettings(const QString &portName)
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {
                         // booleans
                         memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
-                        for(uint8_t i = 0;; i++) {
+                        for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
                             if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
                                 port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
-                            else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
-                                break;
                             else if(port.bytesAvailable()) port.read(1);
                             else if(!port.waitForReadyRead(2000)) break;
                         }
@@ -141,13 +139,13 @@ bool AppSerial::GetSettings(const QString &portName)
                             if(OneShotSend((char)OF_Const::sGetPins, true)) {
                                 App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
-                                for(uint8_t i = 0;; i++)
+                                for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
+                                    qDebug() << port.peek(port.bytesAvailable());
                                     if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
                                         port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                    else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
-                                        break;
                                     else if(port.bytesAvailable()) port.read(1);
                                     else if(!port.waitForReadyRead(2000)) break;
+                                }
                             } else {
                                 printf("Didn't receive any data in time!\n");
                                 return false;
@@ -163,9 +161,8 @@ bool AppSerial::GetSettings(const QString &portName)
                         port.clear();
                         if(OneShotSend((char)OF_Const::sGetSettings, true)) {
                             memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                            while(true) {
-                                if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
-                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                            while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
+                                if(!port.bytesAvailable()) { if(!port.waitForReadyRead(2000)) break; }
                                 else {
                                     uint8_t i = port.read(1).at(0);
                                     if(i < OF_Const::settingsTypesCount)
@@ -180,9 +177,8 @@ bool AppSerial::GetSettings(const QString &portName)
                             port.clear();
                             if(OneShotSend((char)OF_Const::sGetPeriphs, true)) {
                                 memset(App_Common::i2cPeriphs, 0, OF_Const::i2cDevicesCount);
-                                while(true) {
-                                    if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
-                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
+                                    if(!port.bytesAvailable()) { if(!port.waitForReadyRead(2000)) break; }
                                     else {
                                         switch(port.read(1).at(0)) {
                                         case (char)OF_Const::i2cDevicesEnabled:
@@ -198,6 +194,15 @@ bool AppSerial::GetSettings(const QString &portName)
                                             break;
                                         }
                                         case (char)OF_Const::i2cOLED:
+                                            while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
+                                                if(port.bytesAvailable()) {
+                                                    int type = port.read(1).at(0);
+                                                    if(type < OF_Const::oledSettingsTypes)
+                                                        port.read((char*)&App_Common::i2cOledPrefs[type], sizeof(uint32_t));
+                                                    else port.read(sizeof(uint32_t));
+                                                } else if(!port.waitForReadyRead(2000)) break;
+                                            }
+                                            break;
                                         default: break;
                                         }
                                     }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -179,7 +179,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                         memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
                                         while(true) {
                                             if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
-                                            if(port.peek(1).at(0) == (char)0xFF) break;
+                                            if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
                                             else {
                                                 uint8_t i = port.read(1).at(0);
                                                 if(i < OF_Const::settingsTypesCount)
@@ -198,24 +198,24 @@ bool AppSerial::GetSettings(const QString &portName)
                                             port.write("XlP" + QByteArray::number(i));
                                             port.waitForBytesWritten(500);
                                             if(port.waitForReadyRead(500)) {
-                                                if(port.peek(1).at(0) == (char)0xFE) {
+                                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
                                                     break;
                                                 } else {
                                                     App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
 
                                                     while(port.bytesAvailable()) {
                                                         switch(port.read(1).at(0)) {
-                                                        case 0: port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
-                                                        case 1: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
-                                                        case 2: port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
-                                                        case 3: port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
-                                                        case 4: port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
-                                                        case 5: port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
-                                                        case 6: port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
-                                                        case 7: port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
-                                                        case 8: port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
-                                                        case 9: port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
-                                                        case (char)0xFA:          App_Common::profilesTable[i].profName = port.read(16);         break;
+                                                        case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
+                                                        case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
+                                                        case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
+                                                        case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
+                                                        case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
+                                                        case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
+                                                        case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
+                                                        case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
+                                                        case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
+                                                        case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
+                                                        case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
                                                         default: break;
                                                         }
                                                     }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -398,7 +398,15 @@ bool AppSerial::CommitSettings()
                         { OneShotSend((char)OF_Const::serialTerminator); return false; }
 
                     switch(i) {
-                    case OF_Const::i2cOLED: // OLED currently has no settings
+                    case OF_Const::i2cOLED:
+                        buf[1] = (char)OF_Const::i2cOLED;
+                        for(int type = 0; type < OF_Const::oledSettingsTypes; type++) {
+                            buf[2] = (char)type;
+                            memcpy(&buf[3], (uint8_t*)&App_Common::i2cOledPrefs[type], sizeof(uint32_t));
+                            if(OneShotSend(buf, 7, true)) if(memcmp(App_Common::i2cOledPrefs, port.read(4).constData(), sizeof(uint32_t)))
+                                { OneShotSend((char)OF_Const::serialTerminator); return false; }
+                        }
+                        break;
                     default: break;
                     }
                 }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -220,7 +220,7 @@ bool AppSerial::GetSettings(const QString &portName)
                             return false;
                         }
                     } else {
-                        printf("Port did not respond with expected response! Got: %s\n", buffer.join(',').constData());
+                        printf("Port did not respond with expected response! Got: %s\n", buffer.join(' ').constData());
                         return false;
                     }
                 } else {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -82,7 +82,7 @@ bool AppSerial::GetSettings(const QString &portName)
             // windows needs DTR enabled to actually read responses.
             port.setDataTerminalReady(true);
 
-            if(OneShotSend((char[]){(char)OF_Const::sDock1, (char)OF_Const::sDock2}, 2, true)) {
+            if(char buf[] = {(char)OF_Const::sDock1, (char)OF_Const::sDock2}; OneShotSend(buf, 2, true)) {
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
                 if(buffer.at(0) == "CAMERROR: Not available") {
@@ -169,7 +169,7 @@ bool AppSerial::GetSettings(const QString &portName)
 
                             for(uint8_t i = 0;; i++) {
                                 port.clear();
-                                if(OneShotSend((char[]){(char)OF_Const::sGetProfile, (char)i}, 2, true)) {
+                                if(char buf[] = {(char)OF_Const::sGetProfile, (char)i}; OneShotSend(buf, 2, true)) {
                                     if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
                                         break;
                                     } else {
@@ -308,7 +308,8 @@ bool AppSerial::CommitSettings()
 
 void AppSerial::Disconnect()
 {
-    OneShotSend((char[]){(char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator});
+    char buf[] = {(char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator};
+    OneShotSend(buf);
     port.close();
 
     port.setPortName("");

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -215,13 +215,15 @@ bool AppSerial::GetSettings(const QString &portName)
                     }
                 } else {
                     printf("Port did not respond with expected response! Got: %s\n", buffer.join(' ').constData());
+                    RequestToReboot();
                     return false;
                 }
             } else {
                 QMessageBox::warning(nullptr,   "Data hasn't arrived! (Stale state?)",
-                                     "Device was detected, but initial settings request wasn't received in time!\n"
-                                     "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                                     "Try selecting the device again.");
+                                                "Device was detected, but initial settings request wasn't received in time!\n"
+                                                "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
+                                                "Try selecting the device again.");
+                RequestToReboot();
                 return false;
             }
         } else {
@@ -344,4 +346,23 @@ void AppSerial::Disconnect()
     port.close();
 
     port.setPortName("");
+}
+
+void AppSerial::RequestToReboot()
+{
+    if(QMessageBox::critical(nullptr, "Reset Board to Bootloader?",
+                                      "<p>The board you selected did not respond to the app properly.</p>"
+                                      "<p>This can usually be resolved by rebooting the microcontroller to its bootloader, and then updating the board to the latest firmware, which can be found at:</p>"
+                                      "<p><a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest'><span style=' text-decoration: underline; color:#8ab4f8;'>https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest</span></a></p>"
+                                      "<p>Would you like to reboot this board to apply an update?</p>",
+                                      QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+        RebootToBootldr();
+}
+
+void AppSerial::RebootToBootldr()
+{
+    // The py script had this backwards. huh.
+    port.setBaudRate(QSerialPort::Baud1200);
+    port.setDataTerminalReady(false);
+    port.close();
 }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -82,6 +82,7 @@ bool AppSerial::GetSettings(const QString &portName)
         if(port.open(QIODevice::ReadWrite)) {
             // windows needs DTR enabled to actually read responses.
             port.setDataTerminalReady(true);
+            port.clear();
 
             if(char buf[] = {(char)OF_Const::sDock1, (char)OF_Const::sDock2}; OneShotSend(buf, 2, true)) {
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
@@ -264,6 +265,8 @@ bool AppSerial::CommitSettings()
         emit Serial_SetProgressRange(7);
 
         if(OneShotSend((char)OF_Const::sCommitStart)) {
+            port.clear();
+
             emit Serial_ProgressUpdate(1, "Sending Toggles...");
             for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
                 if(char buf[3] = {(char)OF_Const::sCommitToggles, (char)i, (char)App_Common::boolSettings[i]}; OneShotSend(buf, 3, true)) {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -122,19 +122,21 @@ bool AppSerial::GetSettings(const QString &portName)
                     // toggles
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {
                         // booleans
-                        memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
+                        memset(App_Common::boolSettings, false, sizeof(App_Common::boolSettings));
                         for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
                             if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
-                                port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
+                                port.read((char*)&App_Common::boolSettings[App_Common::dataCurrent][i], sizeof(bool));
                             else if(port.bytesAvailable()) port.read(1);
                             else if(!port.waitForReadyRead(2000)) break;
                         }
-                        memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
+                        memcpy(App_Common::boolSettings[App_Common::dataOrig],
+                               App_Common::boolSettings[App_Common::dataCurrent],
+                               sizeof(App_Common::boolSettings[App_Common::dataCurrent]));
 
                         emit Serial_ProgressUpdate(2, "Getting Settings (1)");
 
                         // pins
-                        if(App_Common::boolSettings[OF_Const::customPins]) {
+                        if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]) {
                             port.clear();
                             if(OneShotSend((char)OF_Const::sGetPins, true)) {
                                 App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
@@ -165,17 +167,19 @@ bool AppSerial::GetSettings(const QString &portName)
                                 else {
                                     uint8_t i = port.read(1).at(0);
                                     if(i < OF_Const::settingsTypesCount)
-                                        port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                                        port.read((char*)&App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t));
                                 }
                             }
-                            memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
+                            memcpy(App_Common::settingsTable[App_Common::dataOrig],
+                                   App_Common::settingsTable[App_Common::dataCurrent],
+                                   sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
                             emit Serial_ProgressUpdate(5, "Getting Profiles Data");
 
                             // i2c peripherals
                             port.clear();
                             if(OneShotSend((char)OF_Const::sGetPeriphs, true)) {
-                                memset(App_Common::i2cPeriphs, 0, OF_Const::i2cDevicesCount);
+                                memset(App_Common::i2cPeriphs, 0, sizeof(App_Common::i2cPeriphs));
                                 while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
                                     if(!port.bytesAvailable()) { if(!port.waitForReadyRead(2000)) break; }
                                     else {
@@ -184,7 +188,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                         {
                                             for(int i = 0;; i++) {
                                                 if(port.bytesAvailable() && i < OF_Const::i2cDevicesCount)
-                                                    port.read((char*)&App_Common::i2cPeriphs[i], sizeof(bool));
+                                                    port.read((char*)&App_Common::i2cPeriphs[App_Common::dataCurrent][i], sizeof(bool));
                                                 else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
                                                     { port.read(1); break; }
                                                 else if(port.bytesAvailable()) port.read(1);
@@ -197,7 +201,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                                 if(port.bytesAvailable()) {
                                                     int type = port.read(1).at(0);
                                                     if(type < OF_Const::oledSettingsTypes)
-                                                        port.read((char*)&App_Common::i2cOledPrefs[type], sizeof(uint32_t));
+                                                        port.read((char*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], sizeof(uint32_t));
                                                     else port.read(sizeof(uint32_t));
                                                 } else if(!port.waitForReadyRead(2000)) break;
                                             }
@@ -206,8 +210,12 @@ bool AppSerial::GetSettings(const QString &portName)
                                         }
                                     }
                                 }
-                                memcpy(App_Common::i2cPeriphs_orig, App_Common::i2cPeriphs, sizeof(App_Common::i2cPeriphs));
-                                // when we have settings for periphs, copy those too
+                                memcpy(App_Common::i2cPeriphs[App_Common::dataOrig],
+                                       App_Common::i2cPeriphs[App_Common::dataCurrent],
+                                       sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent]));
+                                memcpy(App_Common::i2cOledPrefs[App_Common::dataOrig],
+                                       App_Common::i2cOledPrefs[App_Common::dataCurrent],
+                                       sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent]));
 
                                 emit Serial_ProgressUpdate(5, "Getting Profiles Data");
 
@@ -319,9 +327,9 @@ bool AppSerial::CommitSettings()
             emit Serial_ProgressUpdate(1, "Sending Toggles...");
             for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
                 memset(buf, '\0', 3);
-                buf[0] = (char)OF_Const::sCommitToggles, buf[1] = (char)i, buf[2] = (char)App_Common::boolSettings[i];
+                buf[0] = (char)OF_Const::sCommitToggles, buf[1] = (char)i, buf[2] = (char)App_Common::boolSettings[App_Common::dataCurrent][i];
                 if(OneShotSend(buf, 3, true)) {
-                    if(port.read(1).at(0) != App_Common::boolSettings[i]) {
+                    if(port.read(1).at(0) != App_Common::boolSettings[App_Common::dataCurrent][i]) {
                         OneShotSend((char)OF_Const::serialTerminator);
                         return false;
                     }
@@ -346,9 +354,9 @@ bool AppSerial::CommitSettings()
             for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
                 memset(buf, '\0', 6);
                 buf[0] = (char)OF_Const::sCommitSettings, buf[1] = (char)i;
-                memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t));
                 if(OneShotSend(buf, 6, true)) {
-                    if(memcmp(port.read(4).constData(), &App_Common::settingsTable[i], sizeof(uint32_t))) {
+                    if(memcmp(port.read(4).constData(), &App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t))) {
                         OneShotSend((char)OF_Const::serialTerminator);
                         return false;
                     }
@@ -393,8 +401,8 @@ bool AppSerial::CommitSettings()
                 for(int i = 0; i < OF_Const::i2cDevicesCount; i++) {
                     buf[1] = (char)OF_Const::i2cDevicesEnabled;
                     buf[2] = (char)i;
-                    buf[3] = (char)App_Common::i2cPeriphs[i];
-                    if(OneShotSend(buf, 4, true)) if(port.read(1).at(0) != App_Common::i2cPeriphs[i])
+                    buf[3] = (char)App_Common::i2cPeriphs[App_Common::dataCurrent][i];
+                    if(OneShotSend(buf, 4, true)) if(port.read(1).at(0) != App_Common::i2cPeriphs[App_Common::dataCurrent][i])
                         { OneShotSend((char)OF_Const::serialTerminator); return false; }
 
                     switch(i) {
@@ -402,8 +410,8 @@ bool AppSerial::CommitSettings()
                         buf[1] = (char)OF_Const::i2cOLED;
                         for(int type = 0; type < OF_Const::oledSettingsTypes; type++) {
                             buf[2] = (char)type;
-                            memcpy(&buf[3], (uint8_t*)&App_Common::i2cOledPrefs[type], sizeof(uint32_t));
-                            if(OneShotSend(buf, 7, true)) if(memcmp(App_Common::i2cOledPrefs, port.read(4).constData(), sizeof(uint32_t)))
+                            memcpy(&buf[3], (uint8_t*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], sizeof(uint32_t));
+                            if(OneShotSend(buf, 7, true)) if(memcmp((uint8_t*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], port.read(4).constData(), sizeof(uint32_t)))
                                 { OneShotSend((char)OF_Const::serialTerminator); return false; }
                         }
                         break;

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -21,6 +21,7 @@
 #include "appcommon.h"
 #include "../boards/OpenFIREshared.h"
 #include <QMessageBox>
+#include <qtconcurrentrun.h>
 
 bool AppSerial::SearchPorts()
 {
@@ -85,33 +86,39 @@ bool AppSerial::GetSettings(const QString &portName)
             if(char buf[] = {(char)OF_Const::sDock1, (char)OF_Const::sDock2}; OneShotSend(buf, 2, true)) {
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
-                if(buffer.at(0) == "CAMERROR: Not available") {
-                    QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
-                                         "Data received from the board indicates that the camera is in a bad state.\n"
-                                         "This can happen if the camera wires are crossed (data wire to clock pin, clock wire to data pin).\n\n"
-                                         "The camera must be removed or resoldered to resolve this.");
-                    buffer.takeFirst();
-                }
-
-                if(buffer.size() == 5) {
+                if(buffer.size() >= 5) {
                     emit Serial_SetProgressRange(5);
                     emit Serial_ProgressUpdate(1, "Getting Board Info");
 
-                    App_Common::board.versionNumber = buffer.at(0).constData();
+                    App_Common::board.versionNumber = buffer.takeFirst().constData();
                     printf("Version number: %s\n", App_Common::board.versionNumber.constData());
 
-                    App_Common::board.versionCodename = buffer.at(1).constData();
+                    App_Common::board.versionCodename = buffer.takeFirst().constData();
                     printf("Version codename: %s\n", App_Common::board.versionCodename.constData());
 
-                    App_Common::board.boardType = buffer.at(2).constData();
+                    App_Common::board.boardType = buffer.takeFirst().constData();
                     printf("Board type: %s\n", App_Common::board.boardType.constData());
 
-                    App_Common::board.selectedProfile = buffer.at(3).toInt();
+                    App_Common::board.selectedProfile = buffer.takeFirst().toInt();
                     App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
-                    memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(4).constData(), 2);
-                    App_Common::tinyUSBtable.tinyUSBname = &buffer.at(4).constData()[2];
+                    memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(0).constData(), 2);
+                    App_Common::tinyUSBtable.tinyUSBname = &buffer.takeFirst().constData()[2];
                     App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
+
+                    if(buffer.size()) if(buffer.takeFirst().at(0) == OF_Const::sError) {
+                        syncError.setIcon(QMessageBox::Warning);
+                        syncError.setWindowTitle("Device Error: Camera not available!");
+                        syncError.setText("Data received from the board indicates that the camera is in a bad state.\n"
+                                          "This can happen if, for example, the camera wires are crossed\n"
+                                          "(data wire to clock pin, clock wire to data pin),\n"
+                                          "or the camera pins are wired to a different component,\n"
+                                          "such as a button or Force Feedback output.\n\n"
+                                          "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
+                                          "if they should be mapped different GPIO;\n"
+                                          "Otherwise, the camera wires must be resoldered to resolve this error.");
+                        syncError.show();
+                    }
 
                     // toggles
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -114,7 +114,7 @@ bool AppSerial::GetSettings(const QString &portName)
                         App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
                         memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(4).constData(), 2);
-                        App_Common::tinyUSBtable.tinyUSBname.append(&buffer.at(4).constData()[2]);
+                        App_Common::tinyUSBtable.tinyUSBname = &buffer.at(4).constData()[2];
                         App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
 
                         // toggles

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -88,7 +88,7 @@ bool AppSerial::GetSettings(const QString &portName)
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
                 if(buffer.size() >= 5) {
-                    emit Serial_SetProgressRange(5);
+                    emit Serial_SetProgressRange(6);
                     emit Serial_ProgressUpdate(1, "Getting Board Info");
 
                     App_Common::board.versionNumber = buffer.takeFirst().constData();
@@ -126,7 +126,10 @@ bool AppSerial::GetSettings(const QString &portName)
                         for(uint8_t i = 0;; i++) {
                             if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
                                 port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
-                            else break;
+                            else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
+                                break;
+                            else if(port.bytesAvailable()) port.read(1);
+                            else if(!port.waitForReadyRead(2000)) break;
                         }
                         memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
 
@@ -141,13 +144,16 @@ bool AppSerial::GetSettings(const QString &portName)
                                 for(uint8_t i = 0;; i++)
                                     if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
                                         port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                    else break;
+                                    else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
+                                        break;
+                                    else if(port.bytesAvailable()) port.read(1);
+                                    else if(!port.waitForReadyRead(2000)) break;
                             } else {
                                 printf("Didn't receive any data in time!\n");
                                 return false;
                             }
                         } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                                App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
+                            App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
 
                         App_Common::inputsMap = App_Common::inputsMap_orig;
 
@@ -168,43 +174,78 @@ bool AppSerial::GetSettings(const QString &portName)
                             }
                             memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
 
-                            emit Serial_ProgressUpdate(4, "Getting Profiles Data");
+                            emit Serial_ProgressUpdate(5, "Getting Profiles Data");
 
-                            // profiles
-                            App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
-
-                            for(uint8_t i = 0;; i++) {
-                                port.clear();
-                                if(char buf[] = {(char)OF_Const::sGetProfile, (char)i}; OneShotSend(buf, 2, true)) {
-                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
-                                        break;
-                                    } else {
-                                        App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
-
-                                        while(port.bytesAvailable()) {
-                                            switch(port.read(1).at(0)) {
-                                            case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
-                                            case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
-                                            case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
-                                            case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
-                                            case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
-                                            case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
-                                            case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
-                                            case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
-                                            case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
-                                            case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
-                                            case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
-                                            default: break;
+                            // i2c peripherals
+                            port.clear();
+                            if(OneShotSend((char)OF_Const::sGetPeriphs, true)) {
+                                memset(App_Common::i2cPeriphs, 0, OF_Const::i2cDevicesCount);
+                                while(true) {
+                                    if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
+                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                    else {
+                                        switch(port.read(1).at(0)) {
+                                        case (char)OF_Const::i2cDevicesEnabled:
+                                        {
+                                            for(int i = 0;; i++) {
+                                                if(port.bytesAvailable() && i < OF_Const::i2cDevicesCount)
+                                                    port.read((char*)&App_Common::i2cPeriphs[i], sizeof(bool));
+                                                else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
+                                                    { port.read(1); break; }
+                                                else if(port.bytesAvailable()) port.read(1);
+                                                else break; // if there's no more bytes, probably no leftover settings to sync anyways
                                             }
+                                            break;
                                         }
-
-                                        App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                        case (char)OF_Const::i2cOLED:
+                                        default: break;
+                                        }
                                     }
-                                } else break;
-                            }
+                                }
+                                memcpy(App_Common::i2cPeriphs_orig, App_Common::i2cPeriphs, sizeof(App_Common::i2cPeriphs));
+                                // when we have settings for periphs, copy those too
 
-                            emit Serial_ProgressUpdate(5, "Successfully synced data!");
-                            return true;
+                                emit Serial_ProgressUpdate(5, "Getting Profiles Data");
+
+                                // profiles
+                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+
+                                for(uint8_t i = 0;; i++) {
+                                    port.clear();
+                                    if(char buf[] = {(char)OF_Const::sGetProfile, (char)i}; OneShotSend(buf, 2, true)) {
+                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
+                                            break;
+                                        } else {
+                                            App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+
+                                            while(port.bytesAvailable()) {
+                                                switch(port.read(1).at(0)) {
+                                                case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
+                                                case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
+                                                case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
+                                                default: break;
+                                                }
+                                            }
+
+                                            App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                        }
+                                    } else break;
+                                }
+
+                                emit Serial_ProgressUpdate(6, "Successfully synced data!");
+                                return true;
+                            } else {
+                                printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                return false;
+                            }
                         } else {
                             printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                             return false;
@@ -264,7 +305,7 @@ bool AppSerial::OneShotSend(const char &chara, const bool &waitForResponse)
 bool AppSerial::CommitSettings()
 {
     if(port.isOpen()) {
-        emit Serial_SetProgressRange(7);
+        emit Serial_SetProgressRange(8);
 
         if(OneShotSend((char)OF_Const::sCommitStart)) {
             port.clear();
@@ -282,7 +323,7 @@ bool AppSerial::CommitSettings()
             if(App_Common::boolSettings[OF_Const::customPins]) {
                 emit Serial_ProgressUpdate(2, "Sending Pins Map...");
                 for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
-                    if(char buf[3] = {(char)OF_Const::sCommitPins, (char)i, (char)App_Common::inputsMap.value(i)}; OneShotSend(buf, 3, true)) {
+                    if(char buf[3] = { (char)OF_Const::sCommitPins, (char)i, (char)App_Common::inputsMap.value(i) }; OneShotSend(buf, 3, true)) {
                         if(port.read(1).at(0) != App_Common::inputsMap.value(i)) {
                             OneShotSend((char)OF_Const::serialTerminator);
                             return false;
@@ -293,7 +334,7 @@ bool AppSerial::CommitSettings()
 
             emit Serial_ProgressUpdate(3, "Sending Settings...");
             for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
-                char buf[6] = {(char)OF_Const::sCommitSettings, (char)i};
+                char buf[6] = { (char)OF_Const::sCommitSettings, (char)i };
                 memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[i], sizeof(uint32_t));
                 if(OneShotSend(buf, sizeof(buf), true)) {
                     if(memcmp(port.read(4).constData(), &App_Common::settingsTable[i], sizeof(uint32_t))) {
@@ -305,33 +346,74 @@ bool AppSerial::CommitSettings()
 
             emit Serial_ProgressUpdate(4, "Sending Profile Data...");
             for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
+                char buf[19] = {(char)OF_Const::sCommitProfile,
+                                (char)i,
+                                (char)OF_Const::profIrSens,
+                                (char)App_Common::profilesTable.at(i).irSensitivity,
+                                0, 0, 0};
+                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).irSensitivity)
+                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
 
+                buf[2] = OF_Const::profRunMode, buf[3] = App_Common::profilesTable.at(i).runMode;
+                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).runMode)
+                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
+
+                buf[2] = OF_Const::profIrLayout, buf[3] = App_Common::profilesTable.at(i).layoutType;
+                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).layoutType)
+                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
+
+                buf[2] = OF_Const::profColor;
+                memcpy(&buf[3], (uint8_t*)&App_Common::profilesTable.at(i).color, sizeof(uint32_t));
+                if(OneShotSend(buf, 7, true)) if(memcmp(port.read(4).constData(), (uint8_t*)&App_Common::profilesTable.at(i).color, sizeof(uint32_t)))
+                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
+
+                buf[2] = OF_Const::profName;
+                memset(&buf[3], '\0', 16);
+                memcpy(&buf[3], App_Common::profilesTable.at(i).profName.constData(), App_Common::profilesTable.at(i).profName.length());
+                if(OneShotSend(buf, sizeof(buf), true)) if(port.read(16) != App_Common::profilesTable.at(i).profName)
+                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
             }
 
-            emit Serial_ProgressUpdate(5, "Sending TinyUSB ID Data...");
+            if(App_Common::inputsMap.value(OF_Const::periphSDA) > -1 && App_Common::inputsMap.value(OF_Const::periphSCL) > -1) {
+                emit Serial_ProgressUpdate(5, "Sending I2C Peripherals Data...");
+                char buf[20] = { (char)OF_Const::sCommitPeriphs };
+                for(int i = 0; i < OF_Const::i2cDevicesCount; i++) {
+                    buf[1] = (char)OF_Const::i2cDevicesEnabled;
+                    buf[2] = (char)i;
+                    buf[3] = (char)App_Common::i2cPeriphs[i];
+                    if(OneShotSend(buf, 4, true)) if(port.read(1).at(0) != App_Common::i2cPeriphs[i])
+                        { OneShotSend((char)OF_Const::serialTerminator); return false; }
+
+                    switch(i) {
+                    case OF_Const::i2cOLED: // OLED currently has no settings
+                    default: break;
+                    }
+                }
+            }
+
+            emit Serial_ProgressUpdate(6, "Sending TinyUSB ID Data...");
             char buf[18] = {(char)OF_Const::sCommitID, (char)OF_Const::usbPID};
             memcpy(&buf[2], (uint8_t*)&App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t));
             if(OneShotSend(buf, 4, true)) {
                 if(memcmp(port.read(2).constData(), &App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t))) {
                     OneShotSend((char)OF_Const::serialTerminator);
                     return false;
-                } else {
-                    memset(&buf[1], '\0', sizeof(buf)-1);
-                    buf[1] = (char)OF_Const::usbName;
-                    memcpy(&buf[2], (uint8_t*)App_Common::tinyUSBtable.tinyUSBname.constData(), App_Common::tinyUSBtable.tinyUSBname.size());
-                    if(OneShotSend(buf, sizeof(buf), true)) {
-                        if(strcmp(port.read(16).constData(), App_Common::tinyUSBtable.tinyUSBname.constData())) {
-                            OneShotSend((char)OF_Const::serialTerminator);
-                            return false;
-                        }
-                    } else return false;
                 }
+                memset(&buf[1], '\0', sizeof(buf)-1);
+                buf[1] = (char)OF_Const::usbName;
+                memcpy(&buf[2], (uint8_t*)App_Common::tinyUSBtable.tinyUSBname.constData(), App_Common::tinyUSBtable.tinyUSBname.size());
+                if(OneShotSend(buf, sizeof(buf), true)) {
+                    if(strcmp(port.read(16).constData(), App_Common::tinyUSBtable.tinyUSBname.constData())) {
+                        OneShotSend((char)OF_Const::serialTerminator);
+                        return false;
+                    }
+                } else return false;
             } else return false;
 
-            emit Serial_ProgressUpdate(6, "Saving...");
+            emit Serial_ProgressUpdate(7, "Saving...");
             if(OneShotSend((char)OF_Const::sSave, true)) {
                 if(char newBuf[2] = {(char)OF_Const::sSave, (char)true}; memcmp(port.read(2).constData(), newBuf, sizeof(newBuf))) {
-                    emit Serial_ProgressUpdate(7);
+                    emit Serial_ProgressUpdate(8);
                     return true;
                 } else return false;
             } else return false;

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -273,7 +273,7 @@ bool AppSerial::CommitSettings()
 
         serialQueue.append(QString("Xm.3.0.%1").arg(App_Common::tinyUSBtable.tinyUSBid));
         if(!App_Common::tinyUSBtable.tinyUSBname.isEmpty())
-            serialQueue.append(QString("Xm.3.1.%1").arg(App_Common::tinyUSBtable.tinyUSBname));
+            serialQueue.append("Xm.3.1." + App_Common::tinyUSBtable.tinyUSBname);
 
         for(uint8_t i = 0; i < 4; i++) {
             serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).irSensitivity));

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -130,7 +130,7 @@ bool AppSerial::GetSettings(const QString &portName)
 
                                 port.clear();
 
-                                // get toggles
+                                // toggles
                                 port.write("Xlb");
                                 port.waitForBytesWritten(500);
                                 if(port.waitForReadyRead(500)) {
@@ -140,7 +140,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                     // booleans
                                     for(uint8_t i = 0; i < buffer.count(); i++) {
                                         if(i < sizeof(App_Common::boolSettings)) {
-                                            App_Common::boolSettings[i] = buffer[i].toInt();
+                                            App_Common::boolSettings[i] = buffer.at(i).toInt();
                                             App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
                                         } else break;
                                     }
@@ -181,7 +181,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                         buffer = bufStr.split(',');
                                         for(uint8_t i = 0; i < buffer.count(); i++) {
                                             if(i < sizeof(App_Common::settingsTable) / 4) {
-                                                App_Common::settingsTable[i] = buffer[i].toInt();
+                                                App_Common::settingsTable[i] = buffer.at(i).toInt();
                                                 App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
                                             } else break;
                                         }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -203,24 +203,28 @@ bool AppSerial::GetSettings(const QString &portName)
                                             if(port.waitForReadyRead(500)) {
                                                 // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
                                                 bufStr = port.readLine().trimmed();
-                                                buffer = bufStr.split(',');
+                                                if(bufStr.startsWith("PROFERR:")) {
+                                                    break;
+                                                } else {
+                                                    buffer = bufStr.split(',');
 
-                                                App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+                                                    App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
 
-                                                // copy settings
-                                                App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                                                App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                                                App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                                                App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                                App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+                                                    // copy settings
+                                                    App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
+                                                    App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
+                                                    App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
+                                                    App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
+                                                    App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
 
-                                                App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                                    App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                                }
                                             } else break;
                                         }
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -168,9 +168,9 @@ bool AppSerial::GetSettings(const QString &portName)
                                             App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
                                     }
 
-                                    emit Serial_ProgressUpdate(3, "Getting Settings (3)");
-
                                     App_Common::inputsMap = App_Common::inputsMap_orig;
+
+                                    emit Serial_ProgressUpdate(3, "Getting Settings (3)");
 
                                     // settings
                                     port.clear();

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -113,119 +113,124 @@ bool AppSerial::GetSettings(const QString &portName)
                         // get TUSB info
                         port.write("Xli");
                         port.waitForBytesWritten(500);
-                        port.waitForReadyRead(500);
+                        if(port.waitForReadyRead(500)) {
+                            bufStr = port.readLine().trimmed();
+                            buffer = bufStr.split(',');
+                            if(buffer.size() == 2) {
+                                App_Common::tinyUSBtable.tinyUSBid = buffer.at(0);
+                                App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
 
-                        bufStr = port.readLine().trimmed();
-                        buffer = bufStr.split(',');
-                        App_Common::tinyUSBtable.tinyUSBid = buffer.at(0);
-                        App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
+                                if(buffer.at(1) == "SERIALREADERR01")
+                                    App_Common::tinyUSBtable.tinyUSBname = "";
+                                else App_Common::tinyUSBtable.tinyUSBname = buffer.at(1);
 
-                        if(buffer[1] == "SERIALREADERR01")
-                            App_Common::tinyUSBtable.tinyUSBname = "";
-                        else App_Common::tinyUSBtable.tinyUSBname = buffer.at(1);
+                                App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
 
-                        App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
+                                emit Serial_ProgressUpdate(1, "Getting Settings (1)");
 
-                        emit Serial_ProgressUpdate(1, "Getting Settings (1)");
-
-                        port.clear();
-
-                        // get toggles
-                        port.write("Xlb");
-                        if(port.waitForBytesWritten(500)) {
-                            if(port.waitForReadyRead(500)) {
-                                QString bufStr = port.readLine().trimmed();
-                                QStringList buffer = bufStr.split(',');
-
-                                // booleans
-                                for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
-                                    if(!buffer.isEmpty()) {
-                                        App_Common::boolSettings[i] = buffer[i].toInt();
-                                        App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
-                                    } else break;
-                                }
-
-                                emit Serial_ProgressUpdate(2, "Getting Settings (2)");
-
-                                // pins
-                                if(App_Common::boolSettings[OF_Const::customPins]) {
-                                    port.clear();
-                                    port.write("Xlp");
-                                    port.waitForBytesWritten(500);
-                                    port.waitForReadyRead(500);
-                                    App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
-                                    bufStr = port.readLine().trimmed();
-                                    buffer = bufStr.split(',');
-                                    for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
-                                        if(!buffer.isEmpty())
-                                            App_Common::inputsMap_orig[i] = buffer[i].toInt();
-                                        else break;
-                                    }
-                                } else {
-                                    for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                                        App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
-                                }
-
-                                emit Serial_ProgressUpdate(3, "Getting Settings (3)");
-
-                                App_Common::inputsMap = App_Common::inputsMap_orig;
-
-                                // settings
                                 port.clear();
-                                port.write("Xls");
+
+                                // get toggles
+                                port.write("Xlb");
                                 port.waitForBytesWritten(500);
-                                port.waitForReadyRead(500);
-                                bufStr = port.readLine().trimmed();
-                                buffer = bufStr.split(',');
-                                for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
-                                    if(!buffer.isEmpty()) {
-                                        App_Common::settingsTable[i] = buffer[i].toInt();
-                                        App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
-                                    } else break;
-                                }
+                                if(port.waitForReadyRead(500)) {
+                                    QString bufStr = port.readLine().trimmed();
+                                    QStringList buffer = bufStr.split(',');
 
-                                emit Serial_ProgressUpdate(4, "Getting Profiles Data");
+                                    // booleans
+                                    for(uint8_t i = 0; i < buffer.count(); i++) {
+                                        if(i < sizeof(App_Common::boolSettings)) {
+                                            App_Common::boolSettings[i] = buffer[i].toInt();
+                                            App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
+                                        } else break;
+                                    }
 
-                                // profiles
-                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+                                    emit Serial_ProgressUpdate(2, "Getting Settings (2)");
 
-                                for(uint8_t i = 0;; i++) {
+                                    // pins
+                                    if(App_Common::boolSettings[OF_Const::customPins]) {
+                                        port.clear();
+                                        port.write("Xlp");
+                                        port.waitForBytesWritten(500);
+                                        if(port.waitForReadyRead(500)) {
+                                            App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
+
+                                            bufStr = port.readLine().trimmed();
+                                            buffer = bufStr.split(',');
+                                            for(uint8_t i = 0; i < buffer.count(); i++)
+                                                App_Common::inputsMap_orig[i] = buffer.at(i).toInt();
+                                        } else {
+                                            printf("Didn't receive any data in time!\n");
+                                            return false;
+                                        }
+                                    } else {
+                                        for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                                            App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
+                                    }
+
+                                    emit Serial_ProgressUpdate(3, "Getting Settings (3)");
+
+                                    App_Common::inputsMap = App_Common::inputsMap_orig;
+
+                                    // settings
                                     port.clear();
-                                    port.write("XlP" + QByteArray::number(i));
+                                    port.write("Xls");
                                     port.waitForBytesWritten(500);
                                     if(port.waitForReadyRead(500)) {
-                                        // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
                                         bufStr = port.readLine().trimmed();
                                         buffer = bufStr.split(',');
+                                        for(uint8_t i = 0; i < buffer.count(); i++) {
+                                            if(i < sizeof(App_Common::settingsTable) / 4) {
+                                                App_Common::settingsTable[i] = buffer[i].toInt();
+                                                App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
+                                            } else break;
+                                        }
 
-                                        App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+                                        emit Serial_ProgressUpdate(4, "Getting Profiles Data");
 
-                                        // copy settings
-                                        App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                                        App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                                        App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                                        App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                        App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+                                        // profiles
+                                        App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
 
-                                        App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
-                                    } else break;
+                                        for(uint8_t i = 0;; i++) {
+                                            port.clear();
+                                            port.write("XlP" + QByteArray::number(i));
+                                            port.waitForBytesWritten(500);
+                                            if(port.waitForReadyRead(500)) {
+                                                // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
+                                                bufStr = port.readLine().trimmed();
+                                                buffer = bufStr.split(',');
+
+                                                App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+
+                                                // copy settings
+                                                App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
+                                                App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
+                                                App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
+                                                App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
+                                                App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+
+                                                App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                            } else break;
+                                        }
+
+                                        emit Serial_ProgressUpdate(5, "Successfully synced data!");
+                                        return true;
+                                    } else {
+                                        printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                        return false;
+                                    }
+                                } else {
+                                    printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                    return false;
                                 }
-
-                                emit Serial_ProgressUpdate(5, "Successfully synced data!");
-
-                                return true;
-
                             } else {
-                                QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
-                                                                 "Device was detected, but settings request wasn't received in time!\n"
-                                                                 "This can happen if the app was closed in the middle of an operation.\n\n"
-                                                                 "Try selecting the device again.");
+                                printf("Port did not respond with expected response! Got: %s", bufStr.constData());
                                 return false;
                             }
                         } else {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -67,8 +67,10 @@ QStringList AppSerial::GeneratePortsList(const QList<QSerialPortInfo> &portsList
 
 bool AppSerial::GetSettings(const QString &portName)
 {
-    if(port.isOpen())
+    if(port.isOpen()) {
+        OneShotSend("XE");
         port.close();
+    }
 
     for(const auto &curPort : currentPorts)
         if(portName == curPort.portName()+" (" + curPort.description() + ')')

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -67,8 +67,11 @@ QStringList AppSerial::GeneratePortsList(const QList<QSerialPortInfo> &portsList
 
 bool AppSerial::GetSettings(const QString &portName)
 {
+    if(port.isOpen())
+        port.close();
+
     for(const auto &curPort : currentPorts)
-        if(portName == curPort.portName())
+        if(portName == curPort.portName()+" (" + curPort.description() + ')')
             port.setPort(curPort);
 
     if(!port.portName().isEmpty()) {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -87,7 +87,7 @@ bool AppSerial::GetSettings(const QString &portName)
             port.write("XP");
             if(port.waitForBytesWritten(500)) {
                 if(port.waitForReadyRead(500)) {
-                    QList<QByteArray> buffer = port.readLine().trimmed().split(',');
+                    QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
                     if(buffer.at(0) == "CAMERROR: Not available") {
                         QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
@@ -97,150 +97,126 @@ bool AppSerial::GetSettings(const QString &portName)
                         buffer.takeFirst();
                     }
 
-                    if(buffer.size() == 5 && buffer.at(0).contains("OpenFIRE")) {
-                        printf("OpenFIRE gun detected!\n");
-
+                    if(buffer.size() == 5) {
                         emit Serial_SetProgressRange(5);
+                        emit Serial_ProgressUpdate(1, "Getting Board Info");
 
-                        App_Common::board.versionNumber = buffer.at(1).constData();
-                        printf("Version number: %s\n", App_Common::board.versionNumber.toLocal8Bit().constData());
+                        App_Common::board.versionNumber = buffer.at(0).constData();
+                        printf("Version number: %s\n", App_Common::board.versionNumber.constData());
 
-                        App_Common::board.versionCodename = buffer.at(2).constData();
-                        printf("Version codename: %s\n", App_Common::board.versionCodename.toLocal8Bit().constData());
+                        App_Common::board.versionCodename = buffer.at(1).constData();
+                        printf("Version codename: %s\n", App_Common::board.versionCodename.constData());
 
-                        App_Common::board.boardType = buffer.at(3).constData();
-                        printf("Board type: %s\n", App_Common::board.boardType.toLocal8Bit().constData());
+                        App_Common::board.boardType = buffer.at(2).constData();
+                        printf("Board type: %s\n", App_Common::board.boardType.constData());
 
-                        App_Common::board.selectedProfile = buffer.at(4).toInt();
+                        App_Common::board.selectedProfile = buffer.at(3).toInt();
                         App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
-                        // get TUSB info
-                        port.write("Xli");
+                        memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(4).constData(), 2);
+                        App_Common::tinyUSBtable.tinyUSBname.append(&buffer.at(4).constData()[2]);
+                        App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
+
+                        // toggles
+                        port.write("Xlb");
                         port.waitForBytesWritten(500);
                         if(port.waitForReadyRead(500)) {
-                            buffer = port.readLine().trimmed().split(',');
-                            if(buffer.size() == 2) {
-                                App_Common::tinyUSBtable.tinyUSBid = buffer.at(0);
-                                App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
+                            // booleans
+                            memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
+                            for(uint8_t i = 0;; i++) {
+                                if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
+                                    port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
+                                else break;
+                            }
+                            memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
 
-                                if(buffer.at(1) == "SERIALREADERR01")
-                                    App_Common::tinyUSBtable.tinyUSBname = "";
-                                else App_Common::tinyUSBtable.tinyUSBname = buffer.at(1);
+                            emit Serial_ProgressUpdate(2, "Getting Settings (1)");
 
-                                App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
-
-                                emit Serial_ProgressUpdate(1, "Getting Settings (1)");
-
+                            // pins
+                            if(App_Common::boolSettings[OF_Const::customPins]) {
                                 port.clear();
-
-                                // toggles
-                                port.write("Xlb");
+                                port.write("Xlp");
                                 port.waitForBytesWritten(500);
                                 if(port.waitForReadyRead(500)) {
-                                    // booleans
-                                    memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
-                                    for(uint8_t i = 0;; i++) {
-                                        if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
-                                            port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
+                                    App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
+
+                                    for(uint8_t i = 0;; i++)
+                                        if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
+                                            port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
                                         else break;
-                                    }
-                                    memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
-
-                                    emit Serial_ProgressUpdate(2, "Getting Settings (2)");
-
-                                    // pins
-                                    if(App_Common::boolSettings[OF_Const::customPins]) {
-                                        port.clear();
-                                        port.write("Xlp");
-                                        port.waitForBytesWritten(500);
-                                        if(port.waitForReadyRead(500)) {
-                                            App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
-
-                                            for(uint8_t i = 0;; i++)
-                                                if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
-                                                    port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                                else break;
-                                        } else {
-                                            printf("Didn't receive any data in time!\n");
-                                            return false;
-                                        }
-                                    } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                                            App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
-
-                                    App_Common::inputsMap = App_Common::inputsMap_orig;
-
-                                    emit Serial_ProgressUpdate(3, "Getting Settings (3)");
-
-                                    // settings
-                                    port.clear();
-                                    port.write("Xls");
-                                    port.waitForBytesWritten(500);
-                                    if(port.waitForReadyRead(500)) {
-                                        memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                                        while(true) {
-                                            if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
-                                            if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                            else {
-                                                uint8_t i = port.read(1).at(0);
-                                                if(i < OF_Const::settingsTypesCount)
-                                                    port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
-                                            }
-                                        }
-                                        memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
-
-                                        emit Serial_ProgressUpdate(4, "Getting Profiles Data");
-
-                                        // profiles
-                                        App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
-
-                                        for(uint8_t i = 0;; i++) {
-                                            port.clear();
-                                            port.write("XlP" + QByteArray::number(i));
-                                            port.waitForBytesWritten(500);
-                                            if(port.waitForReadyRead(500)) {
-                                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
-                                                    break;
-                                                } else {
-                                                    App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
-
-                                                    while(port.bytesAvailable()) {
-                                                        switch(port.read(1).at(0)) {
-                                                        case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
-                                                        case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
-                                                        case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
-                                                        case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
-                                                        case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
-                                                        case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
-                                                        case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
-                                                        case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
-                                                        case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
-                                                        case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
-                                                        case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
-                                                        default: break;
-                                                        }
-                                                    }
-
-                                                    App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
-                                                }
-                                            } else break;
-                                        }
-
-                                        emit Serial_ProgressUpdate(5, "Successfully synced data!");
-                                        return true;
-                                    } else {
-                                        printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
-                                        return false;
-                                    }
                                 } else {
-                                    printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                    printf("Didn't receive any data in time!\n");
                                     return false;
                                 }
+                            } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                                    App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
+
+                            App_Common::inputsMap = App_Common::inputsMap_orig;
+
+                            emit Serial_ProgressUpdate(3, "Getting Settings (2)");
+
+                            // settings
+                            port.clear();
+                            port.write("Xls");
+                            port.waitForBytesWritten(500);
+                            if(port.waitForReadyRead(500)) {
+                                memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
+                                while(true) {
+                                    if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
+                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                    else {
+                                        uint8_t i = port.read(1).at(0);
+                                        if(i < OF_Const::settingsTypesCount)
+                                            port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                                    }
+                                }
+                                memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
+
+                                emit Serial_ProgressUpdate(4, "Getting Profiles Data");
+
+                                // profiles
+                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+
+                                for(uint8_t i = 0;; i++) {
+                                    port.clear();
+                                    port.write("XlP" + QByteArray::number(i));
+                                    port.waitForBytesWritten(500);
+                                    if(port.waitForReadyRead(500)) {
+                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
+                                            break;
+                                        } else {
+                                            App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+
+                                            while(port.bytesAvailable()) {
+                                                switch(port.read(1).at(0)) {
+                                                case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
+                                                case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
+                                                case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
+                                                case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
+                                                case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
+                                                default: break;
+                                                }
+                                            }
+
+                                            App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                        }
+                                    } else break;
+                                }
+
+                                emit Serial_ProgressUpdate(5, "Successfully synced data!");
+                                return true;
                             } else {
-                                printf("Port did not respond with expected response! Got: %s", buffer.at(0).constData());
+                                printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                                 return false;
                             }
                         } else {
-                            printf("Couldn't send any data in time! Does the port even exist???\n");
+                            printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                             return false;
                         }
                     } else {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -108,14 +108,14 @@ bool AppSerial::GetSettings(const QString &portName)
 
                     if(buffer.size()) if(buffer.takeFirst().at(0) == OF_Const::sError)
                         ShowError("Device Error: Camera not available!",
-                                  "Data received from the board indicates that the camera is in a bad state.\n"
-                                  "This can happen if, for example, the camera wires are crossed\n"
-                                  "(data wire to clock pin, clock wire to data pin),\n"
-                                  "or the camera pins are wired to a different component,\n"
-                                  "such as a button or Force Feedback output.\n\n"
-                                  "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
-                                  "if they should be mapped different GPIO;\n"
-                                  "Otherwise, the camera wires must be resoldered to resolve this error.",
+                                  "<p>Data received from the board indicates that the camera is in a bad state.<br>"
+                                  "This can happen if, for example, the camera wires are crossed<br>"
+                                  "(data wire to clock pin, clock wire to data pin),<br>"
+                                  "or the camera pins are wired to a different component,<br>"
+                                  "such as a button or Force Feedback output.</p>"
+                                  "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
+                                  "if they should be mapped different GPIO;<br>"
+                                  "Otherwise, the camera wires must be resoldered to resolve this error.</p>",
                                   QMessageBox::Warning);
 
                     // toggles

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -378,7 +378,7 @@ bool AppSerial::CommitSettings()
                 buf[2] = OF_Const::profName;
                 memset(&buf[3], '\0', 16);
                 memcpy(&buf[3], App_Common::profilesTable.at(i).profName.constData(), App_Common::profilesTable.at(i).profName.length());
-                if(OneShotSend(buf, 19, true)) if(port.read(16) != App_Common::profilesTable.at(i).profName)
+                if(OneShotSend(buf, 19, true)) if(strcmp(port.read(16).constData(), App_Common::profilesTable.at(i).profName.constData()))
                     { OneShotSend((char)OF_Const::serialTerminator); return false; }
             }
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -309,7 +309,7 @@ bool AppSerial::CommitSettings()
 void AppSerial::Disconnect()
 {
     char buf[] = {(char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator};
-    OneShotSend(buf);
+    OneShotSend(buf, 3);
     port.close();
 
     port.setPortName("");

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -140,7 +140,6 @@ bool AppSerial::GetSettings(const QString &portName)
                                 App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
                                 for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
-                                    qDebug() << port.peek(port.bytesAvailable());
                                     if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
                                         port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
                                     else if(port.bytesAvailable()) port.read(1);

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -21,7 +21,6 @@
 #include "appcommon.h"
 #include "../boards/OpenFIREshared.h"
 #include <QMessageBox>
-#include <QDebug>
 
 bool AppSerial::SearchPorts()
 {
@@ -142,7 +141,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                 if(port.waitForReadyRead(500)) {
                                     // booleans
                                     for(uint8_t i = 0;; i++) {
-                                        if(!port.atEnd() && i < sizeof(App_Common::boolSettings)) {
+                                        if(!port.atEnd() && i < OF_Const::boolTypesCount) {
                                             char buf;
                                             port.read(&buf, 1);
                                             App_Common::boolSettings[i] = buf-32;
@@ -161,10 +160,9 @@ bool AppSerial::GetSettings(const QString &portName)
                                             App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
                                             for(uint8_t i = 0;; i++)
-                                                if(!port.atEnd() && i < sizeof(OF_Const::boardInputsCount)) {
+                                                if(!port.atEnd() && i < OF_Const::boardInputsCount) {
                                                     port.read((char*)&App_Common::inputsMap_orig[i], 1);
                                                     App_Common::inputsMap_orig[i] -= 32;
-                                                    printf("%i ", App_Common::inputsMap_orig.value(i));
                                                 } else break;
                                         } else {
                                             printf("Didn't receive any data in time!\n");

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -227,7 +227,7 @@ bool AppSerial::GetSettings(const QString &portName)
     } else return false;
 }
 
-bool AppSerial::OneShotSend(const QByteArray &string, const unsigned int &len, const bool &waitForResponse)
+bool AppSerial::OneShotSend(const char* string, const unsigned int &len, const bool &waitForResponse)
 {
     if(port.isOpen()) {
         port.write((len > 0) ? string : string, len);

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -1,5 +1,24 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Serial input/output routines.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "appserial.h"
-#include "constants.h"
+#include "appcommon.h"
 #include "../boards/OpenFIREshared.h"
 #include <QMessageBox>
 
@@ -24,10 +43,10 @@ bool AppSerial::SearchPorts()
             printf("Current ports list does not match new list, overriding...\n");
             currentPortsNames = GeneratePortsList(currentPorts);
             return true;
-        } else for(const auto &port : serialFoundList) {
-            if(!currentPortsNames.contains(port.portName())) {
+        } else for(const auto &foundPort : serialFoundList) {
+            if(!currentPortsNames.contains(foundPort.portName())) {
                 currentPorts = serialFoundList;
-                printf("%s not found in current ports, overriding old serial devices list...\n", port.portName().toLocal8Bit().constData());
+                printf("%s not found in current ports, overriding old serial devices list...\n", foundPort.portName().toLocal8Bit().constData());
                 currentPortsNames = GeneratePortsList(currentPorts);
                 return true;
             }
@@ -40,8 +59,8 @@ QStringList AppSerial::GeneratePortsList(const QList<QSerialPortInfo> &portsList
 {
     QStringList newList;
 
-    for(const auto &port : portsList)
-        newList.append(port.portName());
+    for(const auto &newPort : portsList)
+        newList.append(newPort.portName());
 
     return newList;
 }
@@ -74,22 +93,22 @@ bool AppSerial::GetSettings(const QString &portName)
                         buffer.takeFirst();
                     }
 
-                    if(buffer.at(0).contains("OpenFIRE")) {
+                    if(buffer.size() == 5 && buffer.at(0).contains("OpenFIRE")) {
                         printf("OpenFIRE gun detected!\n");
 
                         emit Serial_SetProgressRange(5);
 
-                        App_Const::board.versionNumber = buffer.at(1).constData();
-                        printf("Version number: %s\n", App_Const::board.versionNumber.toLocal8Bit().constData());
+                        App_Common::board.versionNumber = buffer.at(1).constData();
+                        printf("Version number: %s\n", App_Common::board.versionNumber.toLocal8Bit().constData());
 
-                        App_Const::board.versionCodename = buffer.at(2).constData();
-                        printf("Version codename: %s\n", App_Const::board.versionCodename.toLocal8Bit().constData());
+                        App_Common::board.versionCodename = buffer.at(2).constData();
+                        printf("Version codename: %s\n", App_Common::board.versionCodename.toLocal8Bit().constData());
 
-                        App_Const::board.boardType = buffer.at(3).constData();
-                        printf("Board type: %s\n", App_Const::board.boardType.toLocal8Bit().constData());
+                        App_Common::board.boardType = buffer.at(3).constData();
+                        printf("Board type: %s\n", App_Common::board.boardType.toLocal8Bit().constData());
 
-                        App_Const::board.selectedProfile = buffer.at(4).toInt();
-                        App_Const::board.previousProfile = App_Const::board.selectedProfile;
+                        App_Common::board.selectedProfile = buffer.at(4).toInt();
+                        App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
                         // get TUSB info
                         port.write("Xli");
@@ -98,14 +117,14 @@ bool AppSerial::GetSettings(const QString &portName)
 
                         bufStr = port.readLine().trimmed();
                         buffer = bufStr.split(',');
-                        App_Const::tinyUSBtable.tinyUSBid = buffer.at(0);
-                        App_Const::tinyUSBtable_orig.tinyUSBid = App_Const::tinyUSBtable.tinyUSBid;
+                        App_Common::tinyUSBtable.tinyUSBid = buffer.at(0);
+                        App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
 
                         if(buffer[1] == "SERIALREADERR01")
-                            App_Const::tinyUSBtable.tinyUSBname = "";
-                        else App_Const::tinyUSBtable.tinyUSBname = buffer.at(1);
+                            App_Common::tinyUSBtable.tinyUSBname = "";
+                        else App_Common::tinyUSBtable.tinyUSBname = buffer.at(1);
 
-                        App_Const::tinyUSBtable_orig.tinyUSBname = App_Const::tinyUSBtable.tinyUSBname;
+                        App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
 
                         emit Serial_ProgressUpdate(1, "Getting Settings (1)");
 
@@ -121,35 +140,35 @@ bool AppSerial::GetSettings(const QString &portName)
                                 // booleans
                                 for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
                                     if(!buffer.isEmpty()) {
-                                        App_Const::boolSettings[i] = buffer[i].toInt();
-                                        App_Const::boolSettings_orig[i] = App_Const::boolSettings[i];
+                                        App_Common::boolSettings[i] = buffer[i].toInt();
+                                        App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
                                     } else break;
                                 }
 
                                 emit Serial_ProgressUpdate(2, "Getting Settings (2)");
 
                                 // pins
-                                if(App_Const::boolSettings[OF_Const::customPins]) {
+                                if(App_Common::boolSettings[OF_Const::customPins]) {
                                     port.clear();
                                     port.write("Xlp");
                                     port.waitForBytesWritten(500);
                                     port.waitForReadyRead(500);
-                                    App_Const::inputsMap_orig.clear(), App_Const::inputsMap.clear();
+                                    App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
                                     bufStr = port.readLine().trimmed();
                                     buffer = bufStr.split(',');
                                     for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
                                         if(!buffer.isEmpty())
-                                            App_Const::inputsMap_orig[i] = buffer[i].toInt();
+                                            App_Common::inputsMap_orig[i] = buffer[i].toInt();
                                         else break;
                                     }
                                 } else {
                                     for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                                        App_Const::inputsMap_orig[i] = OF_Const::btnUnmapped;
+                                        App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
                                 }
 
                                 emit Serial_ProgressUpdate(3, "Getting Settings (3)");
 
-                                App_Const::inputsMap = App_Const::inputsMap_orig;
+                                App_Common::inputsMap = App_Common::inputsMap_orig;
 
                                 // settings
                                 port.clear();
@@ -160,15 +179,15 @@ bool AppSerial::GetSettings(const QString &portName)
                                 buffer = bufStr.split(',');
                                 for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
                                     if(!buffer.isEmpty()) {
-                                        App_Const::settingsTable[i] = buffer[i].toInt();
-                                        App_Const::settingsTable_orig[i] = App_Const::settingsTable[i];
+                                        App_Common::settingsTable[i] = buffer[i].toInt();
+                                        App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
                                     } else break;
                                 }
 
                                 emit Serial_ProgressUpdate(4, "Getting Profiles Data");
 
                                 // profiles
-                                App_Const::profilesTable.clear(), App_Const::profilesTable_orig.clear();
+                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
 
                                 for(uint8_t i = 0;; i++) {
                                     port.clear();
@@ -179,22 +198,22 @@ bool AppSerial::GetSettings(const QString &portName)
                                         bufStr = port.readLine().trimmed();
                                         buffer = bufStr.split(',');
 
-                                        App_Const::profilesTable << App_Const::profilesTable_s(), App_Const::profilesTable_orig << App_Const::profilesTable_s();
+                                        App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
 
                                         // copy settings
-                                        App_Const::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                                        App_Const::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                                        App_Const::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                                        App_Const::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                        App_Const::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+                                        App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
+                                        App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
+                                        App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
+                                        App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
+                                        App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
 
-                                        App_Const::profilesTable_orig[i] = App_Const::profilesTable.at(i);
+                                        App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
                                     } else break;
                                 }
 
@@ -202,10 +221,13 @@ bool AppSerial::GetSettings(const QString &portName)
 
                                 return true;
 
-                            } else QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
+                            } else {
+                                QMessageBox::warning(nullptr, "Sync Error: Data hasn't arrived!!",
                                                                  "Device was detected, but settings request wasn't received in time!\n"
                                                                  "This can happen if the app was closed in the middle of an operation.\n\n"
                                                                  "Try selecting the device again.");
+                                return false;
+                            }
                         } else {
                             printf("Couldn't send any data in time! Does the port even exist???\n");
                             return false;
@@ -232,7 +254,6 @@ bool AppSerial::GetSettings(const QString &portName)
             return false;
         }
     } else return false;
-    return false;
 }
 
 bool AppSerial::OneShotSend(const QByteArray &string)
@@ -254,25 +275,25 @@ bool AppSerial::CommitSettings()
 
         QStringList serialQueue;
         for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++)
-            serialQueue.append(QString("Xm.0.%1.%2").arg(i).arg(App_Const::boolSettings[i]));
+            serialQueue.append(QString("Xm.0.%1.%2").arg(i).arg(App_Common::boolSettings[i]));
 
-        if(App_Const::boolSettings[OF_Const::customPins])
-            for(uint8_t i = 0; i < App_Const::inputsMap.count(); i++)
-                serialQueue.append(QString("Xm.1.%1.%2").arg(i).arg(App_Const::inputsMap.value(i)));
+        if(App_Common::boolSettings[OF_Const::customPins])
+            for(uint8_t i = 0; i < App_Common::inputsMap.count(); i++)
+                serialQueue.append(QString("Xm.1.%1.%2").arg(i).arg(App_Common::inputsMap.value(i)));
 
         for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-            serialQueue.append(QString("Xm.2.%1.%2").arg(i).arg(App_Const::settingsTable[i]));
+            serialQueue.append(QString("Xm.2.%1.%2").arg(i).arg(App_Common::settingsTable[i]));
 
-        serialQueue.append(QString("Xm.3.0.%1").arg(App_Const::tinyUSBtable.tinyUSBid));
-        if(!App_Const::tinyUSBtable.tinyUSBname.isEmpty())
-            serialQueue.append(QString("Xm.3.1.%1").arg(App_Const::tinyUSBtable.tinyUSBname));
+        serialQueue.append(QString("Xm.3.0.%1").arg(App_Common::tinyUSBtable.tinyUSBid));
+        if(!App_Common::tinyUSBtable.tinyUSBname.isEmpty())
+            serialQueue.append(QString("Xm.3.1.%1").arg(App_Common::tinyUSBtable.tinyUSBname));
 
         for(uint8_t i = 0; i < 4; i++) {
-            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Const::profilesTable[i].irSensitivity));
-            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Const::profilesTable[i].runMode));
-            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Const::profilesTable[i].layoutType));
-            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Const::profilesTable[i].color));
-            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(App_Const::profilesTable[i].profName));
+            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Common::profilesTable[i].irSensitivity));
+            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Common::profilesTable[i].runMode));
+            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Common::profilesTable[i].layoutType));
+            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Common::profilesTable[i].color));
+            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(App_Common::profilesTable[i].profName));
         }
         serialQueue.append("XS");
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -21,6 +21,7 @@
 #include "appcommon.h"
 #include "../boards/OpenFIREshared.h"
 #include <QMessageBox>
+#include <QDebug>
 
 bool AppSerial::SearchPorts()
 {
@@ -139,13 +140,12 @@ bool AppSerial::GetSettings(const QString &portName)
                                 port.write("Xlb");
                                 port.waitForBytesWritten(500);
                                 if(port.waitForReadyRead(500)) {
-                                    QString bufStr = port.readLine().trimmed();
-                                    QStringList buffer = bufStr.split(',');
-
                                     // booleans
-                                    for(uint8_t i = 0; i < buffer.count(); i++) {
-                                        if(i < sizeof(App_Common::boolSettings)) {
-                                            App_Common::boolSettings[i] = buffer.at(i).toInt();
+                                    for(uint8_t i = 0;; i++) {
+                                        if(!port.atEnd() && i < sizeof(App_Common::boolSettings)) {
+                                            char buf;
+                                            port.read(&buf, 1);
+                                            App_Common::boolSettings[i] = buf-32;
                                             App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
                                         } else break;
                                     }
@@ -160,10 +160,12 @@ bool AppSerial::GetSettings(const QString &portName)
                                         if(port.waitForReadyRead(500)) {
                                             App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
-                                            bufStr = port.readLine().trimmed();
-                                            buffer = bufStr.split(',');
-                                            for(uint8_t i = 0; i < buffer.count(); i++)
-                                                App_Common::inputsMap_orig[i] = buffer.at(i).toInt();
+                                            for(uint8_t i = 0;; i++)
+                                                if(!port.atEnd() && i < sizeof(OF_Const::boardInputsCount)) {
+                                                    port.read((char*)&App_Common::inputsMap_orig[i], 1);
+                                                    App_Common::inputsMap_orig[i] -= 32;
+                                                    printf("%i ", App_Common::inputsMap_orig.value(i));
+                                                } else break;
                                         } else {
                                             printf("Didn't receive any data in time!\n");
                                             return false;
@@ -182,12 +184,18 @@ bool AppSerial::GetSettings(const QString &portName)
                                     port.write("Xls");
                                     port.waitForBytesWritten(500);
                                     if(port.waitForReadyRead(500)) {
-                                        bufStr = port.readLine().trimmed();
-                                        buffer = bufStr.split(',');
-                                        for(uint8_t i = 0; i < buffer.count(); i++) {
-                                            if(i < sizeof(App_Common::settingsTable) / 4) {
-                                                App_Common::settingsTable[i] = buffer.at(i).toInt();
-                                                App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
+                                        for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
+                                            if(i < OF_Const::settingsTypesCount) {
+                                                if(port.atEnd()) if(!port.waitForReadyRead(2000)) break;
+                                                if(port.peek(1).at(0) == (char)0xFF) break;
+                                                else {
+                                                    bufStr.clear();
+                                                    while(port.peek(1).at(0) != ' ')
+                                                        bufStr.append(port.read(1));
+                                                    port.skip(1);
+                                                    App_Common::settingsTable[i] = bufStr.toUInt(nullptr, 16);
+                                                    App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
+                                                }
                                             } else break;
                                         }
 
@@ -221,7 +229,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                                     App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
                                                     App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
                                                     App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                                    App_Common::profilesTable[i].profName = buffer.takeFirst().toLocal8Bit();
+                                                    App_Common::profilesTable[i].profName = buffer.takeFirst();
 
                                                     App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
                                                 }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -308,7 +308,7 @@ bool AppSerial::CommitSettings()
 
 void AppSerial::Disconnect()
 {
-    OneShotSend((char)OF_Const::serialTerminator);
+    OneShotSend((char[]){(char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator, (char)OF_Const::serialTerminator});
     port.close();
 
     port.setPortName("");

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -261,54 +261,77 @@ bool AppSerial::OneShotSend(const char &chara, const bool &waitForResponse)
 bool AppSerial::CommitSettings()
 {
     if(port.isOpen()) {
-        // send a signal so the gun pauses its test outputs for the save op.
-        port.write("Xm");
-        port.waitForBytesWritten(1000);
+        emit Serial_SetProgressRange(7);
 
-        QStringList serialQueue;
-        for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++)
-            serialQueue.append(QString("Xm.0.%1.%2").arg(i).arg(App_Common::boolSettings[i]));
+        if(OneShotSend((char)OF_Const::sCommitStart)) {
+            emit Serial_ProgressUpdate(1, "Sending Toggles...");
+            for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
+                if(char buf[3] = {(char)OF_Const::sCommitToggles, (char)i, (char)App_Common::boolSettings[i]}; OneShotSend(buf, 3, true)) {
+                    if(port.read(1).at(0) != App_Common::boolSettings[i]) {
+                        OneShotSend((char)OF_Const::serialTerminator);
+                        return false;
+                    }
+                } else return false;
+            }
 
-        if(App_Common::boolSettings[OF_Const::customPins])
-            for(uint8_t i = 0; i < App_Common::inputsMap.count(); i++)
-                serialQueue.append(QString("Xm.1.%1.%2").arg(i).arg(App_Common::inputsMap.value(i)));
+            if(App_Common::boolSettings[OF_Const::customPins]) {
+                emit Serial_ProgressUpdate(2, "Sending Pins Map...");
+                for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
+                    if(char buf[3] = {(char)OF_Const::sCommitPins, (char)i, (char)App_Common::inputsMap.value(i)}; OneShotSend(buf, 3, true)) {
+                        if(port.read(1).at(0) != App_Common::inputsMap.value(i)) {
+                            OneShotSend((char)OF_Const::serialTerminator);
+                            return false;
+                        }
+                    } else return false;
+                }
+            }
 
-        for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++)
-            serialQueue.append(QString("Xm.2.%1.%2").arg(i).arg(App_Common::settingsTable[i]));
+            emit Serial_ProgressUpdate(3, "Sending Settings...");
+            for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
+                char buf[6] = {(char)OF_Const::sCommitSettings, (char)i};
+                memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                if(OneShotSend(buf, sizeof(buf), true)) {
+                    if(memcmp(port.read(4).constData(), &App_Common::settingsTable[i], sizeof(uint32_t))) {
+                        OneShotSend((char)OF_Const::serialTerminator);
+                        return false;
+                    }
+                } else return false;
+            }
 
-        serialQueue.append(QString("Xm.3.0.%1").arg(App_Common::tinyUSBtable.tinyUSBid));
-        if(!App_Common::tinyUSBtable.tinyUSBname.isEmpty())
-            serialQueue.append("Xm.3.1." + App_Common::tinyUSBtable.tinyUSBname);
+            emit Serial_ProgressUpdate(4, "Sending Profile Data...");
+            for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
 
-        for(uint8_t i = 0; i < 4; i++) {
-            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).irSensitivity));
-            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).runMode));
-            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).layoutType));
-            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).color));
-            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(QString(App_Common::profilesTable.at(i).profName)));
-        }
-        serialQueue.append(QString((char)OF_Const::sSave));
+            }
 
-        emit Serial_SetProgressRange(serialQueue.length()-1);
+            emit Serial_ProgressUpdate(5, "Sending TinyUSB ID Data...");
+            char buf[18] = {(char)OF_Const::sCommitID, (char)OF_Const::usbPID};
+            memcpy(&buf[2], (uint8_t*)&App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t));
+            if(OneShotSend(buf, 4, true)) {
+                if(memcmp(port.read(2).constData(), &App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t))) {
+                    OneShotSend((char)OF_Const::serialTerminator);
+                    return false;
+                } else {
+                    memset(&buf[1], '\0', sizeof(buf)-1);
+                    buf[1] = (char)OF_Const::usbName;
+                    memcpy(&buf[2], (uint8_t*)App_Common::tinyUSBtable.tinyUSBname.constData(), App_Common::tinyUSBtable.tinyUSBname.size());
+                    if(OneShotSend(buf, sizeof(buf), true)) {
+                        if(strcmp(port.read(16).constData(), App_Common::tinyUSBtable.tinyUSBname.constData())) {
+                            OneShotSend((char)OF_Const::serialTerminator);
+                            return false;
+                        }
+                    } else return false;
+                }
+            } else return false;
 
-        // throw out whatever's in the buffer if there's anything there.
-        port.clear();
-
-        for(uint8_t i = 0; i < serialQueue.length(); i++) {
-            port.write(serialQueue.at(i).toLocal8Bit());
-            port.waitForBytesWritten(1000);
-            if(port.waitForReadyRead(1000)) {
-                QString buffer = port.readLine();
-                if(buffer.contains("OK:") || buffer.contains("NOENT:")) {
-                    emit Serial_ProgressUpdate(i, "Committing settings to microcontroller...");
-                } else if(i == serialQueue.length() - 1 && buffer.contains("Saving preferences...")) {
-                    emit Serial_ProgressUpdate(serialQueue.length()-1, "Successfully synced settings!");
+            emit Serial_ProgressUpdate(6, "Saving...");
+            if(OneShotSend((char)OF_Const::sSave, true)) {
+                if(char newBuf[2] = {(char)OF_Const::sSave, (char)true}; memcmp(port.read(2).constData(), newBuf, sizeof(newBuf))) {
+                    emit Serial_ProgressUpdate(7);
                     return true;
                 } else return false;
             } else return false;
-        }
+        } else return false;
     } else return false;
-    return false;
 }
 
 void AppSerial::Disconnect()

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -106,19 +106,17 @@ bool AppSerial::GetSettings(const QString &portName)
                     App_Common::tinyUSBtable.tinyUSBname = &buffer.takeFirst().constData()[2];
                     App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
 
-                    if(buffer.size()) if(buffer.takeFirst().at(0) == OF_Const::sError) {
-                        syncError.setIcon(QMessageBox::Warning);
-                        syncError.setWindowTitle("Device Error: Camera not available!");
-                        syncError.setText("Data received from the board indicates that the camera is in a bad state.\n"
-                                          "This can happen if, for example, the camera wires are crossed\n"
-                                          "(data wire to clock pin, clock wire to data pin),\n"
-                                          "or the camera pins are wired to a different component,\n"
-                                          "such as a button or Force Feedback output.\n\n"
-                                          "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
-                                          "if they should be mapped different GPIO;\n"
-                                          "Otherwise, the camera wires must be resoldered to resolve this error.");
-                        syncError.show();
-                    }
+                    if(buffer.size()) if(buffer.takeFirst().at(0) == OF_Const::sError)
+                        ShowError("Device Error: Camera not available!",
+                                  "Data received from the board indicates that the camera is in a bad state.\n"
+                                  "This can happen if, for example, the camera wires are crossed\n"
+                                  "(data wire to clock pin, clock wire to data pin),\n"
+                                  "or the camera pins are wired to a different component,\n"
+                                  "such as a button or Force Feedback output.\n\n"
+                                  "You are able to change the camera pins in the <i>Boards Layout</i> tab\n"
+                                  "if they should be mapped different GPIO;\n"
+                                  "Otherwise, the camera wires must be resoldered to resolve this error.",
+                                  QMessageBox::Warning);
 
                     // toggles
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -68,7 +68,7 @@ QStringList AppSerial::GeneratePortsList(const QList<QSerialPortInfo> &portsList
 bool AppSerial::GetSettings(const QString &portName)
 {
     if(port.isOpen()) {
-        OneShotSend("XE");
+        OneShotSend((char)OF_Const::serialTerminator);
         port.close();
     }
 
@@ -79,159 +79,143 @@ bool AppSerial::GetSettings(const QString &portName)
     if(!port.portName().isEmpty()) {
         port.setBaudRate(QSerialPort::Baud9600);
         if(port.open(QIODevice::ReadWrite)) {
-            //serialActive = true;
-
             // windows needs DTR enabled to actually read responses.
             port.setDataTerminalReady(true);
 
-            port.write("XP");
-            if(port.waitForBytesWritten(500)) {
-                if(port.waitForReadyRead(500)) {
-                    QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
+            if(OneShotSend((char[]){(char)OF_Const::sDock1, (char)OF_Const::sDock2}, 2, true)) {
+                QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
-                    if(buffer.at(0) == "CAMERROR: Not available") {
-                        QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
-                                             "Data received from the board indicates that the camera is in a bad state.\n"
-                                             "This can happen if the camera wires are crossed (data wire to clock pin, clock wire to data pin).\n\n"
-                                             "The camera must be removed or resoldered to resolve this.");
-                        buffer.takeFirst();
-                    }
+                if(buffer.at(0) == "CAMERROR: Not available") {
+                    QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
+                                         "Data received from the board indicates that the camera is in a bad state.\n"
+                                         "This can happen if the camera wires are crossed (data wire to clock pin, clock wire to data pin).\n\n"
+                                         "The camera must be removed or resoldered to resolve this.");
+                    buffer.takeFirst();
+                }
 
-                    if(buffer.size() == 5) {
-                        emit Serial_SetProgressRange(5);
-                        emit Serial_ProgressUpdate(1, "Getting Board Info");
+                if(buffer.size() == 5) {
+                    emit Serial_SetProgressRange(5);
+                    emit Serial_ProgressUpdate(1, "Getting Board Info");
 
-                        App_Common::board.versionNumber = buffer.at(0).constData();
-                        printf("Version number: %s\n", App_Common::board.versionNumber.constData());
+                    App_Common::board.versionNumber = buffer.at(0).constData();
+                    printf("Version number: %s\n", App_Common::board.versionNumber.constData());
 
-                        App_Common::board.versionCodename = buffer.at(1).constData();
-                        printf("Version codename: %s\n", App_Common::board.versionCodename.constData());
+                    App_Common::board.versionCodename = buffer.at(1).constData();
+                    printf("Version codename: %s\n", App_Common::board.versionCodename.constData());
 
-                        App_Common::board.boardType = buffer.at(2).constData();
-                        printf("Board type: %s\n", App_Common::board.boardType.constData());
+                    App_Common::board.boardType = buffer.at(2).constData();
+                    printf("Board type: %s\n", App_Common::board.boardType.constData());
 
-                        App_Common::board.selectedProfile = buffer.at(3).toInt();
-                        App_Common::board.previousProfile = App_Common::board.selectedProfile;
+                    App_Common::board.selectedProfile = buffer.at(3).toInt();
+                    App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
-                        memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(4).constData(), 2);
-                        App_Common::tinyUSBtable.tinyUSBname = &buffer.at(4).constData()[2];
-                        App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
+                    memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(4).constData(), 2);
+                    App_Common::tinyUSBtable.tinyUSBname = &buffer.at(4).constData()[2];
+                    App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
 
-                        // toggles
-                        port.write("Xlb");
-                        port.waitForBytesWritten(500);
-                        if(port.waitForReadyRead(500)) {
-                            // booleans
-                            memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
-                            for(uint8_t i = 0;; i++) {
-                                if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
-                                    port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
-                                else break;
-                            }
-                            memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
+                    // toggles
+                    if(OneShotSend((char)OF_Const::sGetToggles, true)) {
+                        // booleans
+                        memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
+                        for(uint8_t i = 0;; i++) {
+                            if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
+                                port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
+                            else break;
+                        }
+                        memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
 
-                            emit Serial_ProgressUpdate(2, "Getting Settings (1)");
+                        emit Serial_ProgressUpdate(2, "Getting Settings (1)");
 
-                            // pins
-                            if(App_Common::boolSettings[OF_Const::customPins]) {
-                                port.clear();
-                                port.write("Xlp");
-                                port.waitForBytesWritten(500);
-                                if(port.waitForReadyRead(500)) {
-                                    App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
-
-                                    for(uint8_t i = 0;; i++)
-                                        if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
-                                            port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                        else break;
-                                } else {
-                                    printf("Didn't receive any data in time!\n");
-                                    return false;
-                                }
-                            } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
-                                    App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
-
-                            App_Common::inputsMap = App_Common::inputsMap_orig;
-
-                            emit Serial_ProgressUpdate(3, "Getting Settings (2)");
-
-                            // settings
+                        // pins
+                        if(App_Common::boolSettings[OF_Const::customPins]) {
                             port.clear();
-                            port.write("Xls");
-                            port.waitForBytesWritten(500);
-                            if(port.waitForReadyRead(500)) {
-                                memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                                while(true) {
-                                    if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
-                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                    else {
-                                        uint8_t i = port.read(1).at(0);
-                                        if(i < OF_Const::settingsTypesCount)
-                                            port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
-                                    }
-                                }
-                                memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
+                            if(OneShotSend((char)OF_Const::sGetPins, true)) {
+                                App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
-                                emit Serial_ProgressUpdate(4, "Getting Profiles Data");
-
-                                // profiles
-                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
-
-                                for(uint8_t i = 0;; i++) {
-                                    port.clear();
-                                    port.write("XlP" + QByteArray::number(i));
-                                    port.waitForBytesWritten(500);
-                                    if(port.waitForReadyRead(500)) {
-                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
-                                            break;
-                                        } else {
-                                            App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
-
-                                            while(port.bytesAvailable()) {
-                                                switch(port.read(1).at(0)) {
-                                                case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
-                                                case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
-                                                case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
-                                                default: break;
-                                                }
-                                            }
-
-                                            App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
-                                        }
-                                    } else break;
-                                }
-
-                                emit Serial_ProgressUpdate(5, "Successfully synced data!");
-                                return true;
+                                for(uint8_t i = 0;; i++)
+                                    if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
+                                        port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
+                                    else break;
                             } else {
-                                printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                printf("Didn't receive any data in time!\n");
                                 return false;
                             }
+                        } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                                App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
+
+                        App_Common::inputsMap = App_Common::inputsMap_orig;
+
+                        emit Serial_ProgressUpdate(3, "Getting Settings (2)");
+
+                        // settings
+                        port.clear();
+                        if(OneShotSend((char)OF_Const::sGetSettings, true)) {
+                            memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
+                            while(true) {
+                                if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
+                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                else {
+                                    uint8_t i = port.read(1).at(0);
+                                    if(i < OF_Const::settingsTypesCount)
+                                        port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                                }
+                            }
+                            memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
+
+                            emit Serial_ProgressUpdate(4, "Getting Profiles Data");
+
+                            // profiles
+                            App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+
+                            for(uint8_t i = 0;; i++) {
+                                port.clear();
+                                if(OneShotSend((char[]){(char)OF_Const::sGetProfile, (char)i}, 2, true)) {
+                                    if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
+                                        break;
+                                    } else {
+                                        App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
+
+                                        while(port.bytesAvailable()) {
+                                            switch(port.read(1).at(0)) {
+                                            case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
+                                            case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
+                                            case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
+                                            case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
+                                            case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
+                                            case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
+                                            case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
+                                            case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
+                                            case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
+                                            case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
+                                            case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
+                                            default: break;
+                                            }
+                                        }
+
+                                        App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
+                                    }
+                                } else break;
+                            }
+
+                            emit Serial_ProgressUpdate(5, "Successfully synced data!");
+                            return true;
                         } else {
                             printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                             return false;
                         }
                     } else {
-                        printf("Port did not respond with expected response! Got: %s\n", buffer.join(' ').constData());
+                        printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                         return false;
                     }
                 } else {
-                    QMessageBox::warning(nullptr,   "Data hasn't arrived! (Stale state?)",
-                                                    "Device was detected, but initial settings request wasn't received in time!\n"
-                                                    "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                                                    "Try selecting the device again.");
+                    printf("Port did not respond with expected response! Got: %s\n", buffer.join(' ').constData());
                     return false;
                 }
             } else {
-                printf("Couldn't send any data in time! Does the port even exist???\n");
+                QMessageBox::warning(nullptr,   "Data hasn't arrived! (Stale state?)",
+                                     "Device was detected, but initial settings request wasn't received in time!\n"
+                                     "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
+                                     "Try selecting the device again.");
                 return false;
             }
         } else {
@@ -243,12 +227,28 @@ bool AppSerial::GetSettings(const QString &portName)
     } else return false;
 }
 
-bool AppSerial::OneShotSend(const QByteArray &string)
+bool AppSerial::OneShotSend(const QByteArray &string, const unsigned int &len, const bool &waitForResponse)
 {
     if(port.isOpen()) {
-        port.write(string);
+        port.write((len > 0) ? string : string, len);
         if(port.waitForBytesWritten(1000))
-            return true;
+            if(waitForResponse)
+                if(port.waitForReadyRead(1000)) return true;
+                else return false;
+            else return true;
+        else return false;
+    } else return false;
+}
+
+bool AppSerial::OneShotSend(const char &chara, const bool &waitForResponse)
+{
+    if(port.isOpen()) {
+        port.write(&chara);
+        if(port.waitForBytesWritten(1000))
+            if(waitForResponse)
+                if(port.waitForReadyRead(1000)) return true;
+                else return false;
+            else return true;
         else return false;
     } else return false;
 }
@@ -282,7 +282,7 @@ bool AppSerial::CommitSettings()
             serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).color));
             serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(QString(App_Common::profilesTable.at(i).profName)));
         }
-        serialQueue.append("XS");
+        serialQueue.append(QString((char)OF_Const::sSave));
 
         emit Serial_SetProgressRange(serialQueue.length()-1);
 
@@ -308,12 +308,8 @@ bool AppSerial::CommitSettings()
 
 void AppSerial::Disconnect()
 {
-    if(port.isOpen()) {
-        port.write("XE");
-        port.waitForBytesWritten(500);
-        port.waitForReadyRead(500);
-        port.close();
-    }
+    OneShotSend((char)OF_Const::serialTerminator);
+    port.close();
 
     port.setPortName("");
 }

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -87,8 +87,7 @@ bool AppSerial::GetSettings(const QString &portName)
             port.write("XP");
             if(port.waitForBytesWritten(500)) {
                 if(port.waitForReadyRead(500)) {
-                    QByteArray bufStr = port.readLine().trimmed();
-                    QList<QByteArray> buffer = bufStr.split(',');
+                    QList<QByteArray> buffer = port.readLine().trimmed().split(',');
 
                     if(buffer.at(0) == "CAMERROR: Not available") {
                         QMessageBox::warning(nullptr,  "Device Error: Camera not available!",
@@ -119,8 +118,7 @@ bool AppSerial::GetSettings(const QString &portName)
                         port.write("Xli");
                         port.waitForBytesWritten(500);
                         if(port.waitForReadyRead(500)) {
-                            bufStr = port.readLine().trimmed();
-                            buffer = bufStr.split(',');
+                            buffer = port.readLine().trimmed().split(',');
                             if(buffer.size() == 2) {
                                 App_Common::tinyUSBtable.tinyUSBid = buffer.at(0);
                                 App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
@@ -143,7 +141,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                     memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
                                     for(uint8_t i = 0;; i++) {
                                         if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
-                                            port.read((char*)&App_Common::boolSettings[i], 1);
+                                            port.read((char*)&App_Common::boolSettings[i], sizeof(bool));
                                         else break;
                                     }
                                     memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
@@ -160,7 +158,7 @@ bool AppSerial::GetSettings(const QString &portName)
 
                                             for(uint8_t i = 0;; i++)
                                                 if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
-                                                    port.read((char*)&App_Common::inputsMap_orig[i], 1);
+                                                    port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
                                                 else break;
                                         } else {
                                             printf("Didn't receive any data in time!\n");
@@ -179,18 +177,14 @@ bool AppSerial::GetSettings(const QString &portName)
                                     port.waitForBytesWritten(500);
                                     if(port.waitForReadyRead(500)) {
                                         memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                                        for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
-                                            if(i < OF_Const::settingsTypesCount) {
-                                                if(port.atEnd()) if(!port.waitForReadyRead(2000)) break;
-                                                if(port.peek(1).at(0) == (char)0xFF) break;
-                                                else {
-                                                    bufStr.clear();
-                                                    while(port.peek(1).at(0) != ' ')
-                                                        bufStr.append(port.read(1));
-                                                    port.skip(1);
-                                                    App_Common::settingsTable[i] = bufStr.toUInt(nullptr, 16);
-                                                }
-                                            } else break;
+                                        while(true) {
+                                            if(!port.bytesAvailable()) if(!port.waitForReadyRead(2000)) break;
+                                            if(port.peek(1).at(0) == (char)0xFF) break;
+                                            else {
+                                                uint8_t i = port.read(1).at(0);
+                                                if(i < OF_Const::settingsTypesCount)
+                                                    port.read((char*)&App_Common::settingsTable[i], sizeof(uint32_t));
+                                            }
                                         }
                                         memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
 
@@ -204,27 +198,27 @@ bool AppSerial::GetSettings(const QString &portName)
                                             port.write("XlP" + QByteArray::number(i));
                                             port.waitForBytesWritten(500);
                                             if(port.waitForReadyRead(500)) {
-                                                // TODO (in fw): could be safer if each line was prepended with what type of profile table value it is.
-                                                bufStr = port.readLine().trimmed();
-                                                if(bufStr.startsWith("PROFERR:")) {
+                                                if(port.peek(1).at(0) == (char)0xFE) {
                                                     break;
                                                 } else {
-                                                    buffer = bufStr.split(',');
-
                                                     App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
 
-                                                    // copy settings
-                                                    App_Common::profilesTable[i].topOffset = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].bottomOffset = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].leftOffset = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].rightOffset = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].TLled = buffer.takeFirst().toFloat(),
-                                                    App_Common::profilesTable[i].TRled = buffer.takeFirst().toFloat(),
-                                                    App_Common::profilesTable[i].irSensitivity = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].runMode = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].layoutType = buffer.takeFirst().toInt(),
-                                                    App_Common::profilesTable[i].color = buffer.takeFirst().toLong(),
-                                                    App_Common::profilesTable[i].profName = buffer.takeFirst();
+                                                    while(port.bytesAvailable()) {
+                                                        switch(port.read(1).at(0)) {
+                                                        case 0: port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
+                                                        case 1: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
+                                                        case 2: port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
+                                                        case 3: port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
+                                                        case 4: port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
+                                                        case 5: port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
+                                                        case 6: port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
+                                                        case 7: port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
+                                                        case 8: port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
+                                                        case 9: port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
+                                                        case (char)0xFA:          App_Common::profilesTable[i].profName = port.read(16);         break;
+                                                        default: break;
+                                                        }
+                                                    }
 
                                                     App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
                                                 }
@@ -242,7 +236,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                     return false;
                                 }
                             } else {
-                                printf("Port did not respond with expected response! Got: %s", bufStr.constData());
+                                printf("Port did not respond with expected response! Got: %s", buffer.at(0).constData());
                                 return false;
                             }
                         } else {
@@ -306,11 +300,11 @@ bool AppSerial::CommitSettings()
             serialQueue.append(QString("Xm.3.1.%1").arg(App_Common::tinyUSBtable.tinyUSBname));
 
         for(uint8_t i = 0; i < 4; i++) {
-            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Common::profilesTable[i].irSensitivity));
-            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Common::profilesTable[i].runMode));
-            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Common::profilesTable[i].layoutType));
-            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Common::profilesTable[i].color));
-            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(App_Common::profilesTable[i].profName));
+            serialQueue.append(QString("Xm.P.i.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).irSensitivity));
+            serialQueue.append(QString("Xm.P.r.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).runMode));
+            serialQueue.append(QString("Xm.P.l.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).layoutType));
+            serialQueue.append(QString("Xm.P.c.%1.%2").arg(i).arg(App_Common::profilesTable.at(i).color));
+            serialQueue.append(QString("Xm.P.n.%1.%2").arg(i).arg(QString(App_Common::profilesTable.at(i).profName)));
         }
         serialQueue.append("XS");
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -140,14 +140,13 @@ bool AppSerial::GetSettings(const QString &portName)
                                 port.waitForBytesWritten(500);
                                 if(port.waitForReadyRead(500)) {
                                     // booleans
+                                    memset(App_Common::boolSettings, false, OF_Const::boolTypesCount);
                                     for(uint8_t i = 0;; i++) {
-                                        if(!port.atEnd() && i < OF_Const::boolTypesCount) {
-                                            char buf;
-                                            port.read(&buf, 1);
-                                            App_Common::boolSettings[i] = buf-32;
-                                            App_Common::boolSettings_orig[i] = App_Common::boolSettings[i];
-                                        } else break;
+                                        if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
+                                            port.read((char*)&App_Common::boolSettings[i], 1);
+                                        else break;
                                     }
+                                    memcpy(App_Common::boolSettings_orig, App_Common::boolSettings, sizeof(App_Common::boolSettings));
 
                                     emit Serial_ProgressUpdate(2, "Getting Settings (2)");
 
@@ -160,18 +159,15 @@ bool AppSerial::GetSettings(const QString &portName)
                                             App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
                                             for(uint8_t i = 0;; i++)
-                                                if(!port.atEnd() && i < OF_Const::boardInputsCount) {
+                                                if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
                                                     port.read((char*)&App_Common::inputsMap_orig[i], 1);
-                                                    App_Common::inputsMap_orig[i] -= 32;
-                                                } else break;
+                                                else break;
                                         } else {
                                             printf("Didn't receive any data in time!\n");
                                             return false;
                                         }
-                                    } else {
-                                        for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                                    } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
                                             App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
-                                    }
 
                                     App_Common::inputsMap = App_Common::inputsMap_orig;
 
@@ -182,6 +178,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                     port.write("Xls");
                                     port.waitForBytesWritten(500);
                                     if(port.waitForReadyRead(500)) {
+                                        memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
                                         for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
                                             if(i < OF_Const::settingsTypesCount) {
                                                 if(port.atEnd()) if(!port.waitForReadyRead(2000)) break;
@@ -192,10 +189,10 @@ bool AppSerial::GetSettings(const QString &portName)
                                                         bufStr.append(port.read(1));
                                                     port.skip(1);
                                                     App_Common::settingsTable[i] = bufStr.toUInt(nullptr, 16);
-                                                    App_Common::settingsTable_orig[i] = App_Common::settingsTable[i];
                                                 }
                                             } else break;
                                         }
+                                        memcpy(App_Common::settingsTable_orig, App_Common::settingsTable, sizeof(App_Common::settingsTable));
 
                                         emit Serial_ProgressUpdate(4, "Getting Profiles Data");
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -310,9 +310,13 @@ bool AppSerial::CommitSettings()
         if(OneShotSend((char)OF_Const::sCommitStart)) {
             port.clear();
 
+            char buf[64];
+
             emit Serial_ProgressUpdate(1, "Sending Toggles...");
             for(uint8_t i = 0; i < OF_Const::boolTypesCount; i++) {
-                if(char buf[3] = {(char)OF_Const::sCommitToggles, (char)i, (char)App_Common::boolSettings[i]}; OneShotSend(buf, 3, true)) {
+                memset(buf, '\0', 3);
+                buf[0] = (char)OF_Const::sCommitToggles, buf[1] = (char)i, buf[2] = (char)App_Common::boolSettings[i];
+                if(OneShotSend(buf, 3, true)) {
                     if(port.read(1).at(0) != App_Common::boolSettings[i]) {
                         OneShotSend((char)OF_Const::serialTerminator);
                         return false;
@@ -323,7 +327,9 @@ bool AppSerial::CommitSettings()
             if(App_Common::boolSettings[OF_Const::customPins]) {
                 emit Serial_ProgressUpdate(2, "Sending Pins Map...");
                 for(uint8_t i = 0; i < OF_Const::boardInputsCount; i++) {
-                    if(char buf[3] = { (char)OF_Const::sCommitPins, (char)i, (char)App_Common::inputsMap.value(i) }; OneShotSend(buf, 3, true)) {
+                    memset(buf, '\0', 3);
+                    buf[0] = (char)OF_Const::sCommitPins, buf[1] = (char)i, buf[2] = (char)App_Common::inputsMap.value(i);
+                    if(OneShotSend(buf, 3, true)) {
                         if(port.read(1).at(0) != App_Common::inputsMap.value(i)) {
                             OneShotSend((char)OF_Const::serialTerminator);
                             return false;
@@ -334,9 +340,10 @@ bool AppSerial::CommitSettings()
 
             emit Serial_ProgressUpdate(3, "Sending Settings...");
             for(uint8_t i = 0; i < OF_Const::settingsTypesCount; i++) {
-                char buf[6] = { (char)OF_Const::sCommitSettings, (char)i };
+                memset(buf, '\0', 6);
+                buf[0] = (char)OF_Const::sCommitSettings, buf[1] = (char)i;
                 memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[i], sizeof(uint32_t));
-                if(OneShotSend(buf, sizeof(buf), true)) {
+                if(OneShotSend(buf, 6, true)) {
                     if(memcmp(port.read(4).constData(), &App_Common::settingsTable[i], sizeof(uint32_t))) {
                         OneShotSend((char)OF_Const::serialTerminator);
                         return false;
@@ -346,11 +353,12 @@ bool AppSerial::CommitSettings()
 
             emit Serial_ProgressUpdate(4, "Sending Profile Data...");
             for(uint8_t i = 0; i < App_Common::profilesTable.count(); i++) {
-                char buf[19] = {(char)OF_Const::sCommitProfile,
-                                (char)i,
-                                (char)OF_Const::profIrSens,
-                                (char)App_Common::profilesTable.at(i).irSensitivity,
-                                0, 0, 0};
+                memset(buf, '\0', 19);
+                buf[0] = (char)OF_Const::sCommitProfile,
+                    buf[1] = (char)i,
+                    buf[2] = (char)OF_Const::profIrSens,
+                    buf[3] = (char)App_Common::profilesTable.at(i).irSensitivity;
+
                 if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).irSensitivity)
                     { OneShotSend((char)OF_Const::serialTerminator); return false; }
 
@@ -370,13 +378,14 @@ bool AppSerial::CommitSettings()
                 buf[2] = OF_Const::profName;
                 memset(&buf[3], '\0', 16);
                 memcpy(&buf[3], App_Common::profilesTable.at(i).profName.constData(), App_Common::profilesTable.at(i).profName.length());
-                if(OneShotSend(buf, sizeof(buf), true)) if(port.read(16) != App_Common::profilesTable.at(i).profName)
+                if(OneShotSend(buf, 19, true)) if(port.read(16) != App_Common::profilesTable.at(i).profName)
                     { OneShotSend((char)OF_Const::serialTerminator); return false; }
             }
 
             if(App_Common::inputsMap.value(OF_Const::periphSDA) > -1 && App_Common::inputsMap.value(OF_Const::periphSCL) > -1) {
                 emit Serial_ProgressUpdate(5, "Sending I2C Peripherals Data...");
-                char buf[20] = { (char)OF_Const::sCommitPeriphs };
+                memset(buf, '\0', 20);
+                buf[0] = (char)OF_Const::sCommitPeriphs;
                 for(int i = 0; i < OF_Const::i2cDevicesCount; i++) {
                     buf[1] = (char)OF_Const::i2cDevicesEnabled;
                     buf[2] = (char)i;
@@ -392,17 +401,18 @@ bool AppSerial::CommitSettings()
             }
 
             emit Serial_ProgressUpdate(6, "Sending TinyUSB ID Data...");
-            char buf[18] = {(char)OF_Const::sCommitID, (char)OF_Const::usbPID};
+            memset(buf, '0', 18);
+            buf[0] = (char)OF_Const::sCommitID, buf[1] = (char)OF_Const::usbPID;
             memcpy(&buf[2], (uint8_t*)&App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t));
             if(OneShotSend(buf, 4, true)) {
                 if(memcmp(port.read(2).constData(), &App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t))) {
                     OneShotSend((char)OF_Const::serialTerminator);
                     return false;
                 }
-                memset(&buf[1], '\0', sizeof(buf)-1);
+                memset(&buf[1], '\0', 17);
                 buf[1] = (char)OF_Const::usbName;
                 memcpy(&buf[2], (uint8_t*)App_Common::tinyUSBtable.tinyUSBname.constData(), App_Common::tinyUSBtable.tinyUSBname.size());
-                if(OneShotSend(buf, sizeof(buf), true)) {
+                if(OneShotSend(buf, 18, true)) {
                     if(strcmp(port.read(16).constData(), App_Common::tinyUSBtable.tinyUSBname.constData())) {
                         OneShotSend((char)OF_Const::serialTerminator);
                         return false;

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -76,6 +76,12 @@ public:
     /// @brief      Disconnects current serial device and clears port name
     void Disconnect();
 
+    /// @brief      Prompts user to reboot to bootloader
+    void RequestToReboot();
+
+    /// @brief      Sends magic baud 1200 signal to reset connected board to bootloader
+    void RebootToBootldr();
+
     /// @brief      Show error message popup regarding serial
     void ShowError(const char* titleText, const char* text, const QMessageBox::Icon icon = QMessageBox::Warning) {
         if(!syncError.isVisible()) {

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -1,3 +1,22 @@
+/*  OpenFIRE App: a configuration utility for the OpenFIRE light gun system.
+    Serial input/output routines.
+
+    Copyright (C) 2025  Team OpenFIRE
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef APPSERIAL_H
 #define APPSERIAL_H
 

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -76,6 +76,16 @@ public:
     /// @brief      Disconnects current serial device and clears port name
     void Disconnect();
 
+    /// @brief      Show error message popup regarding serial
+    void ShowError(const char* titleText, const char* text, const QMessageBox::Icon icon = QMessageBox::Warning) {
+        if(!syncError.isVisible()) {
+            syncError.setWindowTitle(titleText);
+            syncError.setText(text);
+            syncError.setIcon(icon);
+            syncError.show();
+        }
+    }
+
 private:
     QMessageBox syncError;
 

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -65,7 +65,7 @@ public:
     /// @returns    Success (true) or failure (false)
     /// @param      QString
     ///             String to send to device
-    bool OneShotSend(const QByteArray &, const unsigned int & = 0, const bool & = false);
+    bool OneShotSend(const char*, const unsigned int & = 0, const bool & = false);
     bool OneShotSend(const char &, const bool & = false);
 
     /// @brief      Commits settings (App_Const) to currently connected Serial device

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -21,6 +21,7 @@
 #define APPSERIAL_H
 
 #include <QObject>
+#include <QMessageBox>
 #include <QSerialPort>
 #include <QSerialPortInfo>
 
@@ -74,6 +75,9 @@ public:
 
     /// @brief      Disconnects current serial device and clears port name
     void Disconnect();
+
+private:
+    QMessageBox syncError;
 
 signals:
     /// @brief

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -65,7 +65,8 @@ public:
     /// @returns    Success (true) or failure (false)
     /// @param      QString
     ///             String to send to device
-    bool OneShotSend(const QByteArray &);
+    bool OneShotSend(const QByteArray &, const unsigned int & = 0, const bool & = false);
+    bool OneShotSend(const char &, const bool & = false);
 
     /// @brief      Commits settings (App_Const) to currently connected Serial device
     /// @returns    Success (true) or failure (false)

--- a/translation/AppTranslations_en_US.ts
+++ b/translation/AppTranslations_en_US.ts
@@ -5,31 +5,37 @@
     <name>AppAbout</name>
     <message>
         <location filename="../src/appabout.ui" line="17"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="133"/>
         <source>About OpenFIRE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appabout.ui" line="70"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="135"/>
         <source>Made with blood, sweat, and Qt </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appabout.ui" line="88"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="136"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Primary OpenFIRE Firmware maintainership and Desktop App developed by &lt;a href=&quot;https://github.com/SeongGino&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;That One Seong&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;If this software has given you any value,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appabout.ui" line="104"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="137"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://ko-fi.com/thatoneseong&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;/&gt;&lt;img src=&quot;:/icon/donate.svg&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appabout.ui" line="117"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="138"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;Special Thanks:&lt;br/&gt;Samuel Ballantyne, for their work on the original &lt;a href=&quot;https://github.com/samuelballantyne/IR-Light-Gun&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;SAMCO lightgun system&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;Mike Lynch, AKA Prow7, for their enhanced fork and libraries.&lt;br/&gt;&lt;a href=&quot;https://forum.arcadecontrols.com/index.php/board,20.0.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;The ArcadeControls forums&lt;/span&gt;&lt;/a&gt; for their support.&lt;br/&gt;All the early GitHub testers for their feedback.&lt;br/&gt;And You, for enjoying this software!&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;OpenFIRE, as the name implies, is FREE SOFTWARE;&lt;br/&gt;if you have paid for the firmware or this utility, you have been scammed and should demand your money back!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appabout.ui" line="151"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="139"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Firmware&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/TeamOpenFIRE/OpenFIRE-App&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Desktop Source&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;discord.com/invite/dFw5z6PBQv&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Discord&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -38,6 +44,7 @@
     <name>AppDebugWindow</name>
     <message>
         <location filename="../src/appdebug.ui" line="14"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appdebug.h" line="63"/>
         <source>Serial Debug</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,161 +53,193 @@
     <name>guiWindow</name>
     <message>
         <location filename="../src/appmainwindow.ui" line="49"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1238"/>
         <source>COM Port:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="125"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1246"/>
         <source>Board Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="211"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1241"/>
         <source>Enable to use custom pins mapping, or disable to use the default mappings for the current board.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="214"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1243"/>
         <source>Use Custom Pins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="234"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1244"/>
         <source>User Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="250"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1245"/>
         <source>Select Layout Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="263"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1525"/>
         <source>Gun Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="436"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1286"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the rumble motor is enabled.&lt;/p&gt;&lt;p&gt;Under normal conditions, the rumble motor will actuate when shooting offscreen &lt;span style=&quot; font-style:italic;&quot;&gt;(i.e. when the cursor is at the edge of the display)&lt;/span&gt;, and can also provide feedback in various sections of the Pause Menu interface.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="439"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1289"/>
         <source>Rumble Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="442"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1291"/>
         <source>Rumble Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="483"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1308"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the solenoid is enabled.&lt;/p&gt;&lt;p&gt;Under normal circumstances, the solenoid actuates when shooting at the display; the &amp;quot;engaged&amp;quot; duration is set in &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Interval&lt;/span&gt;. When depressed for the length of &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length&lt;/span&gt;, the solenoid will fire rapidly for as long as the trigger is held, with &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval&lt;/span&gt; determining state of the &amp;quot;engaged&amp;quot; duration and pause between engagements calculated by &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval * Autofire Wait Factor.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Note that the &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; setting conflicts with solenoid functionality, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="486"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1311"/>
         <source>Solenoid Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="489"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1313"/>
         <source>Solenoid Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="458"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1296"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable for rapid solenoid feedback while the trigger is pressed.&lt;/p&gt;&lt;p&gt;When enabled, the solenoid will always fire off automatically, as if the trigger has been held when using normal solenoid force feedback.&lt;/p&gt;&lt;p&gt;Note: if &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; is enabled, this option will provide continuous rumble motor feedback instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="461"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1299"/>
         <source>Autofire Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="464"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1301"/>
         <source>Autofire Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="467"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1302"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="414"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1276"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the rumble motor will be used for onscreen trigger feedback; taking the place of the solenoid feedback, rather than using the default off-screen motor feedback. Naturally, this requires &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; to be enabled.&lt;/p&gt;&lt;p&gt;Note that &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; takes priority over this setting, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="417"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1279"/>
         <source>Rumble-based Force Feedback Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1045"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1454"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how Pause Mode functions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode will use a scrolling menu layout - navigate by using &lt;span style=&quot; font-style:italic;&quot;&gt;Button A/B&lt;/span&gt; to select, and press Trigger to activate.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Menu options are activated with hotkeys.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns with less than two sub buttons, but &lt;span style=&quot; font-weight:700;&quot;&gt;requires an LED or OLED Display for visual feedback!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1048"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1457"/>
         <source>Simple Pause Menu Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1051"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1459"/>
         <source>Simple Pause Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1013"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1444"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how to trigger Pause Mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode can be activated by holding &lt;span style=&quot; font-style:italic;&quot;&gt;Trigger&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;while no IR points are visible.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Mode can be activated by pressing the Pause Mode hotkey (Button C + Select).&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons.&lt;/span&gt; Note that regardless of setting, Pause Mode can always be accessed by pressing the Home Button (if set).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1016"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1447"/>
         <source>Pause Mode Hold-to-Activate Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1019"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1449"/>
         <source>Hold to Pause Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="699"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1364"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the 4-pin RGB LED module uses a &lt;span style=&quot; font-style:italic;&quot;&gt;Common Anode&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Common Cathode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enable&lt;/span&gt; if your 4-pin LED is a Common Anode type (with common connected to 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disable&lt;/span&gt; if your 4-pin LED is a Common Cathode (with common connected to GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="702"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1367"/>
         <source>4-Pin RGB LED Common Anode Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="928"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1422"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; behaves during normal use.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled, &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; will perform different functions when aiming off-screen, instead actuating the functions of &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; respectively.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; all buttons will perform the same functions, regardless of aiming off-screen or not.&lt;/p&gt;&lt;p&gt;Enabled is recommended for lightguns &lt;span style=&quot; font-weight:700;&quot;&gt;with two or less sub buttons.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="931"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1425"/>
         <source>Low Buttons Mode Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="934"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1427"/>
         <source>Low Buttons Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="511"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1319"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time between solenoid activations when the trigger is held in &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; mode (or after holding the trigger for &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length),&lt;/span&gt; in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 30 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="514"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1322"/>
         <source>Autofire Solenoid Engagement Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,127 +249,157 @@
         <location filename="../src/appmainwindow.ui" line="577"/>
         <location filename="../src/appmainwindow.ui" line="618"/>
         <location filename="../src/appmainwindow.ui" line="968"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1271"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1324"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1336"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1347"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1438"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="326"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1250"/>
         <source>Rumble Intensity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="342"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1255"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the intensity of rumble force feedback events. Scales from 0 (disabled) to 255 (maximum).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="345"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1258"/>
         <source>Rumble Intensity Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="357"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1260"/>
         <source> / 255</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="370"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1261"/>
         <source>Rumble Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="386"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1266"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When Rumble is enabled, this setting determines the length of how long the rumble motor is activated when pulling the trigger offscreen, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="389"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1269"/>
         <source>Length of Rumble Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="565"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1331"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="568"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1334"/>
         <source>Normal Solenoid Engagement Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="606"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1342"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="609"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1345"/>
         <source>Solenoid Trigger Hold to Autofire Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="994"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1439"/>
         <source>Hold-to-Pause Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="956"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1433"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Hold To Pause&lt;/span&gt; mode is enabled, this setting determines how long (in milliseconds) should the buttons be held before Pause Mode activates.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 2500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="959"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1436"/>
         <source>Length to activate Hold-to-Pause Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="631"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1348"/>
         <source>Autofire Wait Factor:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="650"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1353"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the multiplier that&apos;s applied to the interval between solenoid activations when &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is enabled.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 3(x)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="653"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1356"/>
         <source>Autofire Wait Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="665"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1358"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="715"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1370"/>
         <source>NeoPixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="885"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1415"/>
         <source>NeoPixel Strand Length: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="854"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1408"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs are in the NeoPixel chain. More than one NeoPixel can be daisychained together, starting from the Pixel that&apos;s directly connected to &lt;span style=&quot; font-style:italic;&quot;&gt;NeoPixel Pin.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="857"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1411"/>
         <source>NeoPixel Strand Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="799"/>
         <location filename="../src/appmainwindow.ui" line="866"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1401"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1413"/>
         <source> Pixel(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="815"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1403"/>
         <source>Static NeoPixels: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -339,111 +408,136 @@
         <location filename="../src/appmainwindow.ui" line="751"/>
         <location filename="../src/appmainwindow.ui" line="772"/>
         <location filename="../src/appmainwindow.ui" line="793"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1372"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1379"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1386"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1396"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won&apos;t be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="796"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1399"/>
         <source>Amount of NeoPixels using Static Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="802"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1402"/>
         <source>First </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="733"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1375"/>
         <source>First NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="736"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1377"/>
         <source>Static Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="754"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1382"/>
         <source>Second NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="757"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1384"/>
         <source>Static Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="775"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1389"/>
         <source>Third NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="778"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1391"/>
         <source>Static Color 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="903"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1416"/>
         <source>Changes to NeoPixel settings may require a power cycle to update properly!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1077"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1460"/>
         <source>TinyUSB Identifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1091"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1461"/>
         <source>For Multiplayer, make sure each gun has its own unique identifier!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1121"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1463"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start/Select key mappings will default to &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; binds (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) for custom identifiers set here:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1133"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1464"/>
         <source>Product ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1159"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1466"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the custom Product ID that the microcontroller reports when connected to any given device, in base 16 hexadecimal (0-F)&lt;/p&gt;&lt;p&gt;Custom Product IDs &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;Note: The USB Vendor ID is hard-coded into the firmware, &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;0xF143.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1162"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1469"/>
         <source>Custom USB Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1168"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1471"/>
         <source>0x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1184"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1472"/>
         <source>Product Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1213"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1477"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This dictates the custom Product Name that the microcontroller reports when connected to any given device.&lt;/p&gt;&lt;p&gt;Custom Product Names are helpful (and in some cases, &lt;span style=&quot; font-weight:700;&quot;&gt;required&lt;/span&gt;) to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1216"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1480"/>
         <source>Custom USB Product Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1228"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1482"/>
         <source>(15 Characters)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1263"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1484"/>
         <source>Start/Select key mappings will change according to the player identifier set here:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -452,6 +546,10 @@
         <location filename="../src/appmainwindow.ui" line="1291"/>
         <location filename="../src/appmainwindow.ui" line="1307"/>
         <location filename="../src/appmainwindow.ui" line="1323"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1486"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1493"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1500"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1507"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -460,289 +558,352 @@
         <location filename="../src/appmainwindow.ui" line="1294"/>
         <location filename="../src/appmainwindow.ui" line="1310"/>
         <location filename="../src/appmainwindow.ui" line="1326"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1489"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1496"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1503"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1510"/>
         <source>Simple USB Identifier Presets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1281"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1491"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1297"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1498"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1313"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1505"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1329"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1512"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1344"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1514"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines whether to show/use &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Presets&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Custom USB ID Settings.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This can be useful for users with either more than four OpenFIRE lightguns, or simply want to personalize each lightgun, but the &lt;span style=&quot; font-style:italic;&quot;&gt;Simple Presets&lt;/span&gt; may be preferable to some.&lt;/p&gt;&lt;p&gt;All lightguns default to a &lt;span style=&quot; font-style:italic;&quot;&gt;P1 Simple USB ID Preset.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1347"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1517"/>
         <source>Toggle Advanced USB ID Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1350"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1519"/>
         <source>Advanced View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1381"/>
         <location filename="../src/appmainwindow.ui" line="1387"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1522"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1524"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab has a variety of settings to tweak about the lightgun&apos;s force feedback, lighting effects, and how it presents itself to the device.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1930"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1237"/>
         <source>Debug Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1407"/>
         <location filename="../src/appmainwindow.ui" line="1437"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1526"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1544"/>
         <source>Calibration Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="65"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1239"/>
         <source>[No devices detected]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="305"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1247"/>
         <source>Force Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="311"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1248"/>
         <source>Rumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="420"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1281"/>
         <source>Use Rumble as primary Force Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="474"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1303"/>
         <source>Solenoid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="533"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1325"/>
         <source>Solenoid Hold-to-Autofire Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="549"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1326"/>
         <source>Solenoid ON Normal Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="587"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1337"/>
         <source>Solenoid ON Fast Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="690"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1359"/>
         <source>Lighting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="705"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1369"/>
         <source>4-Pin RGB Common Anode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="919"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1417"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="947"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1428"/>
         <source>UI and UX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1459"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1527"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1469"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1528"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1496"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1530"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1516"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1532"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1526"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1533"/>
         <source>Run Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1543"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1534"/>
         <source>TRled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1560"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1535"/>
         <source>TLled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1593"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1536"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1617"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1537"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1627"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1538"/>
         <source>Sensitivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1689"/>
         <location filename="../src/appmainwindow.ui" line="1695"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1541"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1543"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows information and settings to tweak about your current calibration profiles.&lt;/p&gt;&lt;p&gt;The table above represents the amount of profiles the current board can store, including currently selected profile, names shown for each profile when using a compatible &lt;span style=&quot; font-style:italic;&quot;&gt;I2C Display,&lt;/span&gt; and colors used for lighting devices when switching to them from &lt;span style=&quot; font-style:italic;&quot;&gt;Pause Mode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1721"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1556"/>
         <source>Gun Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1727"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1545"/>
         <source>Buttons Tester</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1735"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1546"/>
         <source>Feedback Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1743"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1547"/>
         <source>Test Rumble Motor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1750"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1548"/>
         <source>Test Solenoid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1761"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1549"/>
         <source>Test Red LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1768"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1550"/>
         <source>Test Green LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1775"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1551"/>
         <source>Test Blue LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1787"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1552"/>
         <source>Open IR Camera Tester...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1814"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1553"/>
         <source>Board Actions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1820"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1554"/>
         <source>Clear Save Memory [!]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1830"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1555"/>
         <source>Reboot to Bootloader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1847"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1557"/>
         <source>[Nothing To Save]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1864"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1558"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1870"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1559"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1888"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1225"/>
         <source>&amp;About OpenFIRE...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1893"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1226"/>
         <source>&amp;OpenFIRE Documentation...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1896"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1228"/>
         <source>Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1901"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1230"/>
         <source>OpenFIRE &amp;Serial Usage Docs...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1904"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1232"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1909"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1234"/>
         <source>Open &amp;IR Emitter Alignment Assistant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1914"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1235"/>
         <source>Import Custom Layout...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/appmainwindow.ui" line="1922"/>
+        <location filename="../build/Desktop_Qt_6_8_2_llvm_mingw_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1236"/>
         <source>Export Custom Layout...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translation/AppTranslations_en_US.ts
+++ b/translation/AppTranslations_en_US.ts
@@ -80,644 +80,669 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="317"/>
-        <source>Toggles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="341"/>
+        <location filename="../src/appmainwindow.ui" line="436"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the rumble motor is enabled.&lt;/p&gt;&lt;p&gt;Under normal conditions, the rumble motor will actuate when shooting offscreen &lt;span style=&quot; font-style:italic;&quot;&gt;(i.e. when the cursor is at the edge of the display)&lt;/span&gt;, and can also provide feedback in various sections of the Pause Menu interface.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="344"/>
+        <location filename="../src/appmainwindow.ui" line="439"/>
         <source>Rumble Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="347"/>
+        <location filename="../src/appmainwindow.ui" line="442"/>
         <source>Rumble Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="360"/>
+        <location filename="../src/appmainwindow.ui" line="483"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the solenoid is enabled.&lt;/p&gt;&lt;p&gt;Under normal circumstances, the solenoid actuates when shooting at the display; the &amp;quot;engaged&amp;quot; duration is set in &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Interval&lt;/span&gt;. When depressed for the length of &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length&lt;/span&gt;, the solenoid will fire rapidly for as long as the trigger is held, with &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval&lt;/span&gt; determining state of the &amp;quot;engaged&amp;quot; duration and pause between engagements calculated by &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval * Autofire Wait Factor.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Note that the &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; setting conflicts with solenoid functionality, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="363"/>
+        <location filename="../src/appmainwindow.ui" line="486"/>
         <source>Solenoid Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="366"/>
+        <location filename="../src/appmainwindow.ui" line="489"/>
         <source>Solenoid Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="379"/>
+        <location filename="../src/appmainwindow.ui" line="458"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable for rapid solenoid feedback while the trigger is pressed.&lt;/p&gt;&lt;p&gt;When enabled, the solenoid will always fire off automatically, as if the trigger has been held when using normal solenoid force feedback.&lt;/p&gt;&lt;p&gt;Note: if &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; is enabled, this option will provide continuous rumble motor feedback instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="382"/>
+        <location filename="../src/appmainwindow.ui" line="461"/>
         <source>Autofire Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="385"/>
+        <location filename="../src/appmainwindow.ui" line="464"/>
         <source>Autofire Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="388"/>
+        <location filename="../src/appmainwindow.ui" line="467"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="428"/>
+        <location filename="../src/appmainwindow.ui" line="414"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the rumble motor will be used for onscreen trigger feedback; taking the place of the solenoid feedback, rather than using the default off-screen motor feedback. Naturally, this requires &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; to be enabled.&lt;/p&gt;&lt;p&gt;Note that &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; takes priority over this setting, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="431"/>
+        <location filename="../src/appmainwindow.ui" line="417"/>
         <source>Rumble-based Force Feedback Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="434"/>
-        <source>Rumble FF</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="447"/>
+        <location filename="../src/appmainwindow.ui" line="1045"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how Pause Mode functions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode will use a scrolling menu layout - navigate by using &lt;span style=&quot; font-style:italic;&quot;&gt;Button A/B&lt;/span&gt; to select, and press Trigger to activate.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Menu options are activated with hotkeys.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns with less than two sub buttons, but &lt;span style=&quot; font-weight:700;&quot;&gt;requires an LED or OLED Display for visual feedback!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="450"/>
+        <location filename="../src/appmainwindow.ui" line="1048"/>
         <source>Simple Pause Menu Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="453"/>
+        <location filename="../src/appmainwindow.ui" line="1051"/>
         <source>Simple Pause Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="466"/>
+        <location filename="../src/appmainwindow.ui" line="1013"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how to trigger Pause Mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode can be activated by holding &lt;span style=&quot; font-style:italic;&quot;&gt;Trigger&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;while no IR points are visible.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Mode can be activated by pressing the Pause Mode hotkey (Button C + Select).&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons.&lt;/span&gt; Note that regardless of setting, Pause Mode can always be accessed by pressing the Home Button (if set).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="469"/>
+        <location filename="../src/appmainwindow.ui" line="1016"/>
         <source>Pause Mode Hold-to-Activate Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="472"/>
+        <location filename="../src/appmainwindow.ui" line="1019"/>
         <source>Hold to Pause Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="515"/>
+        <location filename="../src/appmainwindow.ui" line="699"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the 4-pin RGB LED module uses a &lt;span style=&quot; font-style:italic;&quot;&gt;Common Anode&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Common Cathode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enable&lt;/span&gt; if your 4-pin LED is a Common Anode type (with common connected to 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disable&lt;/span&gt; if your 4-pin LED is a Common Cathode (with common connected to GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="518"/>
+        <location filename="../src/appmainwindow.ui" line="702"/>
         <source>4-Pin RGB LED Common Anode Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="521"/>
-        <source>RGB Common Anode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="534"/>
+        <location filename="../src/appmainwindow.ui" line="928"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; behaves during normal use.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled, &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; will perform different functions when aiming off-screen, instead actuating the functions of &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; respectively.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; all buttons will perform the same functions, regardless of aiming off-screen or not.&lt;/p&gt;&lt;p&gt;Enabled is recommended for lightguns &lt;span style=&quot; font-weight:700;&quot;&gt;with two or less sub buttons.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="537"/>
+        <location filename="../src/appmainwindow.ui" line="931"/>
         <source>Low Buttons Mode Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="540"/>
+        <location filename="../src/appmainwindow.ui" line="934"/>
         <source>Low Buttons Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="571"/>
-        <source>Setting Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="577"/>
-        <source>Solenoid Fast Interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="596"/>
+        <location filename="../src/appmainwindow.ui" line="511"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time between solenoid activations when the trigger is held in &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; mode (or after holding the trigger for &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length),&lt;/span&gt; in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 30 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="599"/>
+        <location filename="../src/appmainwindow.ui" line="514"/>
         <source>Autofire Solenoid Engagement Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="608"/>
-        <location filename="../src/appmainwindow.ui" line="706"/>
-        <location filename="../src/appmainwindow.ui" line="734"/>
-        <location filename="../src/appmainwindow.ui" line="759"/>
-        <location filename="../src/appmainwindow.ui" line="816"/>
+        <location filename="../src/appmainwindow.ui" line="398"/>
+        <location filename="../src/appmainwindow.ui" line="523"/>
+        <location filename="../src/appmainwindow.ui" line="577"/>
+        <location filename="../src/appmainwindow.ui" line="618"/>
+        <location filename="../src/appmainwindow.ui" line="968"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="618"/>
-        <source>Solenoid Hold Length:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="634"/>
+        <location filename="../src/appmainwindow.ui" line="326"/>
         <source>Rumble Intensity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="650"/>
+        <location filename="../src/appmainwindow.ui" line="342"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the intensity of rumble force feedback events. Scales from 0 (disabled) to 255 (maximum).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="653"/>
+        <location filename="../src/appmainwindow.ui" line="345"/>
         <source>Rumble Intensity Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="665"/>
+        <location filename="../src/appmainwindow.ui" line="357"/>
         <source> / 255</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="678"/>
+        <location filename="../src/appmainwindow.ui" line="370"/>
         <source>Rumble Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="694"/>
+        <location filename="../src/appmainwindow.ui" line="386"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When Rumble is enabled, this setting determines the length of how long the rumble motor is activated when pulling the trigger offscreen, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="697"/>
+        <location filename="../src/appmainwindow.ui" line="389"/>
         <source>Length of Rumble Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="722"/>
+        <location filename="../src/appmainwindow.ui" line="565"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="725"/>
+        <location filename="../src/appmainwindow.ui" line="568"/>
         <source>Normal Solenoid Engagement Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="747"/>
+        <location filename="../src/appmainwindow.ui" line="606"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="750"/>
+        <location filename="../src/appmainwindow.ui" line="609"/>
         <source>Solenoid Trigger Hold to Autofire Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="772"/>
+        <location filename="../src/appmainwindow.ui" line="994"/>
         <source>Hold-to-Pause Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="788"/>
-        <source>Solenoid Interval:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/appmainwindow.ui" line="804"/>
+        <location filename="../src/appmainwindow.ui" line="956"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Hold To Pause&lt;/span&gt; mode is enabled, this setting determines how long (in milliseconds) should the buttons be held before Pause Mode activates.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 2500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="807"/>
+        <location filename="../src/appmainwindow.ui" line="959"/>
         <source>Length to activate Hold-to-Pause Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="829"/>
+        <location filename="../src/appmainwindow.ui" line="631"/>
         <source>Autofire Wait Factor:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="848"/>
+        <location filename="../src/appmainwindow.ui" line="650"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the multiplier that&apos;s applied to the interval between solenoid activations when &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is enabled.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 3(x)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="851"/>
+        <location filename="../src/appmainwindow.ui" line="653"/>
         <source>Autofire Wait Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="863"/>
+        <location filename="../src/appmainwindow.ui" line="665"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="882"/>
+        <location filename="../src/appmainwindow.ui" line="715"/>
         <source>NeoPixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="903"/>
+        <location filename="../src/appmainwindow.ui" line="885"/>
         <source>NeoPixel Strand Length: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="916"/>
+        <location filename="../src/appmainwindow.ui" line="854"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs are in the NeoPixel chain. More than one NeoPixel can be daisychained together, starting from the Pixel that&apos;s directly connected to &lt;span style=&quot; font-style:italic;&quot;&gt;NeoPixel Pin.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="919"/>
+        <location filename="../src/appmainwindow.ui" line="857"/>
         <source>NeoPixel Strand Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="928"/>
-        <location filename="../src/appmainwindow.ui" line="996"/>
+        <location filename="../src/appmainwindow.ui" line="799"/>
+        <location filename="../src/appmainwindow.ui" line="866"/>
         <source> Pixel(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="977"/>
+        <location filename="../src/appmainwindow.ui" line="815"/>
         <source>Static NeoPixels: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="990"/>
-        <location filename="../src/appmainwindow.ui" line="1019"/>
-        <location filename="../src/appmainwindow.ui" line="1040"/>
-        <location filename="../src/appmainwindow.ui" line="1061"/>
+        <location filename="../src/appmainwindow.ui" line="730"/>
+        <location filename="../src/appmainwindow.ui" line="751"/>
+        <location filename="../src/appmainwindow.ui" line="772"/>
+        <location filename="../src/appmainwindow.ui" line="793"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won&apos;t be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="993"/>
+        <location filename="../src/appmainwindow.ui" line="796"/>
         <source>Amount of NeoPixels using Static Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="999"/>
+        <location filename="../src/appmainwindow.ui" line="802"/>
         <source>First </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1022"/>
+        <location filename="../src/appmainwindow.ui" line="733"/>
         <source>First NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1025"/>
+        <location filename="../src/appmainwindow.ui" line="736"/>
         <source>Static Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1043"/>
+        <location filename="../src/appmainwindow.ui" line="754"/>
         <source>Second NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1046"/>
+        <location filename="../src/appmainwindow.ui" line="757"/>
         <source>Static Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1064"/>
+        <location filename="../src/appmainwindow.ui" line="775"/>
         <source>Third NeoPixel Static Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1067"/>
+        <location filename="../src/appmainwindow.ui" line="778"/>
         <source>Static Color 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1100"/>
+        <location filename="../src/appmainwindow.ui" line="903"/>
         <source>Changes to NeoPixel settings may require a power cycle to update properly!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1126"/>
+        <location filename="../src/appmainwindow.ui" line="1077"/>
         <source>TinyUSB Identifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1140"/>
+        <location filename="../src/appmainwindow.ui" line="1091"/>
         <source>For Multiplayer, make sure each gun has its own unique identifier!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1170"/>
+        <location filename="../src/appmainwindow.ui" line="1121"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start/Select key mappings will default to &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; binds (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) for custom identifiers set here:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1182"/>
+        <location filename="../src/appmainwindow.ui" line="1133"/>
         <source>Product ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1208"/>
+        <location filename="../src/appmainwindow.ui" line="1159"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the custom Product ID that the microcontroller reports when connected to any given device, in base 16 hexadecimal (0-F)&lt;/p&gt;&lt;p&gt;Custom Product IDs &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;Note: The USB Vendor ID is hard-coded into the firmware, &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;0xF143.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1211"/>
+        <location filename="../src/appmainwindow.ui" line="1162"/>
         <source>Custom USB Product ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1217"/>
+        <location filename="../src/appmainwindow.ui" line="1168"/>
         <source>0x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1233"/>
+        <location filename="../src/appmainwindow.ui" line="1184"/>
         <source>Product Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1262"/>
+        <location filename="../src/appmainwindow.ui" line="1213"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This dictates the custom Product Name that the microcontroller reports when connected to any given device.&lt;/p&gt;&lt;p&gt;Custom Product Names are helpful (and in some cases, &lt;span style=&quot; font-weight:700;&quot;&gt;required&lt;/span&gt;) to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1265"/>
+        <location filename="../src/appmainwindow.ui" line="1216"/>
         <source>Custom USB Product Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1277"/>
+        <location filename="../src/appmainwindow.ui" line="1228"/>
         <source>(15 Characters)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1312"/>
+        <location filename="../src/appmainwindow.ui" line="1263"/>
         <source>Start/Select key mappings will change according to the player identifier set here:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1324"/>
-        <location filename="../src/appmainwindow.ui" line="1340"/>
-        <location filename="../src/appmainwindow.ui" line="1356"/>
-        <location filename="../src/appmainwindow.ui" line="1372"/>
+        <location filename="../src/appmainwindow.ui" line="1275"/>
+        <location filename="../src/appmainwindow.ui" line="1291"/>
+        <location filename="../src/appmainwindow.ui" line="1307"/>
+        <location filename="../src/appmainwindow.ui" line="1323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1327"/>
-        <location filename="../src/appmainwindow.ui" line="1343"/>
-        <location filename="../src/appmainwindow.ui" line="1359"/>
-        <location filename="../src/appmainwindow.ui" line="1375"/>
+        <location filename="../src/appmainwindow.ui" line="1278"/>
+        <location filename="../src/appmainwindow.ui" line="1294"/>
+        <location filename="../src/appmainwindow.ui" line="1310"/>
+        <location filename="../src/appmainwindow.ui" line="1326"/>
         <source>Simple USB Identifier Presets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1330"/>
+        <location filename="../src/appmainwindow.ui" line="1281"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1346"/>
+        <location filename="../src/appmainwindow.ui" line="1297"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1362"/>
+        <location filename="../src/appmainwindow.ui" line="1313"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1378"/>
+        <location filename="../src/appmainwindow.ui" line="1329"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1393"/>
+        <location filename="../src/appmainwindow.ui" line="1344"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines whether to show/use &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Presets&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Custom USB ID Settings.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This can be useful for users with either more than four OpenFIRE lightguns, or simply want to personalize each lightgun, but the &lt;span style=&quot; font-style:italic;&quot;&gt;Simple Presets&lt;/span&gt; may be preferable to some.&lt;/p&gt;&lt;p&gt;All lightguns default to a &lt;span style=&quot; font-style:italic;&quot;&gt;P1 Simple USB ID Preset.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1396"/>
+        <location filename="../src/appmainwindow.ui" line="1347"/>
         <source>Toggle Advanced USB ID Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1399"/>
+        <location filename="../src/appmainwindow.ui" line="1350"/>
         <source>Advanced View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1430"/>
-        <location filename="../src/appmainwindow.ui" line="1436"/>
+        <location filename="../src/appmainwindow.ui" line="1381"/>
+        <location filename="../src/appmainwindow.ui" line="1387"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab has a variety of settings to tweak about the lightgun&apos;s force feedback, lighting effects, and how it presents itself to the device.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1979"/>
+        <location filename="../src/appmainwindow.ui" line="1930"/>
         <source>Debug Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1456"/>
-        <location filename="../src/appmainwindow.ui" line="1486"/>
+        <location filename="../src/appmainwindow.ui" line="1407"/>
+        <location filename="../src/appmainwindow.ui" line="1437"/>
         <source>Calibration Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1508"/>
+        <location filename="../src/appmainwindow.ui" line="65"/>
+        <source>[No devices detected]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="305"/>
+        <source>Force Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="311"/>
+        <source>Rumble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="420"/>
+        <source>Use Rumble as primary Force Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="474"/>
+        <source>Solenoid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="533"/>
+        <source>Solenoid Hold-to-Autofire Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="549"/>
+        <source>Solenoid ON Normal Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="587"/>
+        <source>Solenoid ON Fast Length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="690"/>
+        <source>Lighting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="705"/>
+        <source>4-Pin RGB Common Anode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="919"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="947"/>
+        <source>UI and UX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1459"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1518"/>
+        <location filename="../src/appmainwindow.ui" line="1469"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1545"/>
+        <location filename="../src/appmainwindow.ui" line="1496"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1565"/>
+        <location filename="../src/appmainwindow.ui" line="1516"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1575"/>
+        <location filename="../src/appmainwindow.ui" line="1526"/>
         <source>Run Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1592"/>
+        <location filename="../src/appmainwindow.ui" line="1543"/>
         <source>TRled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1609"/>
+        <location filename="../src/appmainwindow.ui" line="1560"/>
         <source>TLled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1642"/>
+        <location filename="../src/appmainwindow.ui" line="1593"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1666"/>
+        <location filename="../src/appmainwindow.ui" line="1617"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1676"/>
+        <location filename="../src/appmainwindow.ui" line="1627"/>
         <source>Sensitivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1738"/>
-        <location filename="../src/appmainwindow.ui" line="1744"/>
+        <location filename="../src/appmainwindow.ui" line="1689"/>
+        <location filename="../src/appmainwindow.ui" line="1695"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows information and settings to tweak about your current calibration profiles.&lt;/p&gt;&lt;p&gt;The table above represents the amount of profiles the current board can store, including currently selected profile, names shown for each profile when using a compatible &lt;span style=&quot; font-style:italic;&quot;&gt;I2C Display,&lt;/span&gt; and colors used for lighting devices when switching to them from &lt;span style=&quot; font-style:italic;&quot;&gt;Pause Mode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1770"/>
+        <location filename="../src/appmainwindow.ui" line="1721"/>
         <source>Gun Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1776"/>
+        <location filename="../src/appmainwindow.ui" line="1727"/>
         <source>Buttons Tester</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1784"/>
+        <location filename="../src/appmainwindow.ui" line="1735"/>
         <source>Feedback Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1792"/>
+        <location filename="../src/appmainwindow.ui" line="1743"/>
         <source>Test Rumble Motor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1799"/>
+        <location filename="../src/appmainwindow.ui" line="1750"/>
         <source>Test Solenoid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1810"/>
+        <location filename="../src/appmainwindow.ui" line="1761"/>
         <source>Test Red LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1817"/>
+        <location filename="../src/appmainwindow.ui" line="1768"/>
         <source>Test Green LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1824"/>
+        <location filename="../src/appmainwindow.ui" line="1775"/>
         <source>Test Blue LED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1836"/>
+        <location filename="../src/appmainwindow.ui" line="1787"/>
         <source>Open IR Camera Tester...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1863"/>
+        <location filename="../src/appmainwindow.ui" line="1814"/>
         <source>Board Actions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1869"/>
+        <location filename="../src/appmainwindow.ui" line="1820"/>
         <source>Clear Save Memory [!]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1879"/>
+        <location filename="../src/appmainwindow.ui" line="1830"/>
         <source>Reboot to Bootloader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1896"/>
+        <location filename="../src/appmainwindow.ui" line="1847"/>
         <source>[Nothing To Save]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1913"/>
+        <location filename="../src/appmainwindow.ui" line="1864"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1919"/>
+        <location filename="../src/appmainwindow.ui" line="1870"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1937"/>
+        <location filename="../src/appmainwindow.ui" line="1888"/>
         <source>&amp;About OpenFIRE...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1942"/>
+        <location filename="../src/appmainwindow.ui" line="1893"/>
         <source>&amp;OpenFIRE Documentation...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1945"/>
+        <location filename="../src/appmainwindow.ui" line="1896"/>
         <source>Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1950"/>
+        <location filename="../src/appmainwindow.ui" line="1901"/>
         <source>OpenFIRE &amp;Serial Usage Docs...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1953"/>
+        <location filename="../src/appmainwindow.ui" line="1904"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1958"/>
+        <location filename="../src/appmainwindow.ui" line="1909"/>
         <source>Open &amp;IR Emitter Alignment Assistant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1963"/>
+        <location filename="../src/appmainwindow.ui" line="1914"/>
         <source>Import Custom Layout...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appmainwindow.ui" line="1971"/>
+        <location filename="../src/appmainwindow.ui" line="1922"/>
         <source>Export Custom Layout...</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Primarily a sister PR to TeamOpenFIRE/OpenFIRE-Firmware#60, the app's communications syntax has been changed to reflect what will be used in FW 6.0-onwards.

I2C Peripheral decoupling is a thing now, which means the display is considered its own accessory and can be individually enabled/disabled. This should hopefully allow easy integration with future I2C devices.

Analog stick reading actually reflects proper analog positioning, rather than the old hacky 8-directional label workaround before.

The settings screen layout has been additionally reorganized to be more intuitive; even though the page overall takes up more space, the options should speak more for themselves.

A window for previewing supported Boards (and their default layouts) has been added under the Help app menu.

The one-time check for supported devices has been removed - the app will be able to startup without any connected devices, and will search for new devices at a set 5s interval; removing old devices as they are disconnected and adding new ones as they are added.

Valid camera checks are more thorough now (mainly due in part to new checks signaled from FW 6.0), and the app/FW will check at startup and with every syncing of settings if the assigned camera and/or peripherals line is either available or wired correctly.

*Reboot to Bootloader* now uses the magic 1200baud switch correctly, allowing devices to be rebooted regardless of working status or not - the App will even report if a device has failed to sync and ask the user if they wish to reboot this board appropriately.

Most references to fixed Pin Counts are removed (TODO: save for one), prepping work for devices or platforms with more than 30 assignable GPIO maximum. (This means ESP as well, though that platform may need a different method for the aforementioned *Reboot to Bootloader* change.