### PR TITLE
Add Button Mapping tab, Add UI icons

### DIFF
--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -46,6 +46,7 @@ public:
         trackPinbox = 0,
         trackSettingsItem,
         trackProfileItem,
+        trackButtonMapItem,
         trackTestItem
     } uiTrackableObjects_e;
 
@@ -132,7 +133,7 @@ public:
     // array 1 = original and current data array
     // array 2 = buttons count
     // array 3 = data for button ((func type : func num) * 3)
-    static inline uint8_t inputFuncTable[dataTablesCount][BUTTON_COUNT-1][inputTypes*2];
+    static inline uint8_t inputFuncTable[dataTablesCount][BUTTON_COUNT][inputTypes*2];
 
     // Keyboard inputs reference map
     // first int is the value representing the key used by the firmware,
@@ -241,6 +242,12 @@ public:
         "Mouse",
         "Keyboard",
         "Gamepad"
+    };
+
+    static const inline QMap<std::string, QVector<int>> *inputFuncMaps[3] = {
+        &mouseMap,
+        &keyboardInputsMap,
+        &gamepadMap
     };
 };
 

--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -26,6 +26,8 @@
 #include <QVector>
 #include <QMap>
 
+#define BUTTON_COUNT 14
+
 class App_Common
 {
 public:
@@ -49,7 +51,8 @@ public:
 
     enum {
         dataCurrent = 0,
-        dataOrig
+        dataOrig,
+        dataTablesCount
     } dataBlocks_e;
 
     // Single instance of presets and board info
@@ -86,14 +89,12 @@ public:
     // Currently loaded board object
     static inline boardInfo_s board;
 
-    //// TODO: merge orig into main arrays to make them 2D arrays (where second array = main or orig)
-
     /// @brief      Current array of booleans
     /// @details    Meant for toggle/on-off type settings specifically
-    static inline bool boolSettings[2][OF_Const::boolTypesCount] = { false };
+    static inline bool boolSettings[dataTablesCount][OF_Const::boolTypesCount] = { false };
 
     /// @brief      Current array of tunable settings
-    static inline uint32_t settingsTable[2][OF_Const::settingsTypesCount] = { 0 };
+    static inline uint32_t settingsTable[dataTablesCount][OF_Const::settingsTypesCount] = { 0 };
 
     // Currently loaded board's TinyUSB identifier info
     static inline tinyUSBtable_s tinyUSBtable;
@@ -113,6 +114,134 @@ public:
     static inline QMap<uint8_t, int8_t> inputsMap;
     // Inputs map, as loaded from the board
     static inline QMap<uint8_t, int8_t> inputsMap_orig;
+
+    enum {
+        inputFuncData = 0,
+        inputFuncOrder,
+        inputFuncTypes
+    } kbInputs_e;
+
+    enum {
+        inputMouse = 0,
+        inputKB,
+        inputGamepad,
+        inputTypes
+    } inputFuncTypes_e;
+
+    // Map of input funcs
+    // array 1 = original and current data array
+    // array 2 = buttons count
+    // array 3 = data for button ((func type : func num) * 3)
+    static inline uint8_t inputFuncTable[dataTablesCount][BUTTON_COUNT-1][inputTypes*2];
+
+    // Keyboard inputs reference map
+    // first int is the value representing the key used by the firmware,
+    // second int is the desired order (since no Map allows
+    static const inline QMap<std::string, QVector<int>> keyboardInputsMap = {
+        {"Player-relative Start Key",   {0xFF,      0 }},
+        {"Player-relative Coin Key",    {0xFE,      1 }},
+        {"Up Arrow",                    {0xDA,      2 }},
+        {"Down Arrow",                  {0xD9,      3 }},
+        {"Left Arrow",                  {0xD8,      4 }},
+        {"Right Arrow",                 {0xD7,      5 }},
+        {"Enter/Return",                {0xB0,      6 }},
+        {"Backspace",                   {0xB2,      7 }},
+        {"Escape",                      {0xB1,      8 }},
+        {"Left Ctrl",                   {0x80,      9 }},
+        {"Right Ctrl",                  {0x84,      10}},
+        {"Left Alt",                    {0x82,      11}},
+        {"Right Alt",                   {0x86,      12}},
+        {"Left Shift",                  {0x81,      13}},
+        {"Right Shift",                 {0x85,      14}},
+        {"Tab",                         {0xB3,      15}},
+        {"A",                           {'a',       16}},
+        {"B",                           {'b',       17}},
+        {"C",                           {'c',       18}},
+        {"D",                           {'d',       19}},
+        {"E",                           {'e',       20}},
+        {"F",                           {'f',       21}},
+        {"G",                           {'g',       22}},
+        {"H",                           {'h',       23}},
+        {"I",                           {'i',       24}},
+        {"J",                           {'j',       25}},
+        {"K",                           {'k',       26}},
+        {"L",                           {'l',       27}},
+        {"M",                           {'m',       28}},
+        {"N",                           {'n',       29}},
+        {"O",                           {'o',       30}},
+        {"P",                           {'p',       31}},
+        {"Q",                           {'q',       32}},
+        {"R",                           {'r',       33}},
+        {"S",                           {'s',       34}},
+        {"T",                           {'t',       35}},
+        {"U",                           {'u',       36}},
+        {"V",                           {'v',       37}},
+        {"W",                           {'w',       38}},
+        {"X",                           {'x',       39}},
+        {"Y",                           {'y',       40}},
+        {"Z",                           {'z',       41}},
+        {"F1",                          {0xC2,      42}},
+        {"F2",                          {0xC3,      43}},
+        {"F3",                          {0xC4,      44}},
+        {"F4",                          {0xC5,      45}},
+        {"F5",                          {0xC6,      46}},
+        {"F6",                          {0xC7,      47}},
+        {"F7",                          {0xC8,      48}},
+        {"F8",                          {0xC9,      49}},
+        {"F9",                          {0xCA,      50}},
+        {"F10",                         {0xCB,      51}},
+        {"F11",                         {0xCC,      52}},
+        {"F12",                         {0xCD,      53}}
+    };
+
+    // Used for combobox elements so that the order isn't haphazard
+    // TODO: is a map the best way of doing this? hrm
+    static inline char* kbOrderedStrings[54];
+
+    static const inline QMap<std::string, QVector<int>> mouseMap = {
+        {"Left Click",          {0b00000001, 0}},
+        {"Right Click",         {0b00000010, 1}},
+        {"Middle Click",        {0b00000100, 2}},
+        {"Side Button Back",    {0b00001000, 3}},
+        {"Side Button Forward", {0b00010000, 4}}
+    };
+
+    // Used for combobox elements so that the order isn't haphazard
+    static inline char* mouseOrderedStrings[5];
+
+    // Gamepad inputs reference map
+    // first int is the value representing the key used by the firmware,
+    // second int is the desired order (since no Map allows
+    static const inline QMap<std::string, QVector<int>> gamepadMap = {
+        {"A Button",            {0,  0 }},
+        {"B Button",            {1,  1 }},
+        // C Button (N/A)
+        {"X Button",            {3,  2 }},
+        {"Y Button",            {4,  3 }},
+        // Z Button (N/A)
+        {"Left Shoulder",       {6,  4 }},
+        {"Right Shoulder",      {7,  5 }},
+        {"Left Trigger",        {8,  6 }},
+        {"Right Trigger",       {9,  7 }},
+        {"Select Button",       {10, 8 }},
+        {"Start Button",        {11, 9 }},
+        // Home Button (N/A)
+        {"Left Stick Click",    {13, 10}},
+        {"Right Stick Click",   {14, 11}},
+        {"D-Pad Up",            {15, 12}},
+        {"D-Pad Down",          {16, 13}},
+        {"D-Pad Left",          {17, 14}},
+        {"D-Pad Right",         {18, 15}}
+    };
+
+    // Used for combobox elements so that the order isn't haphazard
+    static inline char* gpadOrderedStrings[16];
+
+    static inline const char* inputFuncTypesStrings[3] = {
+        "Mouse",
+        "Keyboard",
+        "Gamepad"
+    };
 };
 
 #endif // CONSTANTS_H

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -125,8 +125,6 @@ guiWindow::guiWindow(QWidget *parent)
             btnFuncBox[1][0][i].addItem(item);
             btnFuncBox[2][0][i].addItem(item);
         }
-        for(const auto &item : App_Common::gpadOrderedStrings)
-            btnFuncBox[2][1][i].addItem(item);
 
         btnFuncLayout[i].addWidget(new QLabel(App_Common::OFPresets.boardInputs_sortedStr[i+1]), 1, Qt::AlignRight);
         btnFuncLayout[i].addSpacing(4);
@@ -136,32 +134,80 @@ guiWindow::guiWindow(QWidget *parent)
 
             btnFuncLayout[i].addWidget(&btnFuncBox[slot][0][i]);
 
+            btnFuncBox[slot][0][i].setCurrentIndex(-1);
+            btnFuncBox[slot][0][i].setProperty("curType", -1);
+
             // only onscreen/offscreen have editable func type selectors
