### PR TITLE
Corrects packet reading/waiting logic for >64B transactions from microcontroller, add custom temperatures support

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -134,7 +134,8 @@ guiWindow::guiWindow(QWidget *parent)
     ui->tUSBLayoutAdvanced->setVisible(false);
 
     // set hidden by default until a board with presets is loaded
-    ui->presetsBox->setHidden(true);
+    ui->presetsBox->setVisible(true);
+    ui->solenoidTempBox->setVisible(false);
 
     statusBar()->showMessage("Welcome to the OpenFIRE app!", 3000);
 
@@ -777,7 +778,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             boardPic.load(origBoardPicFile);
             boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
 
-            int prevPadCount;
+            int prevPadCount = 0;
             for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
                 if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
                     ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
@@ -814,6 +815,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->solenoidHoldLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::solenoidHoldLength]);
             ui->autofireWaitFactorBox->setEnabled(App_Common::boolSettings[App_Common::dataOrig][OF_Const::autofire]), ui->autofireWaitFactorBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::autofireWaitFactor]);
             ui->invertStaticPixelsBox->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::invertStaticPixels]);
+            ui->tempWarningBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempWarning]);
+            ui->tempShutoffBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown]);
 
             ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs[App_Common::dataOrig][OF_Const::i2cOLED]);
             ui->oledAltAddrsToggle->setChecked(App_Common::i2cOledPrefs[App_Common::dataOrig][OF_Const::oledAltAddr]);
@@ -1026,6 +1029,8 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
         ui->rumbleFFToggle->setChecked(false);
         ui->rumbleFFBox->setEnabled(false);
     }
+
+    ui->solenoidTempBox->setEnabled(App_Common::inputsMap.value(OF_Const::tempPin) > -1 ? true : false);
 
     if(App_Common::inputsMap.value(OF_Const::solenoidPin) >= 0)
          ui->solenoidFFBox->setEnabled(true);
@@ -1260,6 +1265,20 @@ void guiWindow::on_rumbleFFToggle_stateChanged(int arg1)
         ui->autofireToggle->setEnabled(true);
     }
 
+    DiffUpdate();
+}
+
+
+void guiWindow::on_tempWarningBox_valueChanged(int arg1)
+{
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::tempWarning] = arg1;
+    DiffUpdate();
+}
+
+
+void guiWindow::on_tempShutoffBox_valueChanged(int arg1)
+{
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::tempShutdown] = arg1;
     DiffUpdate();
 }
 
@@ -2007,6 +2026,13 @@ void guiWindow::on_tabWidget_currentChanged(int index)
 }
 
 
+void guiWindow::on_actionShow_Unsafe_Settings_toggled(bool arg1)
+{
+    if(arg1) ui->solenoidTempBox->setVisible(true);
+    else     ui->solenoidTempBox->setVisible(false);
+}
+
+
 void guiWindow::on_actionCompatible_Boards_triggered()
 {
     boardsWindow.show();
@@ -2018,6 +2044,7 @@ void guiWindow::on_actionAbout_UI_triggered()
     AppAbout *about = new AppAbout();
     about->show();
 }
+
 
 void guiWindow::on_actionOpenFIRE_Documentation_triggered()
 {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1632,9 +1632,12 @@ void guiWindow::serialPort_readyRead()
 
                 ui->tmp36Label->setText(QString("Temperature: %1°C").arg(temp));
 
-                if(temp > tempShutoff) {        ui->tmp36Label->setStyleSheet("color: white;      background-color: #FF0000; font: bold"); }
-                else if(temp > tempWarning) {   ui->tmp36Label->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold"); }
-                else {                          ui->tmp36Label->setStyleSheet("color: black;      background-color: #11D00A; font: bold"); }
+                if(     temp > App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown])
+                    ui->tmp36Label->setStyleSheet("color: white;      background-color: #FF0000; font: bold");
+                else if(temp > App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempWarning])
+                    ui->tmp36Label->setStyleSheet("color: light-gray; background-color: #EABD2B; font: bold");
+                else
+                    ui->tmp36Label->setStyleSheet("color: black;      background-color: #11D00A; font: bold");
 
                 break;
             }

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -101,6 +101,10 @@ private slots:
 
     void on_rumbleFFToggle_stateChanged(int arg1);
 
