### PR TITLE
Improve Pin Highlighting to be more flexible to source file formatting

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -174,11 +174,15 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
         {
             // Copy and modify board pic array to change opacity of selected pin element, if existing.
             highlightBoardPic = origBoardPicFile;
-            highlightBoardPic.replace(QString("id=\"OF_pin%1\"\nstyle=\"opacity:0").arg(object->property("slot").toInt()),
-                                      QString("id=\"OF_pin%1\"\nstyle=\"opacity:1").arg(object->property("slot").toInt()));
-
-            boardPic.load(highlightBoardPic.toLocal8Bit());
-            boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+            int i = highlightBoardPic.indexOf(QString("id=\"OF_pin%1\"").arg(object->property("slot").toInt()));
+            if(i > -1) {
+                i = highlightBoardPic.indexOf("opacity:0", i);
+                if(i > -1) {
+                    highlightBoardPic.replace(i+8, 1, '1');
+                    boardPic.load(highlightBoardPic.toLocal8Bit());
+                    boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+                }
+            }
             break;
         }
         case App_Common::trackSettingsItem:

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -53,11 +53,15 @@ bool AppBoardsPreviewer::eventFilter(QObject* object, QEvent* event)
     if(event->type() == QEvent::Enter) {
         // Copy and modify board pic array to change opacity of selected pin element, if existing.
         highlightBoardPic = origBoardPicFile;
-        highlightBoardPic.replace(QString("id=\"OF_pin%1\"\nstyle=\"opacity:0").arg(object->property("slot").toInt()),
-                                  QString("id=\"OF_pin%1\"\nstyle=\"opacity:1").arg(object->property("slot").toInt()));
-
-        boardPic.load(highlightBoardPic.toLocal8Bit());
-        boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+        int i = highlightBoardPic.indexOf(QString("id=\"OF_pin%1\"").arg(object->property("slot").toInt()));
+        if(i > -1) {
+            i = highlightBoardPic.indexOf("opacity:0", i);
+            if(i > -1) {
+                highlightBoardPic.replace(i+8, 1, '1');
+                boardPic.load(highlightBoardPic.toLocal8Bit());
+                boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
+            }
+        }
     } else if(event->type() == QEvent::Leave) {
         boardPic.load(origBoardPicFile);
         boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);


### PR DESCRIPTION
Because of feedback regarding the difficulty of implementing highlights originally, the method was made more robust so that it uses an iterator for each individual element of the needed strings to get to the `opacity:0` line that needs to be modified, rather than depending on exact formatting that demanded required manual intervention.

Depending on the app used to export these files, some manual tweaking *might* still be needed? But at least now it won't break if, for example, someone modifies from Windows with its insistence on Carriage Return+Newlines.

Incidentally, this is also what was needed to make the GH actions artifacts actually show highlights? Neat!

Also, Arduino Nano pic works now. Oops.