-            if(slot < 2) {
-                btnFuncBox[slot][0][i].setProperty("curType", 0);
-                connect(&btnFuncBox[slot][0][i], SIGNAL(activated(int)), this, SLOT(btnFuncTypeBox_activated(int)));
-            } else {
-                btnFuncBox[slot][0][i].setProperty("curType", App_Common::inputGamepad);
+            if(slot >= 2) {
                 btnFuncBox[slot][0][i].setEnabled(false);
                 btnFuncBox[slot][0][i].setFrame(false);
-                btnFuncBox[slot][0][i].setCurrentIndex(App_Common::inputGamepad);
             }
+            connect(&btnFuncBox[slot][0][i], SIGNAL(currentIndexChanged(int)), this, SLOT(btnFuncTypeBox_currentIndexChanged(int)));
 
             btnFuncBox[slot][0][i].setProperty("slot", slot);
             btnFuncBox[slot][0][i].setProperty("btn", i);
+            btnFuncBox[slot][0][i].setProperty("trackable", App_Common::trackButtonMapItem);
+            btnFuncBox[slot][0][i].installEventFilter(this);
 
             btnFuncLayout[i].addWidget(&btnFuncBox[slot][1][i], 1);
             btnFuncBox[slot][1][i].setProperty("slot", slot);
             btnFuncBox[slot][1][i].setProperty("btn", i);
+            btnFuncBox[slot][1][i].setProperty("trackable", App_Common::trackButtonMapItem);
+            btnFuncBox[slot][1][i].installEventFilter(this);
+            switch(slot) {
+            case 0:
+                btnFuncBox[slot][0][i].setAccessibleName(QString("Onscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing at the screen.</b></p>"
+                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                            "three available device outputs that the gun presents to the connected device.</p>")
+                                                            .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(QString("Onscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing at the screen.</b></p>"
+                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                            "three available device outputs that the gun presents to the connected device.</p>")
+                                                            .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                break;
+            case 1:
+                btnFuncBox[slot][0][i].setAccessibleName(QString("Offscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing outside of the screen.</b></p>"
+                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                            "three available device outputs that the gun presents to the connected device.</p>")
+                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(QString("Offscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing outside of the screen.</b></p>"
+                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                            "three available device outputs that the gun presents to the connected device.</p>")
+                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                break;
+            case 2:
+                btnFuncBox[slot][0][i].setAccessibleName(QString("Gamepad Mode Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun set to Gamepad Output Mode.</b></p>"
+                                                            "<p>Only Gamepad-type outputs are available for Gamepad Output Mode, which can be set via "
+                                                            "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
+                                                            "<tt>M0x1</tt>.</p>")
+                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(QString("Gamepad Mode Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is set to Gamepad Output Mode.</b></p>"
+                                                            "<p>Only Gamepad buttons are available to be mapped for Gamepad Output Mode, which can be set via "
+                                                            "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
+                                                            "<tt>M0x1</tt>.</p>"
+                                                            "<p><b>NOTE:</b> When connected to the MiSTer FPGA device, these mappings will NOT be reflected, "
+                                                            "as OpenFIRE has a hard-coded button layout specifically optimized for the MiSTer ecosystem.</p>")
+                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                break;
+            }
 
             connect(&btnFuncBox[slot][1][i], &QComboBox::currentTextChanged, this, &guiWindow::btnFuncBox_currentTextChanged);
         }
 
-        ui->btnFuncLayout->addLayout(&btnFuncLayout[i]);
+        btnFuncGBoxes[i].setFlat(true);
+        btnFuncGBoxes[i].setLayout(&btnFuncLayout[i]);
+
+        ui->btnFuncLayout->addWidget(&btnFuncGBoxes[i]);
     }
 
     // Setup test screen buttons
-    for(int i = 0; i < 14; ++i) {
+    for(int i = 0; i < BUTTON_COUNT; ++i) {
         testLabel << new QLabel(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
 
         testLabel.at(i)->setEnabled(false);
@@ -251,6 +297,10 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
         case App_Common::trackProfileItem:
             ui->profilesDescBox->setTitle(object->property("accessibleName").toString());
             ui->profilesDescText->setText(object->property("whatsThis").toString());
+            break;
+        case App_Common::trackButtonMapItem:
+            ui->btnFuncDescBox->setTitle(object->property("accessibleName").toString());
+            ui->btnFuncDescText->setText(object->property("whatsThis").toString());
             break;
         case App_Common::trackTestItem:
             break;
@@ -346,6 +396,9 @@ void guiWindow::DiffUpdate()
     if(memcmp(App_Common::settingsTable[App_Common::dataCurrent], App_Common::settingsTable[App_Common::dataOrig], sizeof(App_Common::settingsTable[App_Common::dataCurrent])))
         ++settingsDiff;
 
+    if(memcmp(App_Common::inputFuncTable[App_Common::dataCurrent], App_Common::inputFuncTable[App_Common::dataOrig], sizeof(App_Common::inputFuncTable[App_Common::dataCurrent])))
+        ++settingsDiff;
+
     if(memcmp(&App_Common::tinyUSBtable_orig, &App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s)))
         ++settingsDiff;
 
@@ -359,9 +412,11 @@ void guiWindow::DiffUpdate()
     if(settingsDiff) {
         ui->confirmButton->setText("Save and Send Settings");
         ui->confirmButton->setEnabled(true);
+        ui->confirmButton->setIcon(QIcon::fromTheme("DocumentSave"));
     } else {
         ui->confirmButton->setText("[Nothing To Save]");
         ui->confirmButton->setEnabled(false);
+        ui->confirmButton->setIcon(QIcon());
     }
 }
 
@@ -443,6 +498,7 @@ void guiWindow::NewCaliWindow(const int &type) {
         ui->buttonsTestArea->setEnabled(false);
         ui->confirmButton->setEnabled(false);
         ui->confirmButton->setText("[Disabled while in Test Mode]");
+        ui->confirmButton->setIcon(QIcon());
         ui->pinsTab->setEnabled(false);
         ui->settingsTab->setEnabled(false);
         ui->profilesTab->setEnabled(false);
@@ -472,6 +528,7 @@ void guiWindow::on_confirmButton_clicked()
         if(serial.CommitSettings()) {
             statusBar()->showMessage("Sent settings successfully!", 5000);
             ui->confirmButton->setEnabled(false);
+            ui->confirmButton->setIcon(QIcon());
 
             // sync settings
             memcpy(App_Common::boolSettings[App_Common::dataOrig],
@@ -684,6 +741,15 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 ui->caliBtnsLayout->addWidget(caliBtn.at(i), caliBtnRow, i);
             }
 
+            // update button mapping tab
+            for(int i = 0; i < BUTTON_COUNT-1; ++i) {
+                // update the type boxes; the signal for these will handle the other box for each type
+                for(int slot = 0; slot < 3; ++slot) {
+                    btnFuncBox[slot][0][i].setCurrentIndex(-1);
+                    btnFuncBox[slot][0][i].setCurrentIndex(App_Common::inputFuncTable[App_Common::dataOrig][i][2*slot]);
+                }
+            }
+
             // Clears old board layout items
             if(pinBoxes.count()) {
                 for(uint8_t i = 0; i < pinBoxes.count(); ++i)
@@ -868,8 +934,6 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->i2cOLEDtoggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLED]);
             ui->oledAltAddrsToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLEDaltAddr]);
 
-            ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
-            ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
             ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcount]);
             ui->customLEDstaticSpinbox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDstatic]);
             ui->customLEDstaticBtn1->setStyleSheet(QString("background-color: #%1").arg(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcolor1], 6, 16, QLatin1Char('0')));
@@ -912,6 +976,9 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 break;
             }
 
+            ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
+            ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+
         } else ui->comPortSelector->setCurrentIndex(0);
 
         serialPort_progressSet(0);
@@ -936,6 +1003,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         ui->tmp36Label->setStyleSheet("");
         ui->confirmButton->setEnabled(false);
         ui->confirmButton->setText("[Currently Not Connected]");
+        ui->confirmButton->setIcon(QIcon());
     }
     serialActive = false;
 }
@@ -1063,44 +1131,52 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
 
     ui->aStickFuncBox->setEnabled(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0);
     for(int i = 0; i < BUTTON_COUNT-1; ++i)
-        btnFuncLayout[i].setEnabled(App_Common::inputsMap.value(i) >= 0);
+        btnFuncGBoxes[i].setEnabled(App_Common::inputsMap.value(i) >= 0);
 
     DiffUpdate();
 }
 
 
 /// button mapping
-void guiWindow::btnFuncTypeBox_activated(int index)
+void guiWindow::btnFuncTypeBox_currentIndexChanged(int index)
 {
     if(sender()->property("curType").toInt() != index) {
-        QComboBox *btnFuncBoxPtr = &btnFuncBox[sender()->property("slot").toInt()][1][sender()->property("btn").toInt()];
-
         sender()->setProperty("curType", index);
-        App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] = index;
-        btnFuncBoxPtr->blockSignals(true);
-        btnFuncBoxPtr->clear();
+        if(index > -1) {
+            QComboBox *btnFuncBoxPtr = &btnFuncBox[sender()->property("slot").toInt()][1][sender()->property("btn").toInt()];
 
-        switch(index) {
-        case App_Common::inputMouse:
-            for(const auto &item : App_Common::mouseOrderedStrings)
-                btnFuncBoxPtr->addItem(item);
-            break;
-        case App_Common::inputKB:
-            for(const auto &item : App_Common::kbOrderedStrings)
-                btnFuncBoxPtr->addItem(item);
-            break;
-        case App_Common::inputGamepad:
-            for(const auto &item : App_Common::gpadOrderedStrings)
-                btnFuncBoxPtr->addItem(item);
-            break;
+            App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] = index;
+            btnFuncBoxPtr->blockSignals(true);
+            btnFuncBoxPtr->clear();
+
+            switch(index) {
+            case App_Common::inputMouse:
+                for(const auto &item : App_Common::mouseOrderedStrings)
+                    btnFuncBoxPtr->addItem(item);
+                break;
+            case App_Common::inputKB:
+                for(const auto &item : App_Common::kbOrderedStrings)
+                    btnFuncBoxPtr->addItem(item);
+                break;
+            case App_Common::inputGamepad:
+                for(const auto &item : App_Common::gpadOrderedStrings)
+                    btnFuncBoxPtr->addItem(item);
+                break;
+            }
+
+            btnFuncBoxPtr->blockSignals(false);
+
+            // HACK SHACK: very brute-force-y method because I didn't wanna make another redundant af map for this lookup sorz :(
+            if(App_Common::inputFuncTable[App_Common::dataOrig][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] == index) {
+                for(auto i = App_Common::inputFuncMaps[index]->cbegin(), end = App_Common::inputFuncMaps[index]->cend(); i != end; ++i)
+                    if(i.value().at(0) == App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][1 | sender()->property("slot").toInt() << 1]) {
+                        btnFuncBoxPtr->setCurrentIndex(i.value().at(1));
+                        break;
+                    }
+            }
+
+            DiffUpdate();
         }
-
-        btnFuncBoxPtr->blockSignals(false);
-
-        if(App_Common::inputFuncTable[App_Common::dataOrig][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] == index)
-            btnFuncBoxPtr->setCurrentIndex(App_Common::inputFuncTable[App_Common::dataOrig][sender()->property("btn").toInt()][1 | sender()->property("slot").toInt() << 1]);
-
-        DiffUpdate();
     }
 }
 
@@ -1108,8 +1184,8 @@ void guiWindow::btnFuncTypeBox_activated(int index)
 void guiWindow::btnFuncBox_currentTextChanged(const QString &str)
 {
     if(!str.isEmpty()) {
-        uint8_t *dataPtr = &App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][1 | sender()->property("slot").toInt() << 1];
-        switch(*dataPtr-1) {
+        uint8_t *dataPtr = &App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][(2*sender()->property("slot").toInt())+1];
+        switch(*(dataPtr-1)) {
         case App_Common::inputMouse:
             *dataPtr = App_Common::mouseMap.value(str.toStdString()).at(0);
             break;
@@ -1506,7 +1582,7 @@ void guiWindow::on_tinyUSBLayoutToggle_stateChanged(int arg1)
 
 void guiWindow::on_tUSB_p1_toggled(bool checked)
 {
-    if(checked) {
+    if(checked && !serialActive) {
         App_Common::tinyUSBtable.tinyUSBid = 1;
         memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
         strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P1");
@@ -1520,7 +1596,7 @@ void guiWindow::on_tUSB_p1_toggled(bool checked)
 
 void guiWindow::on_tUSB_p2_toggled(bool checked)
 {
-    if(checked) {
+    if(checked && !serialActive) {
         App_Common::tinyUSBtable.tinyUSBid = 2;
         memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
         strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P2");
@@ -1534,7 +1610,7 @@ void guiWindow::on_tUSB_p2_toggled(bool checked)
 
 void guiWindow::on_tUSB_p3_toggled(bool checked)
 {
-    if(checked) {
+    if(checked && !serialActive) {
         App_Common::tinyUSBtable.tinyUSBid = 3;
         memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
         strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P3");
@@ -1548,7 +1624,7 @@ void guiWindow::on_tUSB_p3_toggled(bool checked)
 
 void guiWindow::on_tUSB_p4_toggled(bool checked)
 {
-    if(checked) {
+    if(checked && !serialActive) {
         App_Common::tinyUSBtable.tinyUSBid = 4;
         memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
         strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P4");
@@ -2094,7 +2170,14 @@ void guiWindow::CaliWindowRequestedExit()
 
 void guiWindow::on_tabWidget_currentChanged(int index)
 {
+    // TODO: use enums
+    // ...buuut those have to be manually changed in the ui file. bleh.
     switch(index) {
+    // button mappings tab
+    case 1:
+        ui->btnFuncDescBox->setTitle("");
+        ui->btnFuncDescText->setText(ui->btnFuncDescText->whatsThis());
+        break;
     // settings tab
     case 2:
         ui->settingsDescBox->setTitle("");
@@ -2105,12 +2188,10 @@ void guiWindow::on_tabWidget_currentChanged(int index)
         ui->profilesDescBox->setTitle("");
         ui->profilesDescText->setText(ui->profilesDescText->whatsThis());
         break;
-    // button settings (doesn't have any)
-    case 1:
     // test tab (no use yet)
-    case 4:
+    case App_Common::trackTestItem:
     // pins tab (doesn't have any)
-    case 0:
+    case App_Common::trackPinbox:
     default:
         break;
     }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -286,13 +286,13 @@ void guiWindow::BoxesUpdate()
     // enabling custom pins
     if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]) {
         // enable pinboxes
-        for(const auto &box : qAsConst(pinBoxes))
+        for(const auto &box : std::as_const(pinBoxes))
             box->setEnabled(true);
 
         // if the custom pins setting *grabbed from the gun* has been set
         if(App_Common::boolSettings[App_Common::dataOrig][OF_Const::customPins]) {
             // reset pinboxes
-            for(const auto &box : qAsConst(pinBoxes))
+            for(const auto &box : std::as_const(pinBoxes))
                 box->setCurrentIndex(OF_Const::btnUnmapped+1);
 
             // set pinboxes to copied values (pinbox index is off by 1)
@@ -319,7 +319,7 @@ void guiWindow::BoxesUpdate()
     // disabling custom pins, reset to presets
     } else {
         // reset inputs map, as it's not even referenced when custom pins are disabled
-        for(const auto &box : qAsConst(pinBoxes))
+        for(const auto &box : std::as_const(pinBoxes))
             box->setEnabled(false), box->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if available, copy preset layout to pinboxes
@@ -1938,7 +1938,7 @@ void guiWindow::serialPort_SearchFinished()
             if(serial.currentPorts.count()) {
                 ui->comPortSelector->addItem("[Select a device]");
                 ui->comPortSelector->setCurrentIndex(0);
-                for(auto &port : qAsConst(serial.currentPorts))
+                for(auto &port : std::as_const(serial.currentPorts))
                     ui->comPortSelector->addItem(port.portName()+" (" + port.description() + ')');
             }
         // if comPort is filled
@@ -1950,7 +1950,7 @@ void guiWindow::serialPort_SearchFinished()
                     while(ui->comPortSelector->count() > 1)
                         ui->comPortSelector->removeItem(1);
 
-                    for(const auto &newPort : qAsConst(serial.currentPorts))
+                    for(const auto &newPort : std::as_const(serial.currentPorts))
                         ui->comPortSelector->addItem(newPort.portName()+" (" + newPort.description() + ')');
                 // if comPort is active
                 } else {
@@ -1965,7 +1965,7 @@ void guiWindow::serialPort_SearchFinished()
                     // check if current comPort is still in devices list
                     // TODO: probably a better way of doing this, meh
                     bool inList = false;
-                    for(const auto &newPort : qAsConst(serial.currentPorts))
+                    for(const auto &newPort : std::as_const(serial.currentPorts))
                         if(ui->comPortSelector->currentText() == newPort.portName()+" (" + newPort.description() + ')')
                             inList = true;
                     if(!inList) {
@@ -1974,7 +1974,7 @@ void guiWindow::serialPort_SearchFinished()
                     }
 
                     // append new items to list
-                    for(const auto &newPort : qAsConst(serial.currentPorts))
+                    for(const auto &newPort : std::as_const(serial.currentPorts))
                         if(ui->comPortSelector->currentText() != newPort.portName()+" (" + newPort.description() + ')')
                             ui->comPortSelector->addItem(newPort.portName()+" (" + newPort.description() + ')');
                 }
@@ -2168,7 +2168,7 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
             if(fileIn.readLine().trimmed() == App_Common::board.boardType) {
                 if(!ui->customPinsEnabled->isChecked()) ui->customPinsEnabled->setChecked(true);
                 // clear current mapping
-                for(const auto &box : qAsConst(pinBoxes))
+                for(const auto &box : std::as_const(pinBoxes))
                     box->setCurrentIndex(OF_Const::btnUnmapped+1);
 
                 QByteArray inBuf;

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -111,6 +111,55 @@ guiWindow::guiWindow(QWidget *parent)
     ui->PinsCenter->insertWidget(0, &boardPic, 1);
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
+    // Setup inputs map screen stuff
+    for(auto i = App_Common::keyboardInputsMap.cbegin(), end = App_Common::keyboardInputsMap.cend(); i != end; ++i)
+        App_Common::kbOrderedStrings[i.value().at(1)] = (char*)i.key().c_str();
+    for(auto i = App_Common::mouseMap.cbegin(), end = App_Common::mouseMap.cend(); i != end; ++i)
+        App_Common::mouseOrderedStrings[i.value().at(1)] = (char*)i.key().c_str();
+    for(auto i = App_Common::gamepadMap.cbegin(), end = App_Common::gamepadMap.cend(); i != end; ++i)
+        App_Common::gpadOrderedStrings[i.value().at(1)] = (char*)i.key().c_str();
+
+    for(int i = 0; i < BUTTON_COUNT-1; ++i) {
+        for(const auto &item : App_Common::inputFuncTypesStrings) {
+            btnFuncBox[0][0][i].addItem(item);
+            btnFuncBox[1][0][i].addItem(item);
+            btnFuncBox[2][0][i].addItem(item);
+        }
+        for(const auto &item : App_Common::gpadOrderedStrings)
+            btnFuncBox[2][1][i].addItem(item);
+
+        btnFuncLayout[i].addWidget(new QLabel(App_Common::OFPresets.boardInputs_sortedStr[i+1]), 1, Qt::AlignRight);
+        btnFuncLayout[i].addSpacing(4);
+
+        for(int slot = 0; slot < 3; ++slot) {
+            if(slot > 0) btnFuncLayout[i].addSpacing(6);
+
+            btnFuncLayout[i].addWidget(&btnFuncBox[slot][0][i]);
+
+            // only onscreen/offscreen have editable func type selectors
+            if(slot < 2) {
+                btnFuncBox[slot][0][i].setProperty("curType", 0);
+                connect(&btnFuncBox[slot][0][i], SIGNAL(activated(int)), this, SLOT(btnFuncTypeBox_activated(int)));
+            } else {
+                btnFuncBox[slot][0][i].setProperty("curType", App_Common::inputGamepad);
+                btnFuncBox[slot][0][i].setEnabled(false);
+                btnFuncBox[slot][0][i].setFrame(false);
+                btnFuncBox[slot][0][i].setCurrentIndex(App_Common::inputGamepad);
+            }
+
+            btnFuncBox[slot][0][i].setProperty("slot", slot);
+            btnFuncBox[slot][0][i].setProperty("btn", i);
+
+            btnFuncLayout[i].addWidget(&btnFuncBox[slot][1][i], 1);
+            btnFuncBox[slot][1][i].setProperty("slot", slot);
+            btnFuncBox[slot][1][i].setProperty("btn", i);
+
+            connect(&btnFuncBox[slot][1][i], &QComboBox::currentTextChanged, this, &guiWindow::btnFuncBox_currentTextChanged);
+        }
+
+        ui->btnFuncLayout->addLayout(&btnFuncLayout[i]);
+    }
+
     // Setup test screen buttons
     for(int i = 0; i < 14; ++i) {
         testLabel << new QLabel(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
@@ -220,6 +269,18 @@ bool guiWindow::eventFilter(QObject* object, QEvent* event)
 }
 
 
+void guiWindow::aliveTimer_timeout()
+{
+    serialSearchWatcher.setFuture(serialSearchFuture);
+    // Why did Qt6 change this syntax?
+#if QT_VERSION_MAJOR > 5
+    serialSearchFuture = QtConcurrent::run(&AppSerial::SearchPorts, &serial);
+#else
+    serialSearchFuture = QtConcurrent::run(&serial, &AppSerial::SearchPorts);
+#endif
+}
+
+
 void guiWindow::BoxesUpdate()
 {
     // enabling custom pins
@@ -302,6 +363,41 @@ void guiWindow::DiffUpdate()
         ui->confirmButton->setText("[Nothing To Save]");
         ui->confirmButton->setEnabled(false);
     }
+}
+
+
+// Only runs either on initial load or save
+void guiWindow::LabelsUpdate()
+{
+    // because App_Common::inputsMap uses pin no. starting from 0
+    for(uint8_t i = 0; i < testLabel.count(); ++i) {
+        testLabel.at(i)->setStyleSheet("");
+        if(App_Common::inputsMap.value(i) >= 0) {
+            testLabel.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
+            testLabel.at(i)->setEnabled(true);
+        } else {
+            testLabel.at(i)->setText(QByteArray(App_Common::OFPresets.boardInputs_sortedStr[i+1]) + " (N/C)");
+            testLabel.at(i)->setEnabled(false);
+        }
+    }
+
+    ui->tmp36Label->setStyleSheet("");
+    if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
+        ui->tmp36Label->setText("Temperature Read...");
+        ui->tmp36Label->setEnabled(true);
+    } else {
+        ui->tmp36Label->setText("Temperature Sensor (N/C)");
+        ui->tmp36Label->setEnabled(false);
+    }
+
+    if(App_Common::inputsMap.value(OF_Const::ledR) >= 0) ui->redLedTestBtn->setEnabled(true);   else ui->redLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::ledG) >= 0) ui->greenLedTestBtn->setEnabled(true); else ui->greenLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
+    if(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0)
+        ui->analogGroup->setEnabled(true),  ui->aPosLabel->clear();
+    else ui->analogGroup->setEnabled(false), ui->aPosLabel->setText("Not Connected");
+
+    ui->boardLabel->setText(PrettifyName(App_Common::tinyUSBtable.tinyUSBname));
 }
 
 
@@ -415,18 +511,6 @@ void guiWindow::on_confirmButton_clicked()
         ui->comPortSelector->setEnabled(true);
         serialActive = false;
     } else { statusBar()->showMessage("Save operation canceled.", 3000); }
-}
-
-
-void guiWindow::aliveTimer_timeout()
-{
-    serialSearchWatcher.setFuture(serialSearchFuture);
-    // Why did Qt6 change this syntax?
-#if QT_VERSION_MAJOR > 5
-    serialSearchFuture = QtConcurrent::run(&AppSerial::SearchPorts, &serial);
-#else
-    serialSearchFuture = QtConcurrent::run(&serial, &AppSerial::SearchPorts);
-#endif
 }
 
 
@@ -857,40 +941,6 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 }
 
 
-// Only runs either on initial load or save
-void guiWindow::LabelsUpdate()
-{
-    // because App_Common::inputsMap uses pin no. starting from 0
-    for(uint8_t i = 0; i < testLabel.count(); ++i) {
-        testLabel.at(i)->setStyleSheet("");
-        if(App_Common::inputsMap.value(i) >= 0) {
-            testLabel.at(i)->setText(App_Common::OFPresets.boardInputs_sortedStr[i+1]);
-            testLabel.at(i)->setEnabled(true);
-        } else {
-            testLabel.at(i)->setText(QByteArray(App_Common::OFPresets.boardInputs_sortedStr[i+1]) + " (N/C)");
-            testLabel.at(i)->setEnabled(false);
-        }
-    }
-
-    ui->tmp36Label->setStyleSheet("");
-    if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
-        ui->tmp36Label->setText("Temperature Read...");
-        ui->tmp36Label->setEnabled(true);
-    } else {
-        ui->tmp36Label->setText("Temperature Sensor (N/C)");
-        ui->tmp36Label->setEnabled(false);
-    }
-
-    if(App_Common::inputsMap.value(OF_Const::ledR) >= 0) ui->redLedTestBtn->setEnabled(true);   else ui->redLedTestBtn->setEnabled(false);
-    if(App_Common::inputsMap.value(OF_Const::ledG) >= 0) ui->greenLedTestBtn->setEnabled(true); else ui->greenLedTestBtn->setEnabled(false);
-    if(App_Common::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
-    if(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0)
-         ui->analogGroup->setEnabled(true),  ui->aPosLabel->clear();
-    else ui->analogGroup->setEnabled(false), ui->aPosLabel->setText("Not Connected");
-
-    ui->boardLabel->setText(PrettifyName(App_Common::tinyUSBtable.tinyUSBname));
-}
-
 void guiWindow::pinBoxes_currentIndexChanged(int index)
 {
     // using comboboxes' "slot" property to figure caller,
@@ -1011,65 +1061,80 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
     ui->commonAnodeToggle->setEnabled(App_Common::inputsMap.value(OF_Const::ledR) > -1 && App_Common::inputsMap.value(OF_Const::ledG) > -1 && App_Common::inputsMap.value(OF_Const::ledB) > -1);
     ui->i2cGroup->setEnabled(App_Common::inputsMap.value(OF_Const::periphSDA) > -1 && App_Common::inputsMap.value(OF_Const::periphSCL) > -1);
 
-    DiffUpdate();
-}
-
-void guiWindow::profileBoxes_activated(int index)
-{
-    switch(sender()->property("type").toInt()) {
-    case App_Common::pBoxIRsens:
-        App_Common::profilesTable[sender()->property("slot").toInt()].irSensitivity = index;
-        break;
-    case App_Common::pBoxRunMode:
-        App_Common::profilesTable[sender()->property("slot").toInt()].runMode = index;
-        break;
-    case App_Common::pBoxLayout:
-        App_Common::profilesTable[sender()->property("slot").toInt()].layoutType = index;
-        break;
-    default:
-        break;
-    }
+    ui->aStickFuncBox->setEnabled(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0);
+    for(int i = 0; i < BUTTON_COUNT-1; ++i)
+        btnFuncLayout[i].setEnabled(App_Common::inputsMap.value(i) >= 0);
 
     DiffUpdate();
 }
 
 
-void guiWindow::renameBoxes_clicked()
+/// button mapping
+void guiWindow::btnFuncTypeBox_activated(int index)
 {
-    // TODO: limit character length in the text dialog - for now, just use up to 15 characters.
-    QString newLabel = QInputDialog::getText(this,
-                                             "Input Name",
-                                             QString("Set name for Calibration Profile %1").arg(sender()->property("slot").toInt()+1));
+    if(sender()->property("curType").toInt() != index) {
+        QComboBox *btnFuncBoxPtr = &btnFuncBox[sender()->property("slot").toInt()][1][sender()->property("btn").toInt()];
 
-    if(!newLabel.isEmpty()) {
-        selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()+1).arg(newLabel.left(15)));
-        memset(App_Common::profilesTable[sender()->property("slot").toInt()].profName, 0, sizeof(App_Common::profilesTable_s::profName));
-        strncpy(App_Common::profilesTable[sender()->property("slot").toInt()].profName, newLabel.toLocal8Bit().constData(), sizeof(App_Common::profilesTable_s::profName)-1);
-    }
+        sender()->setProperty("curType", index);
+        App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] = index;
+        btnFuncBoxPtr->blockSignals(true);
+        btnFuncBoxPtr->clear();
 
-    DiffUpdate();
-}
+        switch(index) {
+        case App_Common::inputMouse:
+            for(const auto &item : App_Common::mouseOrderedStrings)
+                btnFuncBoxPtr->addItem(item);
+            break;
+        case App_Common::inputKB:
+            for(const auto &item : App_Common::kbOrderedStrings)
+                btnFuncBoxPtr->addItem(item);
+            break;
+        case App_Common::inputGamepad:
+            for(const auto &item : App_Common::gpadOrderedStrings)
+                btnFuncBoxPtr->addItem(item);
+            break;
+        }
 
+        btnFuncBoxPtr->blockSignals(false);
 
-void guiWindow::colorBoxes_clicked()
-{
-    QColor colorPick = QColorDialog::getColor(App_Common::profilesTable[sender()->property("slot").toInt()].color);
-    if(colorPick.isValid()) {
-        int red;
-        int green;
-        int blue;
-        colorPick.getRgb(&red, &green, &blue);
-        uint32_t packedColor = 0;
-        packedColor |= red << 16;
-        packedColor |= green << 8;
-        packedColor |= blue;
-        App_Common::profilesTable[sender()->property("slot").toInt()].color = packedColor;
-        color[sender()->property("slot").toInt()]->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
+        if(App_Common::inputFuncTable[App_Common::dataOrig][sender()->property("btn").toInt()][sender()->property("slot").toInt() << 1] == index)
+            btnFuncBoxPtr->setCurrentIndex(App_Common::inputFuncTable[App_Common::dataOrig][sender()->property("btn").toInt()][1 | sender()->property("slot").toInt() << 1]);
+
         DiffUpdate();
     }
 }
 
 
+void guiWindow::btnFuncBox_currentTextChanged(const QString &str)
+{
+    if(!str.isEmpty()) {
+        uint8_t *dataPtr = &App_Common::inputFuncTable[App_Common::dataCurrent][sender()->property("btn").toInt()][1 | sender()->property("slot").toInt() << 1];
+        switch(*dataPtr-1) {
+        case App_Common::inputMouse:
+            *dataPtr = App_Common::mouseMap.value(str.toStdString()).at(0);
+            break;
+        case App_Common::inputKB:
+            *dataPtr = App_Common::keyboardInputsMap.value(str.toStdString()).at(0);
+            break;
+        case App_Common::inputGamepad:
+            *dataPtr = App_Common::gamepadMap.value(str.toStdString()).at(0);
+            break;
+        }
+
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::on_aStickModeBox_currentIndexChanged(int index)
+{
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::analogMode] = index;
+
+    DiffUpdate();
+}
+
+
+/// settings
 void guiWindow::on_customPinsEnabled_stateChanged(int arg1)
 {
     App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins] = arg1;
@@ -1280,143 +1345,6 @@ void guiWindow::on_solenoidHoldLengthBox_valueChanged(int arg1)
 }
 
 
-void guiWindow::on_tUSB_p1_toggled(bool checked)
-{
-    if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = 1;
-        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
-        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P1");
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
-        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-
-        DiffUpdate();
-    }
-}
-
-
-void guiWindow::on_tUSB_p2_toggled(bool checked)
-{
-    if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = 2;
-        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
-        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P2");
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
-        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-
-        DiffUpdate();
-    }
-}
-
-
-void guiWindow::on_tUSB_p3_toggled(bool checked)
-{
-    if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = 3;
-        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
-        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P3");
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
-        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-
-        DiffUpdate();
-    }
-}
-
-
-void guiWindow::on_tUSB_p4_toggled(bool checked)
-{
-    if(checked) {
-        App_Common::tinyUSBtable.tinyUSBid = 4;
-        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
-        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P4");
-        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
-        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-
-        DiffUpdate();
-    }
-}
-
-
-void guiWindow::on_productIdInput_valueChanged(int arg1)
-{
-    App_Common::tinyUSBtable.tinyUSBid = arg1;
-    if(ui->productNameInput->text().isEmpty()) {
-        switch(arg1) {
-        case 1:
-            ui->tUSB_p1->setChecked(true);
-            break;
-        case 2:
-            ui->tUSB_p2->setChecked(true);
-            break;
-        case 3:
-            ui->tUSB_p3->setChecked(true);
-            break;
-        case 4:
-            ui->tUSB_p4->setChecked(true);
-            break;
-        default:
-            ui->tUSB_p1->setChecked(false);
-            ui->tUSB_p2->setChecked(false);
-            ui->tUSB_p3->setChecked(false);
-            ui->tUSB_p4->setChecked(false);
-            break;
-        }
-    }
-
-    DiffUpdate();
-}
-
-
-void guiWindow::on_productNameInput_textEdited(const QString &arg1)
-{
-    bool badInput = false;
-    // Very unga-bunga way of doing this.
-    // if someone is aware of a validator for this, feel free to replace this.
-    for(int i = 0; i < arg1.length(); ++i) {
-        if(arg1.at(i).unicode() > 255) {
-            badInput = true;
-            break;
-        }
-    }
-
-    if(badInput) {
-        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
-        ui->productNameInput->setStyleSheet("color: red");
-    } else {
-        if(!ui->productNameInput->styleSheet().isEmpty())
-            ui->productNameInput->setStyleSheet("");
-        strncpy(App_Common::tinyUSBtable.tinyUSBname, arg1.toLocal8Bit().constData(), sizeof(App_Common::tinyUSBtable_s::tinyUSBname)-1);
-        DiffUpdate();
-    }
-}
-
-
-void guiWindow::on_tinyUSBLayoutToggle_stateChanged(int arg1)
-{
-    if(arg1) {
-        ui->tUSBLayoutSimple->setVisible(false);
-        ui->tUSBLayoutAdvanced->setVisible(true);
-    } else {
-        ui->tUSBLayoutAdvanced->setVisible(false);
-        ui->tUSBLayoutSimple->setVisible(true);
-    }
-}
-
-
-void guiWindow::selectedProfile_isChecked(bool isChecked)
-{
-    // apparently we get two signals at once? So just filter for the on.
-    if(isChecked && !serialActive) {
-        // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
-        if(sender()->property("slot").toInt() != App_Common::board.selectedProfile) {
-            char buf[] = {(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt())};
-            serial.OneShotSend(buf, 4);
-            App_Common::board.selectedProfile = sender()->property("slot").toInt();
-            DiffUpdate();
-        }
-    }
-}
-
-
 void guiWindow::on_neopixelStrandLengthBox_valueChanged(int arg1)
 {
     App_Common::settingsTable[App_Common::dataCurrent][OF_Const::customLEDcount] = arg1;
@@ -1564,6 +1492,200 @@ void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
 }
 
 
+void guiWindow::on_tinyUSBLayoutToggle_stateChanged(int arg1)
+{
+    if(arg1) {
+        ui->tUSBLayoutSimple->setVisible(false);
+        ui->tUSBLayoutAdvanced->setVisible(true);
+    } else {
+        ui->tUSBLayoutAdvanced->setVisible(false);
+        ui->tUSBLayoutSimple->setVisible(true);
+    }
+}
+
+
+void guiWindow::on_tUSB_p1_toggled(bool checked)
+{
+    if(checked) {
+        App_Common::tinyUSBtable.tinyUSBid = 1;
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P1");
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::on_tUSB_p2_toggled(bool checked)
+{
+    if(checked) {
+        App_Common::tinyUSBtable.tinyUSBid = 2;
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P2");
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::on_tUSB_p3_toggled(bool checked)
+{
+    if(checked) {
+        App_Common::tinyUSBtable.tinyUSBid = 3;
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P3");
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::on_tUSB_p4_toggled(bool checked)
+{
+    if(checked) {
+        App_Common::tinyUSBtable.tinyUSBid = 4;
+        memset(App_Common::tinyUSBtable.tinyUSBname, 0, sizeof(App_Common::tinyUSBtable_s::tinyUSBname));
+        strcpy(App_Common::tinyUSBtable.tinyUSBname, "FIRECon P4");
+        ui->productIdInput->setValue(App_Common::tinyUSBtable.tinyUSBid);
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::on_productIdInput_valueChanged(int arg1)
+{
+    App_Common::tinyUSBtable.tinyUSBid = arg1;
+    if(ui->productNameInput->text().isEmpty()) {
+        switch(arg1) {
+        case 1:
+            ui->tUSB_p1->setChecked(true);
+            break;
+        case 2:
+            ui->tUSB_p2->setChecked(true);
+            break;
+        case 3:
+            ui->tUSB_p3->setChecked(true);
+            break;
+        case 4:
+            ui->tUSB_p4->setChecked(true);
+            break;
+        default:
+            ui->tUSB_p1->setChecked(false);
+            ui->tUSB_p2->setChecked(false);
+            ui->tUSB_p3->setChecked(false);
+            ui->tUSB_p4->setChecked(false);
+            break;
+        }
+    }
+
+    DiffUpdate();
+}
+
+
+void guiWindow::on_productNameInput_textEdited(const QString &arg1)
+{
+    bool badInput = false;
+    // Very unga-bunga way of doing this.
+    // if someone is aware of a validator for this, feel free to replace this.
+    for(int i = 0; i < arg1.length(); ++i) {
+        if(arg1.at(i).unicode() > 255) {
+            badInput = true;
+            break;
+        }
+    }
+
+    if(badInput) {
+        ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
+        ui->productNameInput->setStyleSheet("color: red");
+    } else {
+        if(!ui->productNameInput->styleSheet().isEmpty())
+            ui->productNameInput->setStyleSheet("");
+        strncpy(App_Common::tinyUSBtable.tinyUSBname, arg1.toLocal8Bit().constData(), sizeof(App_Common::tinyUSBtable_s::tinyUSBname)-1);
+        DiffUpdate();
+    }
+}
+
+
+/// cali profiles
+void guiWindow::profileBoxes_activated(int index)
+{
+    switch(sender()->property("type").toInt()) {
+    case App_Common::pBoxIRsens:
+        App_Common::profilesTable[sender()->property("slot").toInt()].irSensitivity = index;
+        break;
+    case App_Common::pBoxRunMode:
+        App_Common::profilesTable[sender()->property("slot").toInt()].runMode = index;
+        break;
+    case App_Common::pBoxLayout:
+        App_Common::profilesTable[sender()->property("slot").toInt()].layoutType = index;
+        break;
+    default:
+        break;
+    }
+
+    DiffUpdate();
+}
+
+
+void guiWindow::renameBoxes_clicked()
+{
+    // TODO: limit character length in the text dialog - for now, just use up to 15 characters.
+    QString newLabel = QInputDialog::getText(this,
+                                             "Input Name",
+                                             QString("Set name for Calibration Profile %1").arg(sender()->property("slot").toInt()+1));
+
+    if(!newLabel.isEmpty()) {
+        selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()+1).arg(newLabel.left(15)));
+        memset(App_Common::profilesTable[sender()->property("slot").toInt()].profName, 0, sizeof(App_Common::profilesTable_s::profName));
+        strncpy(App_Common::profilesTable[sender()->property("slot").toInt()].profName, newLabel.toLocal8Bit().constData(), sizeof(App_Common::profilesTable_s::profName)-1);
+    }
+
+    DiffUpdate();
+}
+
+
+void guiWindow::colorBoxes_clicked()
+{
+    QColor colorPick = QColorDialog::getColor(App_Common::profilesTable[sender()->property("slot").toInt()].color);
+    if(colorPick.isValid()) {
+        int red;
+        int green;
+        int blue;
+        colorPick.getRgb(&red, &green, &blue);
+        uint32_t packedColor = 0;
+        packedColor |= red << 16;
+        packedColor |= green << 8;
+        packedColor |= blue;
+        App_Common::profilesTable[sender()->property("slot").toInt()].color = packedColor;
+        color[sender()->property("slot").toInt()]->setStyleSheet(QString("background-color: #%1").arg(packedColor, 6, 16, QLatin1Char('0')));
+        DiffUpdate();
+    }
+}
+
+
+void guiWindow::selectedProfile_isChecked(bool isChecked)
+{
+    // apparently we get two signals at once? So just filter for the on.
+    if(isChecked && !serialActive) {
+        // Demultiplexing to figure out which "pin" this combobox that's calling correlates to.
+        if(sender()->property("slot").toInt() != App_Common::board.selectedProfile) {
+            char buf[] = {(char)OF_Const::sCaliProfile, static_cast<char>(sender()->property("slot").toInt())};
+            serial.OneShotSend(buf, 4);
+            App_Common::board.selectedProfile = sender()->property("slot").toInt();
+            DiffUpdate();
+        }
+    }
+}
+
+
 void guiWindow::caliBtns_clicked()
 {
     NewCaliWindow(AppCaliWindow::modeCalibrate);
@@ -1577,6 +1699,107 @@ void guiWindow::caliBtns_clicked()
 }
 
 
+/// gun tests
+void guiWindow::on_rumbleTestBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sTestRumble, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
+}
+
+
+void guiWindow::on_solenoidTestBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sTestSolenoid, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
+}
+
+
+void guiWindow::on_redLedTestBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sTestLEDR, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        ui->statusBar->showMessage("Set LED to Red.", 2500);
+}
+
+
+void guiWindow::on_greenLedTestBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sTestLEDG, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        ui->statusBar->showMessage("Set LED to Green.", 2500);
+}
+
+
+void guiWindow::on_blueLedTestBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sTestLEDB, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        ui->statusBar->showMessage("Set LED to Blue.", 2500);
+}
+
+
+void guiWindow::on_testBtn_clicked()
+{
+    char buf[2] = { (char)OF_Const::sIRTest, true };
+    if(serial.OneShotSend(buf, sizeof(buf)))
+        NewCaliWindow(AppCaliWindow::modeIRTest);
+}
+
+
+void guiWindow::on_clearEepromBtn_clicked()
+{
+    // Do we really need all this msgbox setup?
+    QMessageBox messageBox;
+    messageBox.setText("Really delete saved data?");
+    messageBox.setInformativeText("This operation will delete all saved data, including:\n\n"
+                                  " - Calibration Profiles\n"
+                                  " - Toggles\n - Settings\n"
+                                  " - Custom Identifiers\n\n"
+                                  "Are you sure about this?");
+    messageBox.setWindowTitle("Delete Confirmation");
+    messageBox.setIcon(QMessageBox::Warning);
+    messageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    messageBox.setDefaultButton(QMessageBox::No);
+
+    if(messageBox.exec() == QMessageBox::Yes) {
+        ui->statusBar->showMessage("Board reset to initial settings.");
+        char buf[2] = { (char)OF_Const::sClearFlash, (char)OF_Const::sClearFlash };
+        serial.OneShotSend(buf, sizeof(buf));
+        ui->comPortSelector->setCurrentIndex(0);
+    } else ui->statusBar->showMessage("Clear operation canceled.", 3000);
+}
+
+
+void guiWindow::on_baudResetBtn_clicked()
+{
+    serial.RebootToBootldr();
+
+    /* test stuff for potential app FW update functionality
+    // At least on my system, the Bootloader device takes ~7s to appear
+    QThread::msleep(7000);
+    // Class-ify this function, maybe.
+    QString picoPath;
+    foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
+        if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
+            picoPath = storageDevices.device();
+            qDebug() << "Found a Pico bootloader!";
+            break;
+        } else {
+            qDebug() << "nope";
+        }
+    }
+    qDebug() << picoPath;
+    // QFile::copy("file", picoPath+"file");
+*/
+
+    ui->statusBar->showMessage("Board reset to bootloader.", 5000);
+    ui->comPortSelector->setCurrentIndex(0);
+}
+
+
+/// System/background
 // WARNING: make sure "serialActive" is set ON for important operations, or this will eat the fucker
 // TODO: move to appserial
 void guiWindow::serialPort_readyRead()
@@ -1790,52 +2013,7 @@ void guiWindow::serialPort_progressUpdate(const int &pos, const char *statusText
 }
 
 
-void guiWindow::on_rumbleTestBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sTestRumble, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
-}
 
-
-void guiWindow::on_solenoidTestBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sTestSolenoid, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
-}
-
-
-void guiWindow::on_redLedTestBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sTestLEDR, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Red.", 2500);
-}
-
-
-void guiWindow::on_greenLedTestBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sTestLEDG, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Green.", 2500);
-}
-
-
-void guiWindow::on_blueLedTestBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sTestLEDB, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Blue.", 2500);
-}
-
-
-void guiWindow::on_testBtn_clicked()
-{
-    char buf[2] = { (char)OF_Const::sIRTest, true };
-    if(serial.OneShotSend(buf, sizeof(buf)))
-        NewCaliWindow(AppCaliWindow::modeIRTest);
-}
 
 
 void guiWindow::CaliWindowExiting(const int &mode,
@@ -1914,57 +2092,6 @@ void guiWindow::CaliWindowRequestedExit()
 }
 
 
-void guiWindow::on_clearEepromBtn_clicked()
-{
-    // Do we really need all this msgbox setup?
-    QMessageBox messageBox;
-    messageBox.setText("Really delete saved data?");
-    messageBox.setInformativeText("This operation will delete all saved data, including:\n\n"
-                                  " - Calibration Profiles\n"
-                                  " - Toggles\n - Settings\n"
-                                  " - Custom Identifiers\n\n"
-                                  "Are you sure about this?");
-    messageBox.setWindowTitle("Delete Confirmation");
-    messageBox.setIcon(QMessageBox::Warning);
-    messageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    messageBox.setDefaultButton(QMessageBox::No);
-
-    if(messageBox.exec() == QMessageBox::Yes) {
-        ui->statusBar->showMessage("Board reset to initial settings.");
-        char buf[2] = { (char)OF_Const::sClearFlash, (char)OF_Const::sClearFlash };
-        serial.OneShotSend(buf, sizeof(buf));
-        ui->comPortSelector->setCurrentIndex(0);
-    } else ui->statusBar->showMessage("Clear operation canceled.", 3000);
-}
-
-
-void guiWindow::on_baudResetBtn_clicked()
-{
-    serial.RebootToBootldr();
-
-/* test stuff for potential app FW update functionality
-    // At least on my system, the Bootloader device takes ~7s to appear
-    QThread::msleep(7000);
-    // Class-ify this function, maybe.
-    QString picoPath;
-    foreach(const QStorageInfo &storageDevices, QStorageInfo::mountedVolumes()) {
-        if(storageDevices.isValid() && storageDevices.isReady() && storageDevices.displayName() == "RPI-RP2") {
-            picoPath = storageDevices.device();
-            qDebug() << "Found a Pico bootloader!";
-            break;
-        } else {
-            qDebug() << "nope";
-        }
-    }
-    qDebug() << picoPath;
-    // QFile::copy("file", picoPath+"file");
-*/
-
-    ui->statusBar->showMessage("Board reset to bootloader.", 5000);
-    ui->comPortSelector->setCurrentIndex(0);
-}
-
-
 void guiWindow::on_tabWidget_currentChanged(int index)
 {
     switch(index) {
@@ -1989,6 +2116,7 @@ void guiWindow::on_tabWidget_currentChanged(int index)
 }
 
 
+/// actions
 void guiWindow::on_actionShow_Unsafe_Settings_toggled(bool arg1)
 {
     if(arg1) ui->solenoidTempBox->setVisible(true);

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -2096,18 +2096,19 @@ void guiWindow::on_tabWidget_currentChanged(int index)
 {
     switch(index) {
     // settings tab
-    case 1:
+    case 2:
         ui->settingsDescBox->setTitle("");
         ui->settingsDescText->setText(ui->settingsDescText->whatsThis());
         break;
     // profiles tab
-    case 2:
+    case 3:
         ui->profilesDescBox->setTitle("");
         ui->profilesDescText->setText(ui->profilesDescText->whatsThis());
         break;
+    // button settings (doesn't have any)
+    case 1:
     // test tab (no use yet)
-    case 3:
-        break;
+    case 4:
     // pins tab (doesn't have any)
     case 0:
     default:

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -36,8 +36,8 @@
 #include <QGraphicsItem>
 #include <QPen>
 #include <QTimer>
-#include <QVBoxLayout>
-#include <QGridLayout>
+#include <QLayout>
+#include <QGroupBox>
 #include <QStandardItemModel>
 #include <QComboBox>
 #include <QLabel>
@@ -76,7 +76,7 @@ private slots:
     void on_presetsBox_currentIndexChanged(int index);
 
     /// button mapping
-    void btnFuncTypeBox_activated(int index);
+    void btnFuncTypeBox_currentIndexChanged(int index);
 
     void btnFuncBox_currentTextChanged(const QString &);
 
@@ -305,6 +305,7 @@ private:
     ///             Array 2: 0 = input type, 1 = input data
     ///             Array 3 = button
     QComboBox btnFuncBox[App_Common::inputTypes][App_Common::inputFuncTypes][BUTTON_COUNT-1];
+    QGroupBox btnFuncGBoxes[BUTTON_COUNT-1];
     QHBoxLayout btnFuncLayout[BUTTON_COUNT-1];
 
     /// @brief      Objects that makes up the elements of the profiles tab

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -63,28 +63,26 @@ public:
 private slots:
     void aliveTimer_timeout();
 
+    /// global
     void on_comPortSelector_currentTextChanged(const QString &);
 
     void on_confirmButton_clicked();
 
+    /// pin layouts
     void pinBoxes_currentIndexChanged(int index);
-
-    void renameBoxes_clicked();
-
-    void colorBoxes_clicked();
-
-    void profileBoxes_activated(int arg1);
 
     void on_customPinsEnabled_stateChanged(int arg1);
 
     void on_presetsBox_currentIndexChanged(int index);
 
-    void on_rumbleTestBtn_clicked();
+    /// button mapping
+    void btnFuncTypeBox_activated(int index);
 
-    void on_solenoidTestBtn_clicked();
+    void btnFuncBox_currentTextChanged(const QString &);
 
-    void on_baudResetBtn_clicked();
+    void on_aStickModeBox_currentIndexChanged(int index);
 
+    /// gun settings
     void on_rumbleToggle_stateChanged(int arg1);
 
     void on_solenoidToggle_stateChanged(int arg1);
@@ -117,21 +115,7 @@ private slots:
 
     void on_solenoidHoldLengthBox_valueChanged(int arg1);
 
-    void on_productIdInput_valueChanged(int arg1);
-
-    void on_productNameInput_textEdited(const QString &arg1);
-
     void on_neopixelStrandLengthBox_valueChanged(int arg1);
-
-    void on_clearEepromBtn_clicked();
-
-    void on_testBtn_clicked();
-
-    void selectedProfile_isChecked(bool isChecked);
-
-    void caliBtns_clicked();
-
-    void on_actionAbout_UI_triggered();
 
     void on_customLEDstaticSpinbox_valueChanged(int arg1);
 
@@ -157,12 +141,39 @@ private slots:
 
     void on_tUSB_p4_toggled(bool checked);
 
+    void on_productIdInput_valueChanged(int arg1);
+
+    void on_productNameInput_textEdited(const QString &arg1);
+
+    /// cali profiles
+    void renameBoxes_clicked();
+
+    void colorBoxes_clicked();
+
+    void profileBoxes_activated(int arg1);
+
+    void selectedProfile_isChecked(bool isChecked);
+
+    void caliBtns_clicked();
+
+    /// gun tests
+    void on_rumbleTestBtn_clicked();
+
+    void on_solenoidTestBtn_clicked();
+
     void on_redLedTestBtn_clicked();
 
     void on_greenLedTestBtn_clicked();
 
     void on_blueLedTestBtn_clicked();
 
+    void on_baudResetBtn_clicked();
+
+    void on_clearEepromBtn_clicked();
+
+    void on_testBtn_clicked();
+
+    /// system/background
     void on_tabWidget_currentChanged(int index);
 
     void serialPort_readyRead();
@@ -192,6 +203,8 @@ private slots:
     void CaliWindowRequestedExit();
 
     void on_actionDebug_Window_triggered();
+
+    void on_actionAbout_UI_triggered();
 
 private:
     Ui::guiWindow *ui;
@@ -286,6 +299,13 @@ private:
     /// @brief      Analog stick graphic view
     QGraphicsScene analogGfxScene;
     QGraphicsEllipseItem* analogPos;
+
+    /// @brief      Button Mapping elements
+    /// @details    Array 1 = onscreen input / offscreen input / gamepad mode input
+    ///             Array 2: 0 = input type, 1 = input data
+    ///             Array 3 = button
+    QComboBox btnFuncBox[App_Common::inputTypes][App_Common::inputFuncTypes][BUTTON_COUNT-1];
+    QHBoxLayout btnFuncLayout[BUTTON_COUNT-1];
 
     /// @brief      Objects that makes up the elements of the profiles tab
     QVector<QRadioButton*> selectedProfile;

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>980</width>
-    <height>820</height>
+    <height>830</height>
    </rect>
   </property>
   <property name="windowIcon">
@@ -155,7 +155,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>548</height>
+             <height>558</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -296,7 +296,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>579</height>
+             <height>589</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -482,7 +482,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-350</y>
+             <y>0</y>
              <width>924</width>
              <height>1192</height>
             </rect>
@@ -1735,7 +1735,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>416</height>
+             <height>423</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_16">

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -155,7 +155,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>558</height>
+             <height>559</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -275,7 +275,7 @@
        <attribute name="title">
         <string>Button Mapping</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_18">
+       <layout class="QVBoxLayout" name="verticalLayout_18" stretch="8,3">
         <item>
          <widget class="QScrollArea" name="buttonFuncScroller">
           <property name="frameShadow">
@@ -296,7 +296,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>589</height>
+             <height>424</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -381,7 +381,11 @@
                 </layout>
                </item>
                <item>
-                <layout class="QVBoxLayout" name="btnFuncLayout"/>
+                <layout class="QVBoxLayout" name="btnFuncLayout">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                </layout>
                </item>
               </layout>
              </widget>
@@ -427,6 +431,15 @@
                </item>
                <item>
                 <widget class="QComboBox" name="aStickModeBox">
+                 <property name="whatsThis">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If an analog stick is enabled in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout,&lt;/span&gt; this determines which type of Button Output it uses.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Gamepad Analog Stick&lt;/span&gt; will use either the Left or Right analog stick of the Gamepad device, depending on the circumstances and/or whether &lt;span style=&quot; font-style:italic;&quot;&gt;Gamepad Output Mode&lt;/span&gt; is set via Serial. The other two settings will translate the stick's analog movements into either digital &lt;span style=&quot; font-weight:700;&quot;&gt;Gamepad D-Pad&lt;/span&gt; or &lt;span style=&quot; font-weight:700;&quot;&gt;Keyboard Arrow Key&lt;/span&gt; presses.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Default: Gamepad Analog Stick&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Analog Stick Output Mode</string>
+                 </property>
+                 <property name="trackable" stdset="0">
+                  <number>3</number>
+                 </property>
                  <item>
                   <property name="text">
                    <string>Gamepad Analog Stick (Left/Right)</string>
@@ -449,6 +462,53 @@
             </item>
            </layout>
           </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="btnFuncDescBox">
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QGroupBox::title { color: yellow }</string>
+          </property>
+          <property name="title">
+           <string/>
+          </property>
+          <layout class="QVBoxLayout" name="btnDescLayout">
+           <item>
+            <widget class="QLabel" name="btnFuncDescText">
+             <property name="font">
+              <font>
+               <bold>false</bold>
+              </font>
+             </property>
+             <property name="whatsThis">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows the currently loaded Button Mapping settings.&lt;/p&gt;&lt;p&gt;Any enabled button input in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout&lt;/span&gt; can be assigned to output any button from any of the three Input Devices that OpenFIRE presents to any connected device (a Mouse, Keyboard, and Xbox-like Gamepad), depending on the condition that the input is pressed.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">color: lightgray</string>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows the currently loaded Button Mapping settings.&lt;/p&gt;&lt;p&gt;Any enabled button input in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout&lt;/span&gt; can be assigned to output any button from any of the three Input Devices that OpenFIRE presents to any connected device (a Mouse, Keyboard, and Xbox-like Gamepad), depending on the condition that the input is pressed.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="openExternalLinks">
+              <bool>true</bool>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>
@@ -482,7 +542,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
+             <y>-20</y>
              <width>924</width>
              <height>1192</height>
             </rect>
@@ -1700,6 +1760,9 @@
              <property name="openExternalLinks">
               <bool>true</bool>
              </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+             </property>
             </widget>
            </item>
           </layout>
@@ -1735,7 +1798,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>423</height>
+             <height>424</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -2267,9 +2330,6 @@
       </property>
       <property name="text">
        <string>[Nothing To Save]</string>
-      </property>
-      <property name="icon">
-       <iconset theme="QIcon::ThemeIcon::DocumentSave"/>
       </property>
      </widget>
     </item>

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -118,10 +118,19 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
       <widget class="QWidget" name="pinsTab">
        <property name="enabled">
         <bool>true</bool>
        </property>
+       <attribute name="icon">
+        <iconset theme="QIcon::ThemeIcon::DocumentProperties"/>
+       </attribute>
        <attribute name="title">
         <string>Board Layout</string>
        </attribute>
@@ -146,7 +155,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>558</height>
+             <height>548</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -234,6 +243,9 @@
             <property name="text">
              <string>User Layouts</string>
             </property>
+            <property name="icon">
+             <iconset theme="QIcon::ThemeIcon::EditCopy"/>
+            </property>
             <property name="popupMode">
              <enum>QToolButton::InstantPopup</enum>
             </property>
@@ -256,10 +268,198 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="buttonFuncTab">
+       <attribute name="icon">
+        <iconset theme="QIcon::ThemeIcon::InputKeyboard"/>
+       </attribute>
+       <attribute name="title">
+        <string>Button Mapping</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_18">
+        <item>
+         <widget class="QScrollArea" name="buttonFuncScroller">
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+          </property>
+          <widget class="QWidget" name="buttonFuncScrollLayout">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>938</width>
+             <height>579</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_19">
+            <item>
+             <widget class="QGroupBox" name="buttonFuncBox">
+              <property name="title">
+               <string>Digital Inputs</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_20">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="2,3,3,3">
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_17">
+                   <property name="font">
+                    <font>
+                     <pointsize>11</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>On-Screen Function</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_19">
+                   <property name="font">
+                    <font>
+                     <pointsize>11</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Off-Screen Function</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_18">
+                   <property name="font">
+                    <font>
+                     <pointsize>11</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Gamepad Mode</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="btnFuncLayout"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="aStickFuncBox">
+              <property name="title">
+               <string>Analog Stick</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <spacer name="horizontalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>Send Analog Stick As:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="aStickModeBox">
+                 <item>
+                  <property name="text">
+                   <string>Gamepad Analog Stick (Left/Right)</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Gamepad D-Pad</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Keyboard Arrows</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="settingsTab">
        <property name="enabled">
         <bool>true</bool>
        </property>
+       <attribute name="icon">
+        <iconset theme="QIcon::ThemeIcon::DriveHarddisk"/>
+       </attribute>
        <attribute name="title">
         <string>Gun Settings</string>
        </attribute>
@@ -282,7 +482,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
+             <y>-350</y>
              <width>924</width>
              <height>1192</height>
             </rect>
@@ -767,6 +967,7 @@
                      <widget class="QPushButton" name="customLEDstaticBtn1">
                       <property name="font">
                        <font>
+                        <pointsize>10</pointsize>
                         <bold>true</bold>
                         <underline>false</underline>
                         <kerning>false</kerning>
@@ -790,6 +991,7 @@
                      <widget class="QPushButton" name="customLEDstaticBtn2">
                       <property name="font">
                        <font>
+                        <pointsize>10</pointsize>
                         <bold>true</bold>
                        </font>
                       </property>
@@ -811,6 +1013,7 @@
                      <widget class="QPushButton" name="customLEDstaticBtn3">
                       <property name="font">
                        <font>
+                        <pointsize>10</pointsize>
                         <bold>true</bold>
                        </font>
                       </property>
@@ -1505,6 +1708,9 @@
        </layout>
       </widget>
       <widget class="QWidget" name="profilesTab">
+       <attribute name="icon">
+        <iconset theme="QIcon::ThemeIcon::Computer"/>
+       </attribute>
        <attribute name="title">
         <string>Calibration Profiles</string>
        </attribute>
@@ -1529,7 +1735,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>423</height>
+             <height>416</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1819,6 +2025,9 @@
        <property name="enabled">
         <bool>true</bool>
        </property>
+       <attribute name="icon">
+        <iconset theme="QIcon::ThemeIcon::InputTablet"/>
+       </attribute>
        <attribute name="title">
         <string>Gun Tests</string>
        </attribute>
@@ -2059,6 +2268,9 @@
       <property name="text">
        <string>[Nothing To Save]</string>
       </property>
+      <property name="icon">
+       <iconset theme="QIcon::ThemeIcon::DocumentSave"/>
+      </property>
      </widget>
     </item>
    </layout>
@@ -2132,6 +2344,9 @@
    </property>
   </action>
   <action name="actionImport_Custom_Layout">
+   <property name="icon">
+    <iconset theme="QIcon::ThemeIcon::DocumentOpen"/>
+   </property>
    <property name="text">
     <string>Import Custom Layout...</string>
    </property>
@@ -2140,6 +2355,9 @@
    </property>
   </action>
   <action name="actionExport_Custom_Layout">
+   <property name="icon">
+    <iconset theme="QIcon::ThemeIcon::DocumentSaveAs"/>
+   </property>
    <property name="text">
     <string>Export Custom Layout...</string>
    </property>

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -44,7 +44,7 @@ bool AppSerial::SearchPorts()
             printf("Current ports list does not match new list, overriding...\n");
             currentPortsNames = GeneratePortsList(currentPorts);
             return true;
-        } else for(const auto &foundPort : qAsConst(serialFoundList)) {
+        } else for(const auto &foundPort : std::as_const(serialFoundList)) {
             if(!currentPortsNames.contains(foundPort.portName())) {
                 currentPorts = serialFoundList;
                 printf("%s not found in current ports, overriding old serial devices list...\n", foundPort.portName().toLocal8Bit().constData());
@@ -73,7 +73,7 @@ bool AppSerial::GetSettings(const QString &portName)
         port.close();
     }
 
-    for(const auto &curPort : qAsConst(currentPorts))
+    for(const auto &curPort : std::as_const(currentPorts))
         if(portName == curPort.portName()+" (" + curPort.description() + ')')
             port.setPort(curPort);
 
@@ -88,7 +88,7 @@ bool AppSerial::GetSettings(const QString &portName)
                 QList<QByteArray> buffer = port.readLine().split((char)OF_Const::serialTerminator);
 
                 if(buffer.size() >= 3) {
-                    emit Serial_SetProgressRange(5);
+                    emit Serial_SetProgressRange(6);
                     emit Serial_ProgressUpdate(1, "Getting Board Info");
 
                     ////* Opening board message bits *////
@@ -162,20 +162,40 @@ bool AppSerial::GetSettings(const QString &portName)
                                    App_Common::settingsTable[App_Common::dataCurrent],
                                    sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
-                            emit Serial_ProgressUpdate(4, "Getting Profiles Data");
+                            emit Serial_ProgressUpdate(4, "Getting Button Mappings");
 
-                            // profiles
-                            App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
-
+                            ////* buttons *////
                             port.clear();
-                            if(OneShotSend((char)OF_Const::sGetProfile, true)) {
-                                if(BatchStoreSettings(nullptr, App_Common::OFPresets.profSettingTypes_Strings, sizeof(float))) {
-                                    App_Common::profilesTable_orig = App_Common::profilesTable;
-                                    App_Common::board.previousProfile = App_Common::board.selectedProfile;
-                                    emit Serial_ProgressUpdate(5, "Successfully synced data!");
-                                    port.clear();
-                                    return true;
-                                } else return false;
+                            if(OneShotSend((char)OF_Const::sGetBtns, true)) {
+                                memset(App_Common::inputFuncTable, 0, sizeof(App_Common::inputFuncTable));
+
+                                if(!BatchStoreSettings(App_Common::inputFuncTable[App_Common::dataCurrent],
+                                                       App_Common::OFPresets.boardInputs_Strings,
+                                                       sizeof(App_Common::inputFuncTable[App_Common::dataCurrent]) / BUTTON_COUNT))
+                                    return false;
+
+                                memcpy(App_Common::inputFuncTable[App_Common::dataOrig],
+                                       App_Common::inputFuncTable[App_Common::dataCurrent],
+                                       sizeof(App_Common::inputFuncTable[App_Common::dataCurrent]));
+
+                                emit Serial_ProgressUpdate(5, "Getting Profiles Data");
+
+                                ////* profiles *////
+                                App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
+
+                                port.clear();
+                                if(OneShotSend((char)OF_Const::sGetProfile, true)) {
+                                    if(BatchStoreSettings(nullptr, App_Common::OFPresets.profSettingTypes_Strings, sizeof(float))) {
+                                        App_Common::profilesTable_orig = App_Common::profilesTable;
+                                        App_Common::board.previousProfile = App_Common::board.selectedProfile;
+                                        emit Serial_ProgressUpdate(6, "Successfully synced data!");
+                                        port.clear();
+                                        return true;
+                                    } else return false;
+                                } else {
+                                    printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
+                                    return false;
+                                }
                             } else {
                                 printf("Couldn't send any data in time! Was it disconnected mid-transaction?\n");
                                 return false;
@@ -269,7 +289,6 @@ bool AppSerial::BatchStoreSettings(void *dataPtr, const std::unordered_map<std::
                 if(port.bytesAvailable() < sizeRead) if(!port.waitForReadyRead(500)) return false;
                 buf += port.read(sizeRead);
             }
-
             // Report back received buffer to board for verification
             // (board will re-send output if buffers aren't matching)
             OneShotSend(buf.constData(), buf.length());
@@ -324,7 +343,7 @@ bool AppSerial::OneShotSend(const char &chara, const bool &waitForResponse)
 bool AppSerial::CommitSettings()
 {
     if(port.isOpen()) {
-        emit Serial_SetProgressRange(7);
+        emit Serial_SetProgressRange(8);
 
         char message[2] = { (char)OF_Const::sCommitStart, true };
         if(OneShotSend(message, sizeof(message), true)) {
@@ -362,7 +381,13 @@ bool AppSerial::CommitSettings()
                                   sizeof(App_Common::settingsTable[App_Common::dataCurrent]) / OF_Const::settingsTypesCount))
                 return false;
 
-            emit Serial_ProgressUpdate(4, "Sending Profile Data...");
+            emit Serial_ProgressUpdate(4, "Sending Buttons...");
+            if(!BatchSendSettings(App_Common::inputFuncTable[App_Common::dataCurrent],
+                                  App_Common::OFPresets.boardInputs_Strings,
+                                  sizeof(App_Common::inputFuncTable[App_Common::dataCurrent]) / BUTTON_COUNT))
+                return false;
+
+            emit Serial_ProgressUpdate(5, "Sending Profile Data...");
             for(size_t i = 0; i < App_Common::profilesTable.count(); ++i) {
                 if(!BatchSendSettings(&App_Common::profilesTable[i],
                                       App_Common::OFPresets.profSettingTypes_Strings,
@@ -371,7 +396,7 @@ bool AppSerial::CommitSettings()
                     return false;
             }
 
-            emit Serial_ProgressUpdate(5, "Sending TinyUSB ID Data...");
+            emit Serial_ProgressUpdate(6, "Sending TinyUSB ID Data...");
             TXbuf[0] = (char)OF_Const::sCommitID;
             memcpy(&TXbuf[1], (uint8_t*)&App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s));
             for(size_t sendAttempt = 1;; ++sendAttempt) {
@@ -383,10 +408,10 @@ bool AppSerial::CommitSettings()
                 } else return false;
             }
 
-            emit Serial_ProgressUpdate(6, "Saving...");
+            emit Serial_ProgressUpdate(7, "Saving...");
             if(OneShotSend((char)OF_Const::sSave, true)) {
                 if(char newBuf[2] = {(char)OF_Const::sSave, (char)true}; memcmp(port.read(2).constData(), newBuf, sizeof(newBuf)) == 0) {
-                    emit Serial_ProgressUpdate(7);
+                    emit Serial_ProgressUpdate(8);
                     port.clear();
                     return true;
                 } else return false;
@@ -399,51 +424,58 @@ bool AppSerial::BatchSendSettings(void *dataPtr, const std::unordered_map<std::s
 {
     size_t txLen = 0;
     bool profCurrentMarked = false;
-    if(&dataMap == &App_Common::OFPresets.boolTypes_Strings)
+
+    if(dataPtr == &App_Common::boolSettings[App_Common::dataCurrent])
         TXbuf[txLen++] = OF_Const::sCommitToggles;
+    else if(dataPtr == &App_Common::inputFuncTable[App_Common::dataCurrent])
+        TXbuf[txLen++] = OF_Const::sCommitBtns;
     else if(&dataMap == &App_Common::OFPresets.boardInputs_Strings)
         TXbuf[txLen++] = OF_Const::sCommitPins;
-    else if(&dataMap == &App_Common::OFPresets.settingsTypes_Strings)
+    else if(dataPtr == &App_Common::settingsTable[App_Common::dataCurrent])
         TXbuf[txLen++] = OF_Const::sCommitSettings;
     else if(&dataMap == &App_Common::OFPresets.profSettingTypes_Strings)
         TXbuf[txLen++] = OF_Const::sCommitProfile;
+
     for(auto &pair : dataMap) {
-        txLen = 1;
-        strcpy(&TXbuf[txLen], pair.first.c_str());
-        // std::string length doesn't account for terminator
-        txLen += pair.first.length()+1;
+        if(pair.second >= 0) {
+            txLen = 1;
+            strcpy(&TXbuf[txLen], pair.first.c_str());
+            // std::string length doesn't account for terminator
+            txLen += pair.first.length()+1;
 
-        if(dataMap == App_Common::OFPresets.profSettingTypes_Strings) {
-            if(pair.second < OF_Const::profIrSens) continue;
-            else if(pair.second == OF_Const::profCurrent) {
-                if(profCurrentMarked) continue;
-                TXbuf[txLen++] = sizeof(uint8_t);
-                TXbuf[txLen++] = App_Common::board.selectedProfile;
-                profCurrentMarked = true;
+            if(dataMap == App_Common::OFPresets.profSettingTypes_Strings) {
+                if(pair.second < OF_Const::profIrSens) continue;
+                else if(pair.second == OF_Const::profCurrent) {
+                    if(profCurrentMarked) continue;
+                    TXbuf[txLen++] = sizeof(uint8_t);
+                    TXbuf[txLen++] = App_Common::board.selectedProfile;
+                    profCurrentMarked = true;
+                } else {
+                    if(pair.second == OF_Const::profName)
+                        TXbuf[txLen++] = sizeof(App_Common::profilesTable_s::profName);
+                    else TXbuf[txLen++] = dataSize;
+
+                    TXbuf[txLen++] = profNum;
+
+                    memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), TXbuf[txLen-2]);
+                    txLen += TXbuf[txLen-2];
+                }
             } else {
-                if(pair.second == OF_Const::profName)
-                     TXbuf[txLen++] = sizeof(App_Common::profilesTable_s::profName);
-                else TXbuf[txLen++] = dataSize;
-
-                TXbuf[txLen++] = profNum;
-
-                memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), TXbuf[txLen-2]);
-                txLen += TXbuf[txLen-2];
+                if(dataPtr == App_Common::inputFuncTable[App_Common::dataCurrent] && pair.second >= BUTTON_COUNT-1) continue;
+                TXbuf[txLen++] = dataSize;
+                memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), dataSize);
+                txLen += dataSize;
             }
-        } else {
-            TXbuf[txLen++] = dataSize;
-            memcpy(&TXbuf[txLen], (uint8_t*)dataPtr + (dataSize * pair.second), dataSize);
-            txLen += dataSize;
-        }
 
-        // try to resend data if not matching, fail after three tries
-        for(size_t sendAttempt = 1;; ++sendAttempt) {
-            if(OneShotSend(TXbuf, txLen, true)) {
-                port.read(RXbuf, port.bytesAvailable());
-                if(memcmp(&TXbuf[1], RXbuf, txLen-1)) {
-                    if(sendAttempt >= 3) return false;
-                } else break;
-            } else return false;
+            // try to resend data if not matching, fail after three tries
+            for(size_t sendAttempt = 1;; ++sendAttempt) {
+                if(OneShotSend(TXbuf, txLen, true)) {
+                    port.read(RXbuf, port.bytesAvailable());
+                    if(memcmp(&TXbuf[1], RXbuf, txLen-1)) {
+                        if(sendAttempt >= 3) return false;
+                    } else break;
+                } else return false;
+            }
         }
     }
     return true;


### PR DESCRIPTION
Buttons are (finally!) now able to be mapped on boards running the firmware that goes with this PR (TeamOpenFIRE/OpenFIRE-Firmware#100).

Icons are helpfully added around the UI for some added at-a-glance clarity, which seems to only be really visible on Qt6 builds. :<

Main window code has been reorganized for consistency with how it's structured in the UI, for (hopefully) less aimless scrolling.

Also apparently `qAsConst` was deprecated in Qt6, so fix that too as `std::as_const` works in both.