### PR TITLE
More robust buffer checks and wait before starting commit sequence to make sure board is ready

### DIFF
--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -329,6 +329,13 @@ bool AppSerial::CommitSettings()
         emit Serial_SetProgressRange(8);
 
         if(OneShotSend((char)OF_Const::sCommitStart, true)) {
+            // in case board sends a stale temp/analog state response.
+            emit Serial_ProgressUpdate(0, "Waiting for board...");
+            do {
+                if(port.read(1).at(0) == (char)OF_Const::sCommitStart) break;
+                if(!port.bytesAvailable()) if(!port.waitForReadyRead(1000)) break;
+            } while (port.bytesAvailable());
+
             port.clear();
 
             char buf[64];


### PR DESCRIPTION
An attempt at addressing a concern brought up with #57 (i think?); because test outputs should always be sent *before* the commit readback, actually check what's being sent for that signal before going on with the commit op.