### PR TITLE
Move to string keys-based lookups for syncing

### DIFF
--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -52,31 +52,35 @@ public:
         dataOrig
     } dataBlocks_e;
 
+    // Single instance of presets and board info
+    static inline OF_Const OFPresets;
+
     typedef struct boardInfo_t {
-        uint8_t    selectedProfile;
-        uint8_t    previousProfile;
+        int        selectedProfile;
+        int        previousProfile;
         QByteArray boardType;
         QByteArray versionNumber;
-        QByteArray versionCodename;
     } boardInfo_s;
 
     typedef struct tinyUSBtable_t {
         uint16_t   tinyUSBid;
-        QByteArray tinyUSBname;
+        char       tinyUSBname[16];
     } tinyUSBtable_s;
 
     typedef struct profilesTable_t {
-        int32_t  topOffset      = 0;
-        int32_t  bottomOffset   = 0;
-        int32_t  leftOffset     = 0;
-        int32_t  rightOffset    = 0;
-        float    TLled          = 0;
-        float    TRled          = 0;
-        uint8_t  irSensitivity  = 0;
-        uint8_t  runMode        = 0;
-        uint8_t  layoutType     = false;
-        uint32_t color          = 0;
-        QByteArray profName     = "";
+        int32_t    topOffset     = 0;
+        int32_t    bottomOffset  = 0;
+        int32_t    leftOffset    = 0;
+        int32_t    rightOffset   = 0;
+        float      TLled         = 0;
+        float      TRled         = 0;
+        float      AdjX          = 0;
+        float      AdjY          = 0;
+        uint32_t   irSensitivity = 0;
+        uint32_t   runMode       = 0;
+        uint32_t   layoutType    = false;
+        uint32_t   color         = 0;
+        char       profName[16]  = "";
     } profilesTable_s;
 
     // Currently loaded board object
@@ -90,11 +94,6 @@ public:
 
     /// @brief      Current array of tunable settings
     static inline uint32_t settingsTable[2][OF_Const::settingsTypesCount] = { 0 };
-
-    /// @brief      Array of I2C peripheral devices that can be toggled
-    static inline bool i2cPeriphs[2][OF_Const::i2cDevicesCount] = { false };
-
-    static inline uint32_t i2cOledPrefs[2][OF_Const::oledSettingsTypes] = { false };
 
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -109,7 +109,7 @@ guiWindow::guiWindow(QWidget *parent)
 
     // Setup test screen buttons
     for(int i = 0; i < 14; ++i) {
-        testLabel << new QLabel(OF_Const::valuesNameList[i+1]);
+        testLabel << new QLabel(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
 
         testLabel.at(i)->setEnabled(false);
         testLabel.at(i)->setAlignment(Qt::AlignCenter);
@@ -136,6 +136,8 @@ guiWindow::guiWindow(QWidget *parent)
     // set hidden by default until a board with presets is loaded
     ui->presetsBox->setVisible(true);
     ui->solenoidTempBox->setVisible(false);
+
+    ui->versionLabel->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
     statusBar()->showMessage("Welcome to the OpenFIRE app!", 3000);
 
@@ -237,10 +239,10 @@ void guiWindow::BoxesUpdate()
             App_Common::inputsMap = App_Common::inputsMap_orig;
 
             // copy presets to inputs map
-            if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
+            if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
                 for(int i = 0; i < pinBoxes.count(); ++i)
-                    if(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i) > OF_Const::btnUnmapped)
-                        App_Common::inputsMap[OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)] = i;
+                    if(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i) > OF_Const::btnUnmapped)
+                        App_Common::inputsMap[App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)] = i;
         }
 
         return;
@@ -252,9 +254,9 @@ void guiWindow::BoxesUpdate()
             pinBoxes.at(i)->setEnabled(false), pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if available, copy preset layout to pinboxes
-        if(OF_Const::boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
+        if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
             for(int i = 0; i < pinBoxes.count(); ++i)
-                pinBoxes.at(i)->setCurrentIndex(OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)+1);
+                pinBoxes.at(i)->setCurrentIndex(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)+1);
 
         return;
     }
@@ -263,67 +265,27 @@ void guiWindow::BoxesUpdate()
 
 void guiWindow::DiffUpdate()
 {
-    int settingsDiff = 0;
+    size_t settingsDiff = 0;
 
     if(memcmp(App_Common::boolSettings[App_Common::dataCurrent], App_Common::boolSettings[App_Common::dataOrig], sizeof(App_Common::boolSettings[App_Common::dataCurrent])))
-        settingsDiff++;
+        ++settingsDiff;
 
     if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins])
         if(App_Common::inputsMap_orig != App_Common::inputsMap)
-            settingsDiff++;
+            ++settingsDiff;
 
     if(memcmp(App_Common::settingsTable[App_Common::dataCurrent], App_Common::settingsTable[App_Common::dataOrig], sizeof(App_Common::settingsTable[App_Common::dataCurrent])))
-        settingsDiff++;
+        ++settingsDiff;
 
-    if(App_Common::tinyUSBtable_orig.tinyUSBid != App_Common::tinyUSBtable.tinyUSBid)
-        settingsDiff++;
-
-    if(App_Common::tinyUSBtable_orig.tinyUSBname != App_Common::tinyUSBtable.tinyUSBname)
-        settingsDiff++;
+    if(memcmp(&App_Common::tinyUSBtable_orig, &App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s)))
+        ++settingsDiff;
 
     if(App_Common::board.selectedProfile != App_Common::board.previousProfile)
-        settingsDiff++;
+        ++settingsDiff;
 
-    if(memcmp(App_Common::i2cPeriphs[App_Common::dataCurrent], App_Common::i2cPeriphs[App_Common::dataOrig], sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent])))
-        settingsDiff++;
-
-    if(memcmp(App_Common::i2cOledPrefs[App_Common::dataCurrent], App_Common::i2cOledPrefs[App_Common::dataOrig], sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent])))
-        settingsDiff++;
-
-    for(uint8_t i = 0; i < App_Common::profilesTable.count(); ++i) {
-        if(App_Common::profilesTable_orig[i].profName != App_Common::profilesTable[i].profName)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].topOffset != App_Common::profilesTable[i].topOffset)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].bottomOffset != App_Common::profilesTable[i].bottomOffset)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].leftOffset != App_Common::profilesTable[i].leftOffset)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].rightOffset != App_Common::profilesTable[i].rightOffset)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].TLled != App_Common::profilesTable[i].TLled)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].TRled != App_Common::profilesTable[i].TRled)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].irSensitivity != App_Common::profilesTable[i].irSensitivity)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].runMode != App_Common::profilesTable[i].runMode)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].layoutType != App_Common::profilesTable[i].layoutType)
-            settingsDiff++;
-
-        if(App_Common::profilesTable_orig[i].color != App_Common::profilesTable[i].color)
-            settingsDiff++;
-    }
+    for(size_t i = 0; i < App_Common::profilesTable.count(); ++i)
+        if(memcmp(&App_Common::profilesTable_orig.at(i), &App_Common::profilesTable.at(i), sizeof(App_Common::profilesTable_s)))
+            ++settingsDiff;
 
     if(settingsDiff) {
         ui->confirmButton->setText("Save and Send Settings");
@@ -341,9 +303,9 @@ QString guiWindow::PrettifyName(QString name)
         name = "Unnamed Device";
 
     // append name of board to gun name string.
-    if(OF_Const::boardNames.count(App_Common::board.boardType.toStdString()))
-         return name + " | " + OF_Const::boardNames.at(App_Common::board.boardType.toStdString());
-    else return name + " | " + OF_Const::boardNames.at("generic");
+    if(App_Common::OFPresets.boardNames.count(App_Common::board.boardType.toStdString()))
+         return name + " | " + App_Common::OFPresets.boardNames.at(App_Common::board.boardType.toStdString());
+    else return name + " | " + App_Common::OFPresets.boardNames.at("generic");
 }
 
 
@@ -415,30 +377,22 @@ void guiWindow::on_confirmButton_clicked()
             if(App_Common::boolSettings[App_Common::dataOrig][OF_Const::customPins])
                 App_Common::inputsMap_orig = App_Common::inputsMap;
             else for(int i = 0; i < App_Common::inputsMap.size(); ++i)
-                    App_Common::inputsMap_orig[i] = -1;
+                App_Common::inputsMap_orig[i] = -1;
 
             memcpy(App_Common::settingsTable[App_Common::dataOrig],
                    App_Common::settingsTable[App_Common::dataCurrent],
                    sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
-            memcpy(App_Common::i2cPeriphs[App_Common::dataOrig],
-                   App_Common::i2cPeriphs[App_Common::dataCurrent],
-                   sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent]));
-            memcpy(App_Common::i2cOledPrefs[App_Common::dataOrig],
-                   App_Common::i2cOledPrefs[App_Common::dataCurrent],
-                   sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent]));
+            memcpy(&App_Common::tinyUSBtable_orig,
+                   &App_Common::tinyUSBtable,
+                   sizeof(App_Common::tinyUSBtable_s));
 
-            App_Common::tinyUSBtable_orig.tinyUSBid = App_Common::tinyUSBtable.tinyUSBid;
-            App_Common::tinyUSBtable_orig.tinyUSBname = App_Common::tinyUSBtable.tinyUSBname;
             App_Common::board.previousProfile = App_Common::board.selectedProfile;
 
-            for(uint8_t i = 0; i < App_Common::profilesTable.count(); ++i) {
-                App_Common::profilesTable_orig[i].irSensitivity = App_Common::profilesTable[i].irSensitivity;
-                App_Common::profilesTable_orig[i].runMode = App_Common::profilesTable[i].runMode;
-                App_Common::profilesTable_orig[i].layoutType = App_Common::profilesTable[i].layoutType;
-                App_Common::profilesTable_orig[i].color = App_Common::profilesTable[i].color;
-                App_Common::profilesTable_orig[i].profName = App_Common::profilesTable[i].profName;
-            }
+            for(size_t i = 0; i < App_Common::profilesTable.count(); ++i)
+                memcpy(&App_Common::profilesTable_orig[i],
+                       &App_Common::profilesTable[i],
+                       sizeof(App_Common::profilesTable_s));
 
             // Reflect new names in UI
             LabelsUpdate();
@@ -530,7 +484,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                                               "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
                 connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
 
-                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(QString(App_Common::profilesTable.at(i).profName.constData())));
+                selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Common::profilesTable.at(i).profName));
                 if(i == App_Common::board.selectedProfile)
                     selectedProfile.at(i)->setChecked(true);
                 selectedProfile.at(i)->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
@@ -652,7 +606,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinLabel.clear();
             }
 
-            for(uint8_t i = 0; i < OF_Const::boardsPresetsMap.at(App_Common::board.boardType.toStdString()).size(); ++i) {
+            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).size(); ++i) {
                 pinBoxes << new QComboBox();
                 pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinBoxes.at(i)->setProperty("slot", i);
@@ -660,7 +614,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinBoxes.at(i)->setProperty("trackable", App_Common::trackPinbox);
                 pinBoxes.at(i)->installEventFilter(this);
                 // install items
-                for(auto item : OF_Const::valuesNameList)
+                for(auto item : App_Common::OFPresets.boardInputs_sortedStr)
                     pinBoxes.at(i)->addItem(item);
                 // clear out analog options for digital pins (< GPIO26)
                 // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
@@ -677,8 +631,6 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                     SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
                     SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
                 }
-                // for now, disable unused "battery sensor" option.
-                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::battery+1, false);
                 // connect up combobox signal
                 connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
 
@@ -695,16 +647,16 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
             }
 
-            ui->versionLabel->setText(QString("v%1 - \"%2\"").arg(App_Common::board.versionNumber, App_Common::board.versionCodename));
+            ui->versionLabel->setText("FW v" + App_Common::board.versionNumber);
 
             // update presets box if this board has any
             ui->presetsBox->clear();
 
-            if(OF_Const::boardsAltPresets.count(App_Common::board.boardType.toStdString())) {
+            if(App_Common::OFPresets.boardsAltPresets.count(App_Common::board.boardType.toStdString())) {
                 ui->presetsBox->setHidden(false);
                 ui->presetsBox->setEnabled(true);
 
-                auto iter = OF_Const::boardsAltPresets.equal_range(App_Common::board.boardType.toStdString());
+                auto iter = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.boardType.toStdString());
                 for(auto i = iter.first; i != iter.second; ++i)
                     ui->presetsBox->addItem(i->second.name);
             } else {
@@ -718,33 +670,33 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             LabelsUpdate();
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(OF_Const::boardsBoxPositions.count(App_Common::board.boardType.toStdString())) {
+            if(App_Common::OFPresets.boardsBoxPositions.count(App_Common::board.boardType.toStdString())) {
                 QFile resource(":/boardPics/" + App_Common::board.boardType);
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < pinBoxes.count(); ++i) {
-                    if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posLeft) {
+                    if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
                                                 1);
-                    } else if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posRight) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
                                                  0);
-                    } else if(OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posMiddle) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     OF_Const::boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
                     }
                 }
             } else {
@@ -753,27 +705,27 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < pinBoxes.count(); ++i) {
-                    if(OF_Const::boardsBoxPositions.at("generic").at(i) & OF_Const::posLeft) {
+                    if(App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posLeft,
                                                 1);
-                    } else if(OF_Const::boardsBoxPositions.at("generic").at(i) & OF_Const::posRight) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posRight,
                                                  0);
-                    } else if(OF_Const::boardsBoxPositions.at("generic").at(i) & OF_Const::posMiddle) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     OF_Const::boardsBoxPositions.at("generic").at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at("generic").at(i) ^ OF_Const::posMiddle);
                     }
                 }
             }
@@ -821,8 +773,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->tempWarningBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempWarning]);
             ui->tempShutoffBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown]);
 
-            ui->i2cOLEDtoggle->setChecked(App_Common::i2cPeriphs[App_Common::dataOrig][OF_Const::i2cOLED]);
-            ui->oledAltAddrsToggle->setChecked(App_Common::i2cOledPrefs[App_Common::dataOrig][OF_Const::oledAltAddr]);
+            ui->i2cOLEDtoggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLED]);
+            ui->oledAltAddrsToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLEDaltAddr]);
 
             ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
@@ -904,10 +856,10 @@ void guiWindow::LabelsUpdate()
     for(uint8_t i = 0; i < testLabel.count(); ++i) {
         testLabel.at(i)->setStyleSheet("");
         if(App_Common::inputsMap.value(i) >= 0) {
-            testLabel.at(i)->setText(OF_Const::valuesNameList[i+1]);
+            testLabel.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
             testLabel.at(i)->setEnabled(true);
         } else {
-            testLabel.at(i)->setText(QByteArray(OF_Const::valuesNameList[i+1]) + " (N/C)");
+            testLabel.at(i)->setText(QByteArray(App_Common::OFPresets.boardInputs_sortedStr[i+1]) + " (N/C)");
             testLabel.at(i)->setEnabled(false);
         }
     }
@@ -939,7 +891,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
 
     /* For debugging pinBoxes (too lazy to ifdef guard)
     if(index >= 0 && index <= App_Common::inputsMap.size()) {
-        //printf("Requesting pinbox %d to set to %s\n", sender()->property("slot").toInt(), OF_Const::valuesNameList.at(index).toLocal8Bit().constData());
+        //printf("Requesting pinbox %d to set to %s\n", sender()->property("slot").toInt(), App_Common::OFPresets.boardInputs_sortedStr.at(index).toLocal8Bit().constData());
     } else printf("Oops! Seems like pinbox %d is trying to set itself to index %d, which is out of range!\n", sender()->property("slot").toInt(), index);
     //*/
 
@@ -1083,7 +1035,8 @@ void guiWindow::renameBoxes_clicked()
 
     if(!newLabel.isEmpty()) {
         selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()+1).arg(newLabel.left(15)));
-        App_Common::profilesTable[sender()->property("slot").toInt()].profName = newLabel.left(15).toLocal8Bit();
+        memset(App_Common::profilesTable[sender()->property("slot").toInt()].profName, 0, sizeof(App_Common::profilesTable_s::profName));
+        strcpy(App_Common::profilesTable[sender()->property("slot").toInt()].profName, newLabel.left(15).toLocal8Bit().constData());
     }
 
     DiffUpdate();
@@ -1149,7 +1102,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
             pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // set pinboxes to alt preset values (and let the index changed signal handle the rest)
-        auto preset = OF_Const::boardsAltPresets.equal_range(App_Common::board.boardType.toStdString()).first;
+        auto preset = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.boardType.toStdString()).first;
         for(int i = 0; i < index; ++i)
             preset++;
 
@@ -1325,7 +1278,8 @@ void guiWindow::on_tUSB_p1_toggled(bool checked)
 {
     if(checked) {
         App_Common::tinyUSBtable.tinyUSBid = 1;
-        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P1";
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P1");
         ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
@@ -1338,7 +1292,8 @@ void guiWindow::on_tUSB_p2_toggled(bool checked)
 {
     if(checked) {
         App_Common::tinyUSBtable.tinyUSBid = 2;
-        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P2";
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P2");
         ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
@@ -1351,7 +1306,8 @@ void guiWindow::on_tUSB_p3_toggled(bool checked)
 {
     if(checked) {
         App_Common::tinyUSBtable.tinyUSBid = 3;
-        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P3";
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P3");
         ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
@@ -1364,7 +1320,8 @@ void guiWindow::on_tUSB_p4_toggled(bool checked)
 {
     if(checked) {
         App_Common::tinyUSBtable.tinyUSBid = 4;
-        App_Common::tinyUSBtable.tinyUSBname = "FIRECon P4";
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P4");
         ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
         ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
@@ -1421,7 +1378,8 @@ void guiWindow::on_productNameInput_textEdited(const QString &arg1)
     } else {
         if(!ui->productNameInput->styleSheet().isEmpty())
             ui->productNameInput->setStyleSheet("");
-        App_Common::tinyUSBtable.tinyUSBname = arg1.toLocal8Bit();
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, arg1.toLocal8Bit().constData());
         DiffUpdate();
     }
 }
@@ -1586,7 +1544,7 @@ void guiWindow::on_invertStaticPixelsBox_stateChanged(int arg1)
 
 void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 {
-    App_Common::i2cPeriphs[App_Common::dataCurrent][OF_Const::i2cOLED] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::i2cOLED] = arg1;
     ui->oledGroup->setEnabled(arg1);
 
     DiffUpdate();
@@ -1595,7 +1553,7 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 
 void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
 {
-    App_Common::i2cOledPrefs[App_Common::dataCurrent][OF_Const::oledAltAddr] = arg1;
+    App_Common::boolSettings[App_Common::dataCurrent][OF_Const::i2cOLEDaltAddr] = arg1;
 
     DiffUpdate();
 }

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -33,7 +33,7 @@
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -49,7 +49,7 @@
          <string>COM Port:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -79,14 +79,14 @@
        <string notr="true"/>
       </property>
       <property name="alignment">
-       <set>Qt::AlignmentFlag::AlignCenter</set>
+       <set>Qt::AlignCenter</set>
       </property>
      </widget>
     </item>
     <item>
      <widget class="Line" name="line">
       <property name="orientation">
-       <enum>Qt::Orientation::Horizontal</enum>
+       <enum>Qt::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -95,24 +95,25 @@
       <property name="font">
        <font>
         <pointsize>11</pointsize>
-        <italic>true</italic>
+        <italic>false</italic>
+        <bold>true</bold>
        </font>
       </property>
       <property name="text">
        <string notr="true"/>
       </property>
       <property name="textFormat">
-       <enum>Qt::TextFormat::PlainText</enum>
+       <enum>Qt::PlainText</enum>
       </property>
       <property name="alignment">
-       <set>Qt::AlignmentFlag::AlignCenter</set>
+       <set>Qt::AlignCenter</set>
       </property>
      </widget>
     </item>
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="tabPosition">
-       <enum>QTabWidget::TabPosition::South</enum>
+       <enum>QTabWidget::South</enum>
       </property>
       <property name="currentIndex">
        <number>0</number>
@@ -128,16 +129,16 @@
         <item>
          <widget class="QScrollArea" name="pinsScrollArea">
           <property name="frameShadow">
-           <enum>QFrame::Shadow::Plain</enum>
+           <enum>QFrame::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
           </property>
           <widget class="QWidget" name="scrollAreaWidgetContents">
            <property name="geometry">
@@ -184,7 +185,7 @@
         </item>
         <item>
          <layout class="QHBoxLayout" name="PinsBottomHalf">
-          <item alignment="Qt::AlignmentFlag::AlignBottom">
+          <item alignment="Qt::AlignBottom">
            <widget class="QCheckBox" name="customPinsEnabled">
             <property name="enabled">
              <bool>true</bool>
@@ -218,7 +219,7 @@
           <item>
            <spacer name="horizontalSpacer_14">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -234,14 +235,14 @@
              <string>User Layouts</string>
             </property>
             <property name="popupMode">
-             <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+             <enum>QToolButton::InstantPopup</enum>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
+             <enum>Qt::ToolButtonTextBesideIcon</enum>
             </property>
            </widget>
           </item>
-          <item alignment="Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignBottom">
+          <item alignment="Qt::AlignRight|Qt::AlignBottom">
            <widget class="QComboBox" name="presetsBox">
             <property name="enabled">
              <bool>false</bool>
@@ -266,16 +267,16 @@
         <item>
          <widget class="QScrollArea" name="settingsScrollArea">
           <property name="frameShadow">
-           <enum>QFrame::Shadow::Plain</enum>
+           <enum>QFrame::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
           </property>
           <widget class="QWidget" name="settingsScrollContents">
            <property name="geometry">
@@ -326,10 +327,10 @@
                         <string>Rumble Intensity:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::TextFormat::PlainText</enum>
+                        <enum>Qt::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -348,10 +349,10 @@
                         <bool>true</bool>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> / 255</string>
@@ -370,10 +371,10 @@
                         <string>Rumble Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::TextFormat::PlainText</enum>
+                        <enum>Qt::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -389,10 +390,10 @@
                         <string>Length of Rumble Events</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -405,7 +406,7 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="0" colspan="4" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="1" column="0" colspan="4" alignment="Qt::AlignHCenter">
                       <widget class="QCheckBox" name="rumbleFFToggle">
                        <property name="toolTip">
                         <string/>
@@ -427,7 +428,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignHCenter">
                    <widget class="QCheckBox" name="rumbleToggle">
                     <property name="toolTip">
                      <string/>
@@ -449,7 +450,7 @@
                  </layout>
                 </widget>
                </item>
-               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignHCenter">
                 <widget class="QCheckBox" name="autofireToggle">
                  <property name="toolTip">
                   <string/>
@@ -474,7 +475,7 @@
                   <string>Solenoid</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignHCenter">
                    <widget class="QCheckBox" name="solenoidToggle">
                     <property name="toolTip">
                      <string/>
@@ -529,7 +530,7 @@
                            <string>Temperature Warning Threshold:</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                           </property>
                          </widget>
                         </item>
@@ -539,7 +540,7 @@
                            <string>Temperature Shutoff Threshold:</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                           </property>
                          </widget>
                         </item>
@@ -593,10 +594,10 @@
                         <string>Solenoid ON Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::TextFormat::PlainText</enum>
+                        <enum>Qt::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -612,10 +613,10 @@
                         <string>Solenoid Engagement Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -637,10 +638,10 @@
                         <string>Solenoid Autofire Wait Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -656,10 +657,10 @@
                         <string>Solenoid Autofire Wait Time:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::TextFormat::PlainText</enum>
+                        <enum>Qt::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>
@@ -672,10 +673,10 @@
                         <string>Solenoid Hold-to-Autofire Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::TextFormat::PlainText</enum>
+                        <enum>Qt::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>
@@ -694,10 +695,10 @@
                         <string>Solenoid Trigger Hold to Autofire Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -725,7 +726,7 @@
                <string>Lighting</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
-               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignHCenter">
                 <widget class="QCheckBox" name="commonAnodeToggle">
                  <property name="toolTip">
                   <string/>
@@ -756,7 +757,7 @@
                      <string>NeoPixel Strand Length: </string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -841,10 +842,10 @@
                      <string>NeoPixel Strand Length</string>
                     </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                     <enum>QAbstractSpinBox::PlusMinus</enum>
                     </property>
                     <property name="correctionMode">
-                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                     <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                     </property>
                     <property name="suffix">
                      <string> Pixel(s)</string>
@@ -902,14 +903,14 @@
                      <string>Changes to NeoPixel settings may require a power cycle to update properly!</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                     <set>Qt::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item row="0" column="0" rowspan="2">
                    <spacer name="horizontalSpacer_3">
                     <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
+                     <enum>Qt::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -925,14 +926,14 @@
                      <string>Static NeoPixels: </string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item row="0" column="5" rowspan="2">
                    <spacer name="horizontalSpacer_4">
                     <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
+                     <enum>Qt::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -970,7 +971,7 @@
                <string>Input</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
-               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignHCenter">
                 <widget class="QCheckBox" name="lowButtonsToggle">
                  <property name="toolTip">
                   <string/>
@@ -1010,10 +1011,10 @@
                   <string>Length to activate Hold-to-Pause Menu</string>
                  </property>
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
+                  <enum>QAbstractSpinBox::PlusMinus</enum>
                  </property>
                  <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                  <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
                  </property>
                  <property name="suffix">
                   <string> ms</string>
@@ -1029,7 +1030,7 @@
                <item row="1" column="4">
                 <spacer name="horizontalSpacer_2">
                  <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+                  <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1045,10 +1046,10 @@
                   <string>Hold-to-Pause Length:</string>
                  </property>
                  <property name="textFormat">
-                  <enum>Qt::TextFormat::PlainText</enum>
+                  <enum>Qt::PlainText</enum>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                  <property name="wordWrap">
                   <bool>true</bool>
@@ -1077,7 +1078,7 @@
                <item row="1" column="0">
                 <spacer name="horizontalSpacer_5">
                  <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+                  <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1087,7 +1088,7 @@
                  </property>
                 </spacer>
                </item>
-               <item row="0" column="1" colspan="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+               <item row="0" column="1" colspan="3" alignment="Qt::AlignHCenter">
                 <widget class="QCheckBox" name="simplePauseToggle">
                  <property name="toolTip">
                   <string/>
@@ -1115,7 +1116,7 @@
                <string>I2C Peripherals</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
-               <item alignment="Qt::AlignmentFlag::AlignHCenter">
+               <item alignment="Qt::AlignHCenter">
                 <widget class="QCheckBox" name="i2cOLEDtoggle">
                  <property name="whatsThis">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE:&lt;/span&gt; Because this device does not communicate back to the board, the firmware has no way of knowing whether the device successfully initialized or not. If the display is connected properly, but does &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; seem to power on on startup/after syncing settings, then try the &lt;span style=&quot; font-style:italic;&quot;&gt;Use Alternative Device Address&lt;/span&gt; setting before attempting to rewire the device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1137,7 +1138,7 @@
                   <string>SSD1306 OLED Display</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignHCenter">
                    <widget class="QCheckBox" name="oledAltAddrsToggle">
                     <property name="whatsThis">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the display doesn't seem to power on when &lt;span style=&quot; font-style:italic;&quot;&gt;Enable OLED Display&lt;/span&gt; is set on startup/after syncing settings to the device (and you have confirmed that it is wired correctly), enabling this will try a different start address.&lt;/p&gt;&lt;p&gt;The firmware's display component normally defaults to I2C address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3C&lt;/span&gt;, but some 128x64 screens may have device address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3D&lt;/span&gt; instead, which this setting will inform the firmware to try instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1162,7 +1163,7 @@
             <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1192,7 +1193,7 @@
                   <string>For Multiplayer, make sure each gun has its own unique identifier!</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                  <set>Qt::AlignCenter</set>
                  </property>
                 </widget>
                </item>
@@ -1207,7 +1208,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                  <set>Qt::AlignCenter</set>
                  </property>
                  <property name="flat">
                   <bool>true</bool>
@@ -1222,7 +1223,7 @@
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start/Select key mappings will default to &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; binds (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) for custom identifiers set here:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                     <set>Qt::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -1234,17 +1235,17 @@
                        <string>Product ID:</string>
                       </property>
                       <property name="textFormat">
-                       <enum>Qt::TextFormat::PlainText</enum>
+                       <enum>Qt::PlainText</enum>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                       </property>
                      </widget>
                     </item>
                     <item row="0" column="0">
                      <spacer name="horizontalSpacer_9">
                       <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
+                       <enum>Qt::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -1263,7 +1264,7 @@
                        <string>Custom USB Product ID</string>
                       </property>
                       <property name="buttonSymbols">
-                       <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                       <enum>QAbstractSpinBox::NoButtons</enum>
                       </property>
                       <property name="prefix">
                        <string>0x</string>
@@ -1285,17 +1286,17 @@
                        <string>Product Name:</string>
                       </property>
                       <property name="textFormat">
-                       <enum>Qt::TextFormat::PlainText</enum>
+                       <enum>Qt::PlainText</enum>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                       </property>
                      </widget>
                     </item>
                     <item row="0" column="3">
                      <spacer name="horizontalSpacer_8">
                       <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
+                       <enum>Qt::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -1349,7 +1350,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                  <set>Qt::AlignCenter</set>
                  </property>
                  <property name="flat">
                   <bool>true</bool>
@@ -1364,13 +1365,13 @@
                      <string>Start/Select key mappings will change according to the player identifier set here:</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                     <set>Qt::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_8">
-                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item alignment="Qt::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p1">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1386,7 +1387,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item alignment="Qt::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p2">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1402,7 +1403,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item alignment="Qt::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p3">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1418,7 +1419,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item alignment="Qt::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p4">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1439,7 +1440,7 @@
                  </layout>
                 </widget>
                </item>
-               <item alignment="Qt::AlignmentFlag::AlignRight">
+               <item alignment="Qt::AlignRight">
                 <widget class="QCheckBox" name="tinyUSBLayoutToggle">
                  <property name="whatsThis">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines whether to show/use &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Presets&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Custom USB ID Settings.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This can be useful for users with either more than four OpenFIRE lightguns, or simply want to personalize each lightgun, but the &lt;span style=&quot; font-style:italic;&quot;&gt;Simple Presets&lt;/span&gt; may be preferable to some.&lt;/p&gt;&lt;p&gt;All lightguns default to a &lt;span style=&quot; font-style:italic;&quot;&gt;P1 Simple USB ID Preset.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1488,7 +1489,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab has a variety of settings to tweak about the lightgun's force feedback, lighting effects, and how it presents itself to the device.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -1511,16 +1512,16 @@
         <item>
          <widget class="QScrollArea" name="profilesScrollArea">
           <property name="frameShadow">
-           <enum>QFrame::Shadow::Plain</enum>
+           <enum>QFrame::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
           </property>
           <widget class="QWidget" name="profilesScrollContents">
            <property name="geometry">
@@ -1543,14 +1544,14 @@
                  <item row="0" column="6">
                   <widget class="Line" name="line_5">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="16">
                   <widget class="Line" name="line_8">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1560,7 +1561,7 @@
                     <string>Layout</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1570,7 +1571,7 @@
                     <string>Left</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1580,14 +1581,14 @@
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="14">
                   <widget class="Line" name="line_11">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1597,7 +1598,7 @@
                     <string>Right</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1607,7 +1608,7 @@
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1617,7 +1618,7 @@
                     <string>Bottom</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1627,14 +1628,14 @@
                     <string>Run Mode</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="10">
                   <widget class="Line" name="line_7">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1644,14 +1645,14 @@
                     <string>TRled</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="18">
                   <widget class="Line" name="line_3">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1661,31 +1662,31 @@
                     <string>TLled</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="4">
                   <widget class="Line" name="line_4">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="8">
                   <widget class="Line" name="line_6">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="3">
                   <widget class="QLabel" name="topOffHeader">
                    <property name="frameShape">
-                    <enum>QFrame::Shape::NoFrame</enum>
+                    <enum>QFrame::NoFrame</enum>
                    </property>
                    <property name="frameShadow">
-                    <enum>QFrame::Shadow::Plain</enum>
+                    <enum>QFrame::Plain</enum>
                    </property>
                    <property name="lineWidth">
                     <number>1</number>
@@ -1694,21 +1695,21 @@
                     <string>Top</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="20">
                   <widget class="Line" name="line_9">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="12">
                   <widget class="Line" name="line_10">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
+                    <enum>Qt::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1718,7 +1719,7 @@
                     <string>Color</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1728,14 +1729,14 @@
                     <string>Sensitivity</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="2">
                   <spacer name="horizontalSpacer_15">
                    <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
+                    <enum>Qt::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -1756,7 +1757,7 @@
             <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1796,7 +1797,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows information and settings to tweak about your current calibration profiles.&lt;/p&gt;&lt;p&gt;The table above represents the amount of profiles the current board can store, including currently selected profile, names shown for each profile when using a compatible &lt;span style=&quot; font-style:italic;&quot;&gt;I2C Display,&lt;/span&gt; and colors used for lighting devices when switching to them from &lt;span style=&quot; font-style:italic;&quot;&gt;Pause Mode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -1805,7 +1806,7 @@
               <bool>true</bool>
              </property>
              <property name="textInteractionFlags">
-              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
              </property>
             </widget>
            </item>
@@ -1849,16 +1850,16 @@
               <item>
                <widget class="QLabel" name="tmp36Label">
                 <property name="frameShape">
-                 <enum>QFrame::Shape::Box</enum>
+                 <enum>QFrame::Box</enum>
                 </property>
                 <property name="frameShadow">
-                 <enum>QFrame::Shadow::Raised</enum>
+                 <enum>QFrame::Raised</enum>
                 </property>
                 <property name="text">
                  <string>Temperature Sensor (N/A)</string>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>
@@ -1900,7 +1901,7 @@
                  <string/>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>
@@ -1922,16 +1923,16 @@
                  </size>
                 </property>
                 <property name="verticalScrollBarPolicy">
-                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+                 <enum>Qt::ScrollBarAlwaysOff</enum>
                 </property>
                 <property name="horizontalScrollBarPolicy">
-                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+                 <enum>Qt::ScrollBarAlwaysOff</enum>
                 </property>
                 <property name="interactive">
                  <bool>false</bool>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                 </property>
                </widget>
               </item>
@@ -2003,7 +2004,7 @@
         <item>
          <spacer name="verticalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -2016,7 +2017,7 @@
         <item>
          <widget class="Line" name="line_2">
           <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -2136,7 +2137,7 @@
     <string>Import Custom Layout...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::TextHeuristicRole</enum>
+    <enum>QAction::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="actionExport_Custom_Layout">
@@ -2144,7 +2145,7 @@
     <string>Export Custom Layout...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::TextHeuristicRole</enum>
+    <enum>QAction::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="actionDebug_Window">

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -38,7 +38,7 @@ AppBoardsPreviewer::AppBoardsPreviewer(QWidget *parent)
     ui->PinsCenter->insertWidget(0, &boardPic, 1);
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    for(auto &item : OF_Const::boardNames)
+    for(auto &item : App_Common::OFPresets.boardNames)
         if(strcmp(item.first.data(), "generic"))
             ui->boardSelector->addItem(item.second);
 }
@@ -72,7 +72,7 @@ bool AppBoardsPreviewer::eventFilter(QObject* object, QEvent* event)
 
 void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1)
 {
-    for(auto &board : OF_Const::boardNames) {
+    for(auto &board : App_Common::OFPresets.boardNames) {
         if(!strcmp(board.second, arg1.toLocal8Bit().constData())) {
             // Clears old board layout items
             if(pinDefaultFunc.count()) {
@@ -88,7 +88,7 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                 pinLabel.clear();
             }
 
-            for(uint8_t i = 0; i < OF_Const::boardsPresetsMap.at(board.first).size(); i++) {
+            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(board.first).size(); i++) {
                 pinDefaultFunc << new QLabel();
                 pinDefaultFunc.at(i)->setFont(boldFont);
                 pinDefaultFunc.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -114,24 +114,24 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
             origBoardPicFile = resource.readAll();
 
             for(int i = 0; i < pinDefaultFunc.count(); i++) {
-                if(OF_Const::boardsBoxPositions.at(board.first).at(i) & OF_Const::posLeft) {
+                if(App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) & OF_Const::posLeft) {
                     ui->PinsLeft->addWidget(pinDefaultFunc.at(i),
-                                            OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posLeft, 0, Qt::AlignRight);
+                                            App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posLeft, 0, Qt::AlignRight);
                     ui->PinsLeft->addWidget(pinLabel.at(i),
-                                            OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posLeft, 1);
-                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).at(i)+1]);
-                } else if(OF_Const::boardsBoxPositions.at(board.first).at(i) & OF_Const::posRight) {
+                                            App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posLeft, 1);
+                    pinDefaultFunc.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[App_Common::OFPresets.boardsPresetsMap.at(board.first).at(i)+1]);
+                } else if(App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) & OF_Const::posRight) {
                     ui->PinsRight->addWidget(pinDefaultFunc.at(i),
-                                             OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posRight, 1);
+                                             App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posRight, 1);
                     ui->PinsRight->addWidget(pinLabel.at(i),
-                                             OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posRight, 0);
-                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).at(i)+1]);
-                } else if(OF_Const::boardsBoxPositions.at(board.first).at(i) & OF_Const::posMiddle) {
+                                             App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posRight, 0);
+                    pinDefaultFunc.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[App_Common::OFPresets.boardsPresetsMap.at(board.first).at(i)+1]);
+                } else if(App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) & OF_Const::posMiddle) {
                     ui->PinsCenterSub->addWidget(pinDefaultFunc.at(i), 1,
-                                                 OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posMiddle, Qt::AlignCenter);
+                                                 App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posMiddle, Qt::AlignCenter);
                     ui->PinsCenterSub->addWidget(pinLabel.at(i), 0,
-                                                 OF_Const::boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posMiddle, Qt::AlignCenter);
-                    pinDefaultFunc.at(i)->setText(OF_Const::valuesNameList[OF_Const::boardsPresetsMap.at(board.first).at(i)+1]);
+                                                 App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posMiddle, Qt::AlignCenter);
+                    pinDefaultFunc.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[App_Common::OFPresets.boardsPresetsMap.at(board.first).at(i)+1]);
                 }
             }
 

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -87,27 +87,21 @@ bool AppSerial::GetSettings(const QString &portName)
             if(char buf[] = {(char)OF_Const::sDock1, (char)OF_Const::sDock2}; OneShotSend(buf, 2, true)) {
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
-                if(buffer.size() >= 5) {
-                    emit Serial_SetProgressRange(6);
+                if(buffer.size() >= 3) {
+                    emit Serial_SetProgressRange(5);
                     emit Serial_ProgressUpdate(1, "Getting Board Info");
 
+                    ////* Opening board message bits *////
                     App_Common::board.versionNumber = buffer.takeFirst().constData();
                     printf("Version number: %s\n", App_Common::board.versionNumber.constData());
-
-                    App_Common::board.versionCodename = buffer.takeFirst().constData();
-                    printf("Version codename: %s\n", App_Common::board.versionCodename.constData());
 
                     App_Common::board.boardType = buffer.takeFirst().constData();
                     printf("Board type: %s\n", App_Common::board.boardType.constData());
 
-                    App_Common::board.selectedProfile = (uint8_t)buffer.takeFirst().at(0);
-                    App_Common::board.previousProfile = App_Common::board.selectedProfile;
-
-                    memcpy(&App_Common::tinyUSBtable.tinyUSBid, buffer.at(0).constData(), 2);
-                    App_Common::tinyUSBtable.tinyUSBname = &buffer.takeFirst().constData()[2];
-                    App_Common::tinyUSBtable_orig = App_Common::tinyUSBtable;
-
-                    if(buffer.size()) if(buffer.takeFirst().at(0) == OF_Const::sError)
+                    memcpy(&App_Common::tinyUSBtable, buffer.at(0).constData(), buffer.at(0).length());
+                    memcpy(&App_Common::tinyUSBtable_orig, &App_Common::tinyUSBtable, buffer.takeFirst().length());
+                    
+                    if(buffer.size()) if(buffer.takeFirst().at(0) == (char)OF_Const::sError)
                         ShowError("Device Error: Camera not available!",
                                   "<p>Data received from the board indicates that the camera is in a bad state.<br>"
                                   "This can happen if, for example, the camera wires are crossed<br>"
@@ -119,150 +113,69 @@ bool AppSerial::GetSettings(const QString &portName)
                                   "Otherwise, the camera wires must be resoldered to resolve this error.</p>",
                                   QMessageBox::Warning);
 
-                    // toggles
+                    ////* toggles *////
                     if(OneShotSend((char)OF_Const::sGetToggles, true)) {
-                        // booleans
                         memset(App_Common::boolSettings, false, sizeof(App_Common::boolSettings));
-                        for(int i = 0; port.peek(1).at(0) != (char)OF_Const::serialTerminator; ++i) {
-                            if(port.bytesAvailable() && i < OF_Const::boolTypesCount)
-                                port.read((char*)&App_Common::boolSettings[App_Common::dataCurrent][i], sizeof(bool));
-                            else if(port.bytesAvailable()) {
-                                if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                else port.read(1);
-                            } else if(!port.waitForReadyRead(500)) break;
-                        }
+                        if(!BatchStoreSettings( App_Common::boolSettings[App_Common::dataCurrent],
+                                                App_Common::OFPresets.boolTypes_Strings,
+                                                sizeof(App_Common::boolSettings[App_Common::dataCurrent]) / OF_Const::boolTypesCount))
+                            return false;
+
                         memcpy(App_Common::boolSettings[App_Common::dataOrig],
                                App_Common::boolSettings[App_Common::dataCurrent],
                                sizeof(App_Common::boolSettings[App_Common::dataCurrent]));
 
                         emit Serial_ProgressUpdate(2, "Getting Settings (1)");
 
-                        // pins
+                        ////* pins *////
                         if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]) {
                             port.clear();
                             if(OneShotSend((char)OF_Const::sGetPins, true)) {
                                 App_Common::inputsMap_orig.clear(), App_Common::inputsMap.clear();
 
-                                for(int i = 0;; ++i) {
-                                    if(port.bytesAvailable() && i < OF_Const::boardInputsCount)
-                                        port.read((char*)&App_Common::inputsMap_orig[i], sizeof(int8_t));
-                                    else if(port.bytesAvailable()) {
-                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                        else port.read(1);
-                                    } else if(!port.waitForReadyRead(500)) break;
-                                }
+                                if(!BatchStoreSettings(&App_Common::inputsMap_orig,
+                                                       App_Common::OFPresets.boardInputs_Strings,
+                                                       0))
+                                    return false;
                             } else {
                                 printf("Didn't receive any data in time!\n");
                                 return false;
                             }
-                        } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
+                        } else for(int i = 0; i < OF_Const::boardInputsCount; ++i)
                             App_Common::inputsMap_orig[i] = OF_Const::btnUnmapped;
 
                         App_Common::inputsMap = App_Common::inputsMap_orig;
 
                         emit Serial_ProgressUpdate(3, "Getting Settings (2)");
 
-                        // settings
+                        ////* settings *////
                         port.clear();
                         if(OneShotSend((char)OF_Const::sGetSettings, true)) {
                             memset(App_Common::settingsTable, 0, sizeof(App_Common::settingsTable));
-                            while(true) {
-                                if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                else if(port.bytesAvailable() < 5) { if(!port.waitForReadyRead(500)) break; }
-                                else {
-                                    int i = port.read(1).at(0);
-                                    if(i < OF_Const::settingsTypesCount)
-                                        port.read((char*)&App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t));
-                                    else port.read(sizeof(uint32_t));
-                                }
-                            }
+
+                            if(!BatchStoreSettings(App_Common::settingsTable[App_Common::dataCurrent],
+                                                   App_Common::OFPresets.settingsTypes_Strings,
+                                                   sizeof(App_Common::settingsTable[App_Common::dataCurrent]) / OF_Const::settingsTypesCount))
+                                return false;
+
                             memcpy(App_Common::settingsTable[App_Common::dataOrig],
                                    App_Common::settingsTable[App_Common::dataCurrent],
                                    sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
-                            emit Serial_ProgressUpdate(5, "Getting Profiles Data");
+                            emit Serial_ProgressUpdate(4, "Getting Profiles Data");
 
-                            // i2c peripherals
+                            // profiles
+                            App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+
                             port.clear();
-                            if(OneShotSend((char)OF_Const::sGetPeriphs, true)) {
-                                memset(App_Common::i2cPeriphs, 0, sizeof(App_Common::i2cPeriphs));
-                                while(true) {
-                                    if(!port.bytesAvailable()) { if(!port.waitForReadyRead(500)) break; }
-                                    else if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                    else {
-                                        switch(port.read(1).at(0)) {
-                                        case (char)OF_Const::i2cDevicesEnabled:
-                                        {
-                                            for(int i = 0;; i++) {
-                                                if(port.bytesAvailable() && i < OF_Const::i2cDevicesCount)
-                                                    port.read((char*)&App_Common::i2cPeriphs[App_Common::dataCurrent][i], sizeof(bool));
-                                                else if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator)
-                                                    { port.read(1); break; }
-                                                else if(port.bytesAvailable()) port.read(1);
-                                                else break; // if there's no more bytes, probably no leftover settings to sync anyways
-                                            }
-                                            break;
-                                        }
-                                        case (char)OF_Const::i2cOLED:
-                                            while(true) {
-                                                if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
-                                                else if(port.bytesAvailable() < 5) { if(!port.waitForReadyRead(500)) break; }
-                                                else {
-                                                    int type = port.read(1).at(0);
-                                                    if(type < OF_Const::oledSettingsTypes)
-                                                        port.read((char*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], sizeof(uint32_t));
-                                                    else port.read(sizeof(uint32_t));
-                                                }
-                                            }
-                                            break;
-                                        default: break;
-                                        }
-                                    }
-                                }
-                                memcpy(App_Common::i2cPeriphs[App_Common::dataOrig],
-                                       App_Common::i2cPeriphs[App_Common::dataCurrent],
-                                       sizeof(App_Common::i2cPeriphs[App_Common::dataCurrent]));
-                                memcpy(App_Common::i2cOledPrefs[App_Common::dataOrig],
-                                       App_Common::i2cOledPrefs[App_Common::dataCurrent],
-                                       sizeof(App_Common::i2cOledPrefs[App_Common::dataCurrent]));
+                            if(OneShotSend((char)OF_Const::sGetProfile, true)) {
 
-                                emit Serial_ProgressUpdate(5, "Getting Profiles Data");
-
-                                // profiles
-                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
-
-                                for(int i = 0;; ++i) {
-                                    port.clear();
-                                    if(char buf[] = {(char)OF_Const::sGetProfile, (char)i}; OneShotSend(buf, 2, true)) {
-                                        if(port.peek(1).at(0) == (char)OF_Const::serialTerminator) {
-                                            break;
-                                        } else {
-                                            App_Common::profilesTable << App_Common::profilesTable_s(), App_Common::profilesTable_orig << App_Common::profilesTable_s();
-
-                                            while(port.bytesAvailable()) {
-                                                switch(port.read(1).at(0)) {
-                                                case (char)OF_Const::profTopOffset:    port.read((char*)&App_Common::profilesTable[i].topOffset,     sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profBottomOffset: port.read((char*)&App_Common::profilesTable[i].bottomOffset,  sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profLeftOffset:   port.read((char*)&App_Common::profilesTable[i].leftOffset,    sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profRightOffset:  port.read((char*)&App_Common::profilesTable[i].rightOffset,   sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profTLled:        port.read((char*)&App_Common::profilesTable[i].TLled,         sizeof(float));    break;
-                                                case (char)OF_Const::profTRled:        port.read((char*)&App_Common::profilesTable[i].TRled,         sizeof(float));    break;
-                                                case (char)OF_Const::profIrSens:       port.read((char*)&App_Common::profilesTable[i].irSensitivity, sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profRunMode:      port.read((char*)&App_Common::profilesTable[i].runMode,       sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profIrLayout:     port.read((char*)&App_Common::profilesTable[i].layoutType,    sizeof(uint8_t));  break;
-                                                case (char)OF_Const::profColor:        port.read((char*)&App_Common::profilesTable[i].color,         sizeof(uint32_t)); break;
-                                                case (char)OF_Const::profName:                           App_Common::profilesTable[i].profName = port.read(16);         break;
-                                                default: break;
-                                                }
-                                            }
-
-                                            App_Common::profilesTable_orig[i] = App_Common::profilesTable.at(i);
-                                        }
-                                    } else break;
-                                }
-
-                                emit Serial_ProgressUpdate(6, "Successfully synced data!");
-                                return true;
+                                if(BatchStoreSettings(nullptr, App_Common::OFPresets.profSettingTypes_Strings, sizeof(float))) {
+                                    App_Common::profilesTable_orig = App_Common::profilesTable;
+                                    App_Common::board.previousProfile = App_Common::board.selectedProfile;
+                                    emit Serial_ProgressUpdate(5, "Successfully synced data!");
+                                    return true;
+                                } else return false;
                             } else {
                                 printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                                 return false;
@@ -297,6 +210,68 @@ bool AppSerial::GetSettings(const QString &portName)
     } else return false;
 }
 
+bool AppSerial::BatchStoreSettings(void *dataPtr, const std::unordered_map<std::string, int> &dataMap, const size_t &dataSize)
+{
+    QByteArray buf;
+    uint8_t sizeRead = 0;
+    while(true) {
+        if(port.bytesAvailable() && port.peek(1).at(0) == (char)OF_Const::serialTerminator) break;
+        else if(!port.bytesAvailable()) { if(!port.waitForReadyRead(500)) break; }
+        else {
+            buf = RecvDataName();
+
+            port.read((char*)&sizeRead, 1);
+
+            // is this string detected in strings map?
+            if(dataMap.count(buf.constData())) {
+                // For Pins/Inputs Map data (write to InputsMap rather than pointer)
+                if(dataPtr == &App_Common::inputsMap_orig)
+                    port.read((char*)&App_Common::inputsMap_orig[dataMap.at(buf.constData())], sizeRead);
+                // For Profile Data (has extra bits)
+                else if(&dataMap == &App_Common::OFPresets.profSettingTypes_Strings) {
+                    // Current Profile bit has no extra profile bit like the rest of the data
+                    if(dataMap.at(buf.constData()) == OF_Const::profCurrent) {
+                        port.read((char*)&App_Common::board.selectedProfile, sizeRead);
+                    } else {
+                        size_t profNum = 0;
+                        port.read((char*)&profNum, 1);
+
+                        if(profNum == App_Common::profilesTable.size())
+                            App_Common::profilesTable << App_Common::profilesTable_s();
+
+                        port.read((char*)&App_Common::profilesTable[profNum] + (dataSize * dataMap.at(buf.constData())), sizeRead);
+                    }
+                // All other (Generic) data
+                } else port.read((char*)dataPtr + (dataSize * dataMap.at(buf.constData())),  sizeRead);
+            // String not detected, skip over
+            } else {
+                printf("No data found for %s\n", buf.constData());
+                // skip the profile num byte if reading profile type data
+                if(&dataMap == &App_Common::OFPresets.profSettingTypes_Strings) port.read(1);
+                port.read(sizeRead);
+            }
+        }
+    }
+    // if exited from serialTerminator at start of RX buffer, prune that out before exiting
+    port.read(1);
+    return true;
+}
+
+QByteArray AppSerial::RecvDataName()
+{
+    QByteArray data;
+    size_t pos = 0;
+    while(true) {
+        pos += port.read(&RXbuf[pos], port.peek(port.bytesAvailable()).indexOf('\0') < 0 ? port.bytesAvailable() : port.peek(port.bytesAvailable()).indexOf('\0')+1);
+        if(RXbuf[pos-1] != '\0') {
+            if(!port.waitForReadyRead(500)) return "";
+        } else {
+            data.append(RXbuf, pos);
+            return data;
+        }
+    }
+}
+
 bool AppSerial::OneShotSend(const char* string, const unsigned int &len, const bool &waitForResponse)
 {
     if(port.isOpen()) {
@@ -326,7 +301,7 @@ bool AppSerial::OneShotSend(const char &chara, const bool &waitForResponse)
 bool AppSerial::CommitSettings()
 {
     if(port.isOpen()) {
-        emit Serial_SetProgressRange(8);
+        emit Serial_SetProgressRange(7);
 
         if(OneShotSend((char)OF_Const::sCommitStart, true)) {
             // in case board sends a stale temp/analog state response.
@@ -338,133 +313,115 @@ bool AppSerial::CommitSettings()
 
             port.clear();
 
-            char buf[64];
-
             emit Serial_ProgressUpdate(1, "Sending Toggles...");
-            for(int i = 0; i < OF_Const::boolTypesCount; ++i) {
-                memset(buf, '\0', 3);
-                buf[0] = (char)OF_Const::sCommitToggles, buf[1] = (char)i, buf[2] = (char)App_Common::boolSettings[App_Common::dataCurrent][i];
-                if(OneShotSend(buf, 3, true)) {
-                    if(port.read(1).at(0) != App_Common::boolSettings[App_Common::dataCurrent][i]) {
-                        OneShotSend((char)OF_Const::serialTerminator);
-                        return false;
-                    }
-                } else return false;
-            }
+            if(!BatchSendSettings(App_Common::boolSettings[App_Common::dataCurrent],
+                                  App_Common::OFPresets.boolTypes_Strings,
+                                  sizeof(App_Common::boolSettings[App_Common::dataCurrent]) / OF_Const::boolTypesCount))
+                return false;
 
             if(App_Common::boolSettings[OF_Const::customPins]) {
                 emit Serial_ProgressUpdate(2, "Sending Pins Map...");
-                for(int i = 0; i < OF_Const::boardInputsCount; ++i) {
-                    memset(buf, '\0', 3);
-                    buf[0] = (char)OF_Const::sCommitPins, buf[1] = (char)i, buf[2] = (char)App_Common::inputsMap.value(i);
-                    if(OneShotSend(buf, 3, true)) {
-                        if(port.read(1).at(0) != App_Common::inputsMap.value(i)) {
-                            OneShotSend((char)OF_Const::serialTerminator);
-                            return false;
-                        }
-                    } else return false;
-                }
+                // convert pins map to temp buffer
+                int8_t inputMapFW[OF_Const::boardInputsCount];
+                for(size_t i = 0; i < OF_Const::boardInputsCount; ++i)
+                    inputMapFW[i] = App_Common::inputsMap.value(i);
+
+                if(!BatchSendSettings(inputMapFW,
+                                      App_Common::OFPresets.boardInputs_Strings,
+                                      sizeof(inputMapFW) / OF_Const::boardInputsCount))
+                    return false;
             }
 
             emit Serial_ProgressUpdate(3, "Sending Settings...");
-            for(int i = 0; i < OF_Const::settingsTypesCount; ++i) {
-                memset(buf, '\0', 6);
-                buf[0] = (char)OF_Const::sCommitSettings, buf[1] = (char)i;
-                memcpy(&buf[2], (uint8_t*)&App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t));
-                if(OneShotSend(buf, 6, true)) {
-                    if(memcmp(port.read(4).constData(), &App_Common::settingsTable[App_Common::dataCurrent][i], sizeof(uint32_t))) {
-                        OneShotSend((char)OF_Const::serialTerminator);
-                        return false;
-                    }
-                } else return false;
-            }
+            if(!BatchSendSettings(App_Common::settingsTable[App_Common::dataCurrent],
+                                  App_Common::OFPresets.settingsTypes_Strings,
+                                  sizeof(App_Common::settingsTable[App_Common::dataCurrent]) / OF_Const::settingsTypesCount))
+                return false;
 
             emit Serial_ProgressUpdate(4, "Sending Profile Data...");
-            for(int i = 0; i < App_Common::profilesTable.count(); ++i) {
-                memset(buf, '\0', 19);
-                buf[0] = (char)OF_Const::sCommitProfile,
-                    buf[1] = (char)i,
-                    buf[2] = (char)OF_Const::profIrSens,
-                    buf[3] = (char)App_Common::profilesTable.at(i).irSensitivity;
-
-                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).irSensitivity)
-                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
-
-                buf[2] = OF_Const::profRunMode, buf[3] = App_Common::profilesTable.at(i).runMode;
-                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).runMode)
-                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
-
-                buf[2] = OF_Const::profIrLayout, buf[3] = App_Common::profilesTable.at(i).layoutType;
-                if(OneShotSend(buf, 7, true)) if(port.read(4).at(0) != App_Common::profilesTable.at(i).layoutType)
-                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
-
-                buf[2] = OF_Const::profColor;
-                memcpy(&buf[3], (uint8_t*)&App_Common::profilesTable.at(i).color, sizeof(uint32_t));
-                if(OneShotSend(buf, 7, true)) if(memcmp(port.read(4).constData(), (uint8_t*)&App_Common::profilesTable.at(i).color, sizeof(uint32_t)))
-                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
-
-                buf[2] = OF_Const::profName;
-                memset(&buf[3], '\0', 16);
-                memcpy(&buf[3], App_Common::profilesTable.at(i).profName.constData(), App_Common::profilesTable.at(i).profName.length());
-                if(OneShotSend(buf, 19, true)) if(strcmp(port.read(16).constData(), App_Common::profilesTable.at(i).profName.constData()))
-                    { OneShotSend((char)OF_Const::serialTerminator); return false; }
-            }
-
-            if(App_Common::inputsMap.value(OF_Const::periphSDA) > -1 && App_Common::inputsMap.value(OF_Const::periphSCL) > -1) {
-                emit Serial_ProgressUpdate(5, "Sending I2C Peripherals Data...");
-                memset(buf, '\0', 20);
-                buf[0] = (char)OF_Const::sCommitPeriphs;
-                for(int i = 0; i < OF_Const::i2cDevicesCount; ++i) {
-                    buf[1] = (char)OF_Const::i2cDevicesEnabled;
-                    buf[2] = (char)i;
-                    buf[3] = (char)App_Common::i2cPeriphs[App_Common::dataCurrent][i];
-                    if(OneShotSend(buf, 4, true)) if(port.read(1).at(0) != App_Common::i2cPeriphs[App_Common::dataCurrent][i])
-                        { OneShotSend((char)OF_Const::serialTerminator); return false; }
-
-                    switch(i) {
-                    case OF_Const::i2cOLED:
-                        buf[1] = (char)OF_Const::i2cOLED;
-                        for(int type = 0; type < OF_Const::oledSettingsTypes; ++type) {
-                            buf[2] = (char)type;
-                            memcpy(&buf[3], (uint8_t*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], sizeof(uint32_t));
-                            if(OneShotSend(buf, 7, true)) if(memcmp((uint8_t*)&App_Common::i2cOledPrefs[App_Common::dataCurrent][type], port.read(4).constData(), sizeof(uint32_t)))
-                                { OneShotSend((char)OF_Const::serialTerminator); return false; }
-                        }
-                        break;
-                    default: break;
-                    }
-                }
-            }
-
-            emit Serial_ProgressUpdate(6, "Sending TinyUSB ID Data...");
-            memset(buf, '0', 18);
-            buf[0] = (char)OF_Const::sCommitID, buf[1] = (char)OF_Const::usbPID;
-            memcpy(&buf[2], (uint8_t*)&App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t));
-            if(OneShotSend(buf, 4, true)) {
-                if(memcmp(port.read(2).constData(), &App_Common::tinyUSBtable.tinyUSBid, sizeof(uint16_t))) {
-                    OneShotSend((char)OF_Const::serialTerminator);
+            for(size_t i = 0; i < App_Common::profilesTable.count(); ++i) {
+                if(!BatchSendSettings(&App_Common::profilesTable[i],
+                                      App_Common::OFPresets.profSettingTypes_Strings,
+                                      sizeof(float),
+                                      i))
                     return false;
-                }
-                memset(&buf[1], '\0', 17);
-                buf[1] = (char)OF_Const::usbName;
-                memcpy(&buf[2], (uint8_t*)App_Common::tinyUSBtable.tinyUSBname.constData(), App_Common::tinyUSBtable.tinyUSBname.size());
-                if(OneShotSend(buf, 18, true)) {
-                    if(strcmp(port.read(16).constData(), App_Common::tinyUSBtable.tinyUSBname.constData())) {
-                        OneShotSend((char)OF_Const::serialTerminator);
-                        return false;
-                    }
-                } else return false;
-            } else return false;
+            }
 
-            emit Serial_ProgressUpdate(7, "Saving...");
+            emit Serial_ProgressUpdate(5, "Sending TinyUSB ID Data...");
+            TXbuf[0] = (char)OF_Const::sCommitID;
+            memcpy(&TXbuf[1], (uint8_t*)&App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s));
+            for(size_t sendAttempt = 1;; ++sendAttempt) {
+                if(OneShotSend(TXbuf, sizeof(uint8_t)+sizeof(App_Common::tinyUSBtable_s), true)) {
+                    port.read(RXbuf, sizeof(App_Common::tinyUSBtable_s));
+                    if(memcmp(&App_Common::tinyUSBtable, RXbuf, sizeof(App_Common::tinyUSBtable_s))) {
+                        if(sendAttempt >= 3) return false;
+                    } else break;
+                } else return false;
+            }
+
+            emit Serial_ProgressUpdate(6, "Saving...");
             if(OneShotSend((char)OF_Const::sSave, true)) {
                 if(char newBuf[2] = {(char)OF_Const::sSave, (char)true}; memcmp(port.read(2).constData(), newBuf, sizeof(newBuf)) == 0) {
-                    emit Serial_ProgressUpdate(8);
+                    emit Serial_ProgressUpdate(7);
                     return true;
                 } else return false;
             } else return false;
         } else return false;
     } else return false;
+}
+
+bool AppSerial::BatchSendSettings(void *dataPtr, const std::unordered_map<std::string, int> &dataMap, const size_t &dataSize, const size_t &profNum)
+{
+    size_t txLen = 0;
+    bool profCurrentMarked = false;
+    if(&dataMap == &App_Common::OFPresets.boolTypes_Strings)
+        TXbuf[txLen++] = OF_Const::sCommitToggles;
+    else if(&dataMap == &App_Common::OFPresets.boardInputs_Strings)
+        TXbuf[txLen++] = OF_Const::sCommitPins;
+    else if(&dataMap == &App_Common::OFPresets.settingsTypes_Strings)
+        TXbuf[txLen++] = OF_Const::sCommitSettings;
+    else if(&dataMap == &App_Common::OFPresets.profSettingTypes_Strings)
+        TXbuf[txLen++] = OF_Const::sCommitProfile;
+    for(auto &pair : dataMap) {
+        txLen = 1;
+        strcpy(&TXbuf[txLen], pair.first.c_str());
+        // std::string length doesn't account for terminator
+        txLen += pair.first.length()+1;
+
+        if(dataMap == App_Common::OFPresets.profSettingTypes_Strings) {
+            if(pair.second < OF_Const::profIrSens) continue;
+            else if(pair.second == OF_Const::profCurrent) {
+                if(profCurrentMarked) continue;
+                TXbuf[txLen++] = sizeof(uint8_t);
+                TXbuf[txLen++] = App_Common::board.selectedProfile;
+                profCurrentMarked = true;
+            } else {
+                if(pair.second == OF_Const::profName)
+                     TXbuf[txLen++] = sizeof(App_Common::profilesTable_s::profName);
+                else TXbuf[txLen++] = dataSize;
+
+                TXbuf[txLen++] = profNum;
+
+                memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), TXbuf[txLen-2]);
+                txLen += TXbuf[txLen-2];
+            }
+        } else {
+            TXbuf[txLen++] = dataSize;
+            memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), dataSize);
+            txLen += dataSize;
+        }
+
+        // try to resend data if not matching, fail after three tries
+        for(size_t sendAttempt = 1;; ++sendAttempt) {
+            if(OneShotSend(TXbuf, txLen, true)) {
+                port.read(RXbuf, port.bytesAvailable());
+                if(memcmp(&TXbuf[1], RXbuf, txLen-1)) {
+                    if(sendAttempt >= 3) return false;
+                } else break;
+            } else return false;
+        }
+    }
+    return true;
 }
 
 void AppSerial::Disconnect()

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -62,6 +62,20 @@ public:
     /// @param      Index of currentPorts list to pull from
     bool GetSettings(const QString &);
 
+    /// @brief      Macro for saving batches of settings being received over serial
+    /// @returns    Success (true) or failure (false)
+    /// @param      void*
+    ///             Pointer to data array
+    /// @param      unordered_map
+    ///             Map from OF_Const::OFPresets to reference for string names and respective indices
+    /// @param      size_t
+    ///             Size of data blocks that void* points to, for correct seeks through array elements by address
+    bool BatchStoreSettings(void*, const std::unordered_map<std::string, int>&, const size_t&);
+
+    /// @brief      Macro for processing name of data type
+    /// @returns    Name received from serial
+    QByteArray RecvDataName();
+
     /// @brief      Sends serial message to currently connected Serial device
     /// @returns    Success (true) or failure (false)
     /// @param      QString
@@ -72,6 +86,16 @@ public:
     /// @brief      Commits settings (App_Const) to currently connected Serial device
     /// @returns    Success (true) or failure (false)
     bool CommitSettings();
+
+    /// @brief      Macro for committing batches of data to board
+    /// @returns    Success (true) or failure (false)
+    /// @param      void*
+    ///             Pointer to data array
+    /// @param      unordered_map
+    ///             Map from OF_Const::OFPresets to reference for string names and respective indices
+    /// @param      size_t
+    ///             Size of data blocks that void* points to, for correct seeks through array elements by address
+    bool BatchSendSettings(void*, const std::unordered_map<std::string, int>&, const size_t&, const size_t& = 0);
 
     /// @brief      Disconnects current serial device and clears port name
     void Disconnect();
@@ -94,6 +118,9 @@ public:
 
 private:
     QMessageBox syncError;
+
+    char RXbuf[64];
+    char TXbuf[64];
 
 signals:
     /// @brief


### PR DESCRIPTION
Using the settings strings maps in the updated shared submodule, this allows (in theory) for matching settings to always be matched regardless of firmwares, so long as the keys themselves remain the same.

Settings syncing will now retry up to three times if a transmit doesn't match before throwing a fail signal.

Some minor UI fixes.