+    void on_tempWarningBox_valueChanged(int arg1);
+
+    void on_tempShutoffBox_valueChanged(int arg1);
+
     void on_rumbleIntensityBox_valueChanged(int arg1);
 
     void on_rumbleLengthBox_valueChanged(int arg1);
@@ -170,6 +174,8 @@ private slots:
     void serialPort_progressSet(const int &);
 
     void serialPort_progressUpdate(const int &, const char* = nullptr);
+
+    void on_actionShow_Unsafe_Settings_toggled(bool arg1);
 
     void on_actionCompatible_Boards_triggered();
 

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -249,10 +249,6 @@ private:
     // Flag that's set during I/O operations so that the readyRead signal doesn't interfere and absorb RX buffer mid-method.
     bool serialActive = false;
 
-    /// @brief      Temperature thresholds (which should be a customizable setting in the settingsTable)
-    uint8_t tempWarning = 35;
-    uint8_t tempShutoff = 42;
-
     /// @brief      Timer that probes the board if it's still plugged in
     /// @details    Timer interval is provided in ms by ALIVE_TIMER
     QTimer aliveTimer;

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -281,9 +281,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-305</y>
+             <y>0</y>
              <width>924</width>
-             <height>1153</height>
+             <height>1245</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,1,0">
@@ -527,10 +527,10 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="2">
-                      <widget class="QLabel" name="label_9">
+                     <item row="1" column="2">
+                      <widget class="QLabel" name="label_10">
                        <property name="text">
-                        <string>Solenoid Hold-to-Autofire Length:</string>
+                        <string>Autofire Wait Factor:</string>
                        </property>
                        <property name="textFormat">
                         <enum>Qt::TextFormat::PlainText</enum>
@@ -556,31 +556,6 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="1">
-                      <widget class="QSpinBox" name="solenoidNormalIntervalBox">
-                       <property name="toolTip">
-                        <string/>
-                       </property>
-                       <property name="whatsThis">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="accessibleName">
-                        <string>Normal Solenoid Engagement Length</string>
-                       </property>
-                       <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                       </property>
-                       <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                       </property>
-                       <property name="suffix">
-                        <string> ms</string>
-                       </property>
-                       <property name="trackable" stdset="0">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
                      <item row="1" column="0">
                       <widget class="QLabel" name="label_8">
                        <property name="text">
@@ -597,38 +572,10 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="3">
-                      <widget class="QSpinBox" name="solenoidHoldLengthBox">
-                       <property name="toolTip">
-                        <string/>
-                       </property>
-                       <property name="whatsThis">
-                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="accessibleName">
-                        <string>Solenoid Trigger Hold to Autofire Length</string>
-                       </property>
-                       <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
-                       </property>
-                       <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                       </property>
-                       <property name="suffix">
-                        <string> ms</string>
-                       </property>
-                       <property name="maximum">
-                        <number>9999</number>
-                       </property>
-                       <property name="trackable" stdset="0">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QLabel" name="label_10">
+                     <item row="0" column="2">
+                      <widget class="QLabel" name="label_9">
                        <property name="text">
-                        <string>Autofire Wait Factor:</string>
+                        <string>Solenoid Hold-to-Autofire Length:</string>
                        </property>
                        <property name="textFormat">
                         <enum>Qt::TextFormat::PlainText</enum>
@@ -673,6 +620,129 @@
                        <property name="trackable" stdset="0">
                         <number>1</number>
                        </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="3">
+                      <widget class="QSpinBox" name="solenoidHoldLengthBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Solenoid Trigger Hold to Autofire Length</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="maximum">
+                        <number>9999</number>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="solenoidNormalIntervalBox">
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="whatsThis">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
+                       <property name="accessibleName">
+                        <string>Normal Solenoid Engagement Length</string>
+                       </property>
+                       <property name="buttonSymbols">
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="suffix">
+                        <string> ms</string>
+                       </property>
+                       <property name="trackable" stdset="0">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="0" colspan="4">
+                      <widget class="QGroupBox" name="solenoidTempBox">
+                       <property name="title">
+                        <string/>
+                       </property>
+                       <layout class="QGridLayout" name="gridLayout_12">
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_14">
+                          <property name="text">
+                           <string>Temperature Warning Threshold:</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2">
+                         <widget class="QLabel" name="label_16">
+                          <property name="text">
+                           <string>Temperature Shutoff Threshold:</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QSpinBox" name="tempWarningBox">
+                          <property name="whatsThis">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the point at which solenoid activations will force longer OFF periods between sustained fire/autofire shots, in &lt;span style=&quot; font-style:italic;&quot;&gt;degrees Celsius.&lt;/span&gt; Generally speaking, the higher this is set, the longer the solenoid will maintain full sustained fire speeds.&lt;/p&gt;&lt;p&gt;Once this point is hit, the solenoid firing rate is reduced until the temperature monitor reads at least five (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;below&lt;/span&gt; this threshold. The &amp;quot;reduced&amp;quot; firing rate is automatically calculated as &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Solenoid ON Fast Length * 4&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Setting this value too high may reduce the lifespan of the connected solenoid!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                          <property name="accessibleName">
+                           <string>Temperature Warning Threshold</string>
+                          </property>
+                          <property name="suffix">
+                           <string>°C</string>
+                          </property>
+                          <property name="minimum">
+                           <number>20</number>
+                          </property>
+                          <property name="trackable" stdset="0">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="3">
+                         <widget class="QSpinBox" name="tempShutoffBox">
+                          <property name="whatsThis">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the point at which the solenoid will stop activating, in &lt;span style=&quot; font-style:italic;&quot;&gt;degrees Celsius.&lt;/span&gt; Generally speaking, the higher the temperature threshold, the longer the solenoid will activate at reduced sustained fire speeds.&lt;/p&gt;&lt;p&gt;Once this point is triggered, solenoid activations will not be allowed for either single or sustained shots until the temperature monitor reads at least five (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;below&lt;/span&gt; this threshold.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Setting this value too high WILL reduce the lifespan of the connected solenoid!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                          <property name="accessibleName">
+                           <string>Temperature Shutoff Threshold</string>
+                          </property>
+                          <property name="suffix">
+                           <string>°C</string>
+                          </property>
+                          <property name="minimum">
+                           <number>25</number>
+                          </property>
+                          <property name="maximum">
+                           <number>60</number>
+                          </property>
+                          <property name="trackable" stdset="0">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
                       </widget>
                      </item>
                     </layout>
@@ -2055,6 +2125,13 @@
     <addaction name="separator"/>
     <addaction name="actionDebug_Window"/>
    </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <addaction name="actionShow_Unsafe_Settings"/>
+   </widget>
+   <addaction name="menuView"/>
    <addaction name="menuHelp"/>
    <addaction name="menuAbout"/>
   </widget>
@@ -2126,6 +2203,14 @@
   <action name="actionCompatible_Boards">
    <property name="text">
     <string>View Compatible Boards</string>
+   </property>
+  </action>
+  <action name="actionShow_Unsafe_Settings">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Unsafe Settings</string>
    </property>
   </action>
  </widget>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -283,7 +283,7 @@
              <x>0</x>
              <y>0</y>
              <width>924</width>
-             <height>1245</height>
+             <height>1210</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,1,0">
@@ -680,7 +680,22 @@
                        <property name="title">
                         <string/>
                        </property>
+                       <property name="flat">
+                        <bool>true</bool>
+                       </property>
                        <layout class="QGridLayout" name="gridLayout_12">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
                         <item row="0" column="0">
                          <widget class="QLabel" name="label_14">
                           <property name="text">

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -123,11 +123,13 @@ bool AppSerial::GetSettings(const QString &portName)
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {
                         // booleans
                         memset(App_Common::boolSettings, false, sizeof(App_Common::boolSettings));
-                        for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
+                        for(int i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; ++i) {
                             if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
                                 port.read((char*)&App_Common::boolSettings[App_Common::dataCurrent][i], sizeof(bool));
-                            else if(port.bytesAvailable()) port.read(1);
-                            else if(!port.waitForReadyRead(2000)) break;
+                            else if(port.bytesAvailable()) {
+                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                else port.read(1);
+                            } else if(!port.waitForReadyRead(500)) break;
                         }
                         memcpy(App_Common::boolSettings[App_Common::dataOrig],
                                App_Common::boolSettings[App_Common::dataCurrent],
@@ -141,11 +143,13 @@ bool AppSerial::GetSettings(const QString &portName)
                             if(OneShotSend((char)OF_Const::sGetPins, true)) {
                                 App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
-                                for(uint8_t i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; i++) {
+                                for(int i = 0;; ++i) {
                                     if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
                                         port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                    else if(port.bytesAvailable()) port.read(1);
-                                    else if(!port.waitForReadyRead(2000)) break;
+                                    else if(port.bytesAvailable()) {
+                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                        else port.read(1);
+                                    } else if(!port.waitForReadyRead(500)) break;
                                 }
                             } else {
                                 printf("Didn't receive any data in time!\n");
@@ -162,10 +166,11 @@ bool AppSerial::GetSettings(const QString &portName)
                         port.clear();
                         if(OneShotSend((char)OF_Const::sGetSettings, true)) {
                             memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                            while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
-                                if(!port.bytesAvailable()) { if(!port.waitForReadyRead(2000)) break; }
+                            while(true) {
+                                if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                else if(port.bytesAvailable() < 5) { if(!port.waitForReadyRead(500)) break; }
                                 else {
-                                    uint8_t i = port.read(1).at(0);
+                                    int i = port.read(1).at(0);
                                     if(i < OF_Const::settingsTypesCount)
                                         port.read((char*)&App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t));
                                 }
@@ -180,8 +185,9 @@ bool AppSerial::GetSettings(const QString &portName)
                             port.clear();
                             if(OneShotSend((char)OF_Const::sGetPeriphs, true)) {
                                 memset(App_Common::i2cPeriphs, 0, sizeof(App_Common::i2cPeriphs));
-                                while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
-                                    if(!port.bytesAvailable()) { if(!port.waitForReadyRead(2000)) break; }
+                                while(true) {
+                                    if(!port.bytesAvailable()) { if(!port.waitForReadyRead(500)) break; }
+                                    else if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
                                     else {
                                         switch(port.read(1).at(0)) {
                                         case (char)OF_Const::i2cDevicesEnabled:
@@ -197,13 +203,15 @@ bool AppSerial::GetSettings(const QString &portName)
                                             break;
                                         }
                                         case (char)OF_Const::i2cOLED:
-                                            while(port.peek(1).at(0) != (char)OF_Const::serialTerminator) {
-                                                if(port.bytesAvailable()) {
+                                            while(true) {
+                                                if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+                                                else if(port.bytesAvailable() < 5) { if(!port.waitForReadyRead(500)) break; }
+                                                else {
                                                     int type = port.read(1).at(0);
                                                     if(type < OF_Const::oledSettingsTypes)
                                                         port.read((char*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], sizeof(uint32_t));
                                                     else port.read(sizeof(uint32_t));
-                                                } else if(!port.waitForReadyRead(2000)) break;
+                                                }
                                             }
                                             break;
                                         default: break;
@@ -222,7 +230,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                 // profiles
                                 App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
 
-                                for(uint8_t i = 0;; i++) {
+                                for(int i = 0;; ++i) {
                                     port.clear();
                                     if(char buf[] = {(char)OF_Const::sGetProfile, (char)i}; OneShotSend(buf, 2, true)) {
                                         if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {


### PR DESCRIPTION
Turns out, reading logic for longer transactions was fuuuucked and either didn't work, waited too early, or (more commonly) causes an out-of-bounds read exception when peeking into the port when there was no data in a routine that expects to exit via `serialTerminator`. That was my bad, so this should fix that.

Tested with the firmwares with a long-enough settings (temperature settings), the app reads it without any noticeable additional wait in the transaction.

Temperatures can now be customized. However, since the defaults were picked *for very good reason* and are going to reduce life of solenoid when raised, these are hidden behind the new *Show Unsafe Settings* toggle, appropriately under the new *View* appmenu category.