### PR TITLE
Slight Icons fixes

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -244,7 +244,7 @@ guiWindow::guiWindow(QWidget *parent)
     statusProgressBar->setVisible(false);
     ui->statusBar->addPermanentWidget(statusProgressBar);
 
-#if QT_VERSION_MAJOR < 6 || QT_VERSION_MINOR < 6
+#if QT_VERSION_MAJOR < 6 || (QT_VERSION_MAJOR == 6 && QT_VERSION_MINOR < 6)
     // Fixup tab icons for older Qt builds to use XDG names
     ui->tabWidget->setTabIcon(0, QIcon::fromTheme("document-properties"));
     ui->tabWidget->setTabIcon(1, QIcon::fromTheme("input-keyboard"));

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -414,7 +414,11 @@ void guiWindow::DiffUpdate()
     if(settingsDiff) {
         ui->confirmButton->setText("Save and Send Settings");
         ui->confirmButton->setEnabled(true);
-        ui->confirmButton->setIcon(QIcon::fromTheme("DocumentSave"));
+#if QT_VERSION_MAJOR > 5 && QT_VERSION_MINOR > 6
+        ui->confirmButton->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::DocumentSave));
+#else
+        ui->confirmButton->setIcon(QIcon::fromTheme("document-save"));
+#endif
     } else {
         ui->confirmButton->setText("[Nothing To Save]");
         ui->confirmButton->setEnabled(false);

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -244,6 +244,17 @@ guiWindow::guiWindow(QWidget *parent)
     statusProgressBar->setVisible(false);
     ui->statusBar->addPermanentWidget(statusProgressBar);
 
+#if QT_VERSION_MAJOR < 6 || QT_VERSION_MINOR < 6
+    // Fixup tab icons for older Qt builds to use XDG names
+    ui->tabWidget->setTabIcon(0, QIcon::fromTheme("document-properties"));
+    ui->tabWidget->setTabIcon(1, QIcon::fromTheme("input-keyboard"));
+    ui->tabWidget->setTabIcon(2, QIcon::fromTheme("drive-harddisk"));
+    ui->tabWidget->setTabIcon(3, QIcon::fromTheme("computer"));
+    ui->tabWidget->setTabIcon(4, QIcon::fromTheme("input-tablet"));
+    ui->customLayoutToolBtn->setIcon(QIcon::fromTheme("edit-copy"));
+    ui->actionExport_Custom_Layout->setIcon(QIcon::fromTheme("document-open"));
+    ui->actionImport_Custom_Layout->setIcon(QIcon::fromTheme("document-save-as"));
+#endif
     // Disable ONLY the tab widget (doing this from the form also disables children, including the scroll area)
     ui->tabWidget->setEnabled(false);
 

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -296,7 +296,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>424</height>
+             <height>423</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -542,7 +542,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-20</y>
+             <y>0</y>
              <width>924</width>
              <height>1192</height>
             </rect>
@@ -1798,7 +1798,7 @@
              <x>0</x>
              <y>0</y>
              <width>938</width>
-             <height>424</height>
+             <height>423</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_16">


### PR DESCRIPTION
Iconification only really seems to work for Qt 6.7+ because Designer uses the enums introduced with that version, rather than the matching XDG standard name strings that earlier versions relied on. This just provides those in-place on versions that don't support it.