### PR TITLE
Only expose debug window if actually building in non-Release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
+    add_compile_definitions(OFAPP_DEBUG)
+endif()
+
 if(NOT OFAPP_QT_VERSIONS)
     set(OFAPP_QT_VERSIONS Qt6)
 endif()

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -63,6 +63,10 @@ guiWindow::guiWindow(QWidget *parent)
     }
 #endif
 
+#ifndef OFAPP_DEBUG
+    ui->actionDebug_Window->setVisible(false);
+#endif
+
     // Connect together Serial stuff
     connect(&serialSearchWatcher, &QFutureWatcher<uint8_t>::finished, this, &guiWindow::serialPort_SearchFinished);
     connect(&serial.port, &QSerialPort::readyRead, this, &guiWindow::serialPort_readyRead);
@@ -75,7 +79,7 @@ guiWindow::guiWindow(QWidget *parent)
     aliveTimer.start(ALIVE_TIMER);
     aliveTimer_timeout();
 
-#if defined(OFAPP_GITHASH)
+#ifdef OFAPP_GITHASH
     this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + '-' + QString(OFAPP_GITHASH) + ']');
 #else
     this->setWindowTitle("OpenFIRE App - " + QString(OFAPP_CODENAME) + " [v" + QString(OFAPP_VERSION) + ']');
@@ -163,6 +167,10 @@ guiWindow::~guiWindow()
         statusBar()->showMessage("Sending undock request to board...");
         serial.Disconnect();
     }
+
+#ifdef OFAPP_DEBUG
+    debugWindow.close();
+#endif
 
     delete ui;
 }
@@ -1573,7 +1581,9 @@ void guiWindow::caliBtns_clicked()
 // TODO: move to appserial
 void guiWindow::serialPort_readyRead()
 {
+#ifdef OFAPP_DEBUG
     debugWindow.AppendText(serial.port.peek(serial.port.bytesAvailable()));
+#endif
 
     if(!serialActive) {
         while(serial.port.bytesAvailable()) {
@@ -2077,7 +2087,10 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
     } else ui->statusBar->showMessage("Canceled custom layout save operation.", 5000);
 }
 
+
 void guiWindow::on_actionDebug_Window_triggered()
 {
+    #ifdef OFAPP_DEBUG
     debugWindow.show();
+    #endif
 }

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -205,8 +205,10 @@ private:
     /// @brief      Boards previewer window
     AppBoardsPreviewer boardsWindow;
 
+#ifdef OFAPP_DEBUG
     /// @brief      Serial debug window
     AppDebugWindow debugWindow;
+#endif
 
     /// @brief      Macro for making new CaliWindows
     /// @param      int

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -2088,14 +2088,13 @@
     <addaction name="actionOpenFIRE_on_the_Web"/>
     <addaction name="actionOpenFIRE_Documentation"/>
     <addaction name="actionOpenFIRE_Serial_Usage"/>
-    <addaction name="separator"/>
-    <addaction name="actionDebug_Window"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
      <string>View</string>
     </property>
     <addaction name="actionShow_Unsafe_Settings"/>
+    <addaction name="actionDebug_Window"/>
    </widget>
    <addaction name="menuView"/>
    <addaction name="menuHelp"/>


### PR DESCRIPTION
Note to self: I've noticed serial activity-related stuff slowing down over time since adding the debug window. May need to get fixed up, but it shouldn't need to be relevant for users anyways.