### PR TITLE
Initial (placeholder) ESP32 fork and future RP235X support, implem pin capabilities map for determining pin functions

### DIFF
--- a/src/appcommon.h
+++ b/src/appcommon.h
@@ -62,8 +62,9 @@ public:
     typedef struct boardInfo_t {
         int        selectedProfile;
         int        previousProfile;
-        QByteArray boardType;
-        QByteArray versionNumber;
+        QByteArray type;
+        QByteArray arch;
+        QByteArray version;
     } boardInfo_s;
 
     typedef struct tinyUSBtable_t {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -776,13 +776,10 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             if(pinBoxes.count()) {
                 for(uint8_t i = 0; i < pinBoxes.count(); ++i)
                     delete pinBoxes.at(i);
-                for(uint8_t i = 0; i < padding.count(); ++i)
-                    delete padding.at(i);
                 for(uint8_t i = 0; i < pinLabel.count(); ++i)
                     delete pinLabel.at(i);
 
                 pinBoxes.clear();
-                padding.clear();
                 pinLabel.clear();
             }
 
@@ -796,35 +793,80 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 // install items
                 for(auto item : App_Common::OFPresets.boardInputs_sortedStr)
                     pinBoxes.at(i)->addItem(item);
-                // clear out analog options for digital pins (< GPIO26)
-                // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
-                if(i < 26) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
-                }
-                // filter out SCL/SDA if possible.
-                if(i & 1) {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+
+                // check if this board has pin capability overrides
+                if(App_Common::OFPresets.mcuCapableMaps.count(App_Common::board.type.constData())) {
+                    // clear out analog options for digital pins
+                    // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
+                    if(!(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinHasADC)) {
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
+                    }
+
+                    // filter out SCL/SDA if possible.
+                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinCanI2C) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2CSCL) {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                        } else {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                        }
+
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2C1)
+                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                    } else {
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                    }
                 } else {
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                    // clear out analog options for digital pins
+                    // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
+                    if(!(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinHasADC)) {
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogX+1, false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::analogY+1, false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::tempPin+1, false);
+                    }
+
+                    // filter out SCL/SDA if possible.
+                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinCanI2C) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2CSCL) {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                        } else {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                        }
+
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2C1)
+                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                    } else {
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                    }
                 }
+
+                if(App_Common::board.arch != App_Common::OFPresets.boardArchs[OF_Const::boardRP])
+                    SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::wiiClockGen+1, false);
+
                 // connect up combobox signal
                 connect(pinBoxes.at(i), SIGNAL(currentIndexChanged(int)), this, SLOT(pinBoxes_currentIndexChanged(int)));
 
-                padding << new QWidget();
-                padding.at(i)->setMinimumHeight(25);
-
-                // I2C channel coloring
-                if(i & 0b0000010)
-                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
-
                 pinLabel.at(i)->setEnabled(false);
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1.\n\n"
+                                                   "Blue pin numbers are members of I2C0.\n"
+                                                   "Orange are members of I2C1.\n"
+                                                   "Gray cannot use I2C devices.").arg(i));
             }
 
             if(App_Common::board.version.indexOf('-') > -1)
@@ -917,20 +959,13 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             boardPic.load(origBoardPicFile);
             boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
 
-            int prevPadCount = 0;
-            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); ++i) {
-                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                    prevPadCount = padCount;
-                }
-            }
-            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); ++i) {
-                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                }
-            }
+            for(int i = 1; i < ui->PinsLeft->rowCount(); ++i)
+                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr)
+                    ui->PinsLeft->setRowMinimumHeight(i, 25);
+
+            for(int i = 1; i < ui->PinsRight->rowCount(); ++i)
+                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr)
+                    ui->PinsRight->setRowMinimumHeight(i, 25);
 
             ui->tabWidget->setEnabled(true);
             ui->customPinsEnabled->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::customPins]);
@@ -1074,62 +1109,72 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
             pinBoxes.at(App_Common::inputsMap.value(btnRequest))->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if function is I2C, check for other things
-        if(btnRequest == OF_Const::camSDA) {
-            // if it's mapped, check that cam clock pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
+        // I2C Data Members
+        if(btnRequest == OF_Const::camSDA || btnRequest == OF_Const::periphSDA) {
+            // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
+            if(App_Common::inputsMap.value(btnRequest+1) > OF_Const::btnUnmapped &&
+               (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest+1)) & OF_Const::pinIsI2C1)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pin mappings.", 10000);
-            // check that peripheral data isn't mapped to this I2C channel
-            } else if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
-                // channels matched, unmap peripheral data
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral Data.", 10000);
+                if(btnRequest == OF_Const::camSDA) {
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                } else {
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                }
             }
-        } else if(btnRequest == OF_Const::camSCL) {
-            // if it's mapped, check that cam clock pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
+            // check that opposite I2C type SDA isn't mapped to this I2C channel
+            switch(btnRequest) {
+            case OF_Const::camSDA:
+                if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSDA)) & OF_Const::pinIsI2C1)) {
+                    // channels matched, unmap peripheral data
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SDA.", 10000);
+                }
+                break;
+            case OF_Const::periphSDA:
+                if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSDA)) & OF_Const::pinIsI2C1)) {
+                    // channels matched, unmap peripheral data
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SDA.", 10000);
+                }
+                break;
+            }
+        } else if(btnRequest == OF_Const::camSCL || btnRequest == OF_Const::periphSCL) {
+            // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
+            if(App_Common::inputsMap.value(btnRequest-1) > OF_Const::btnUnmapped &&
+               (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest-1)) & OF_Const::pinIsI2C1)) {
                 // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pin mappings.", 10000);
-            // check that peripheral clock isn't mapped to this I2C channel
-            } else if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
-                // channels matched, unmap peripheral clock
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera and Peripheral Clock pins clashed! Please remap Peripheral Clock.", 10000);
+                if(btnRequest == OF_Const::camSCL) {
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                } else {
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                }
             }
-        } else if(btnRequest == OF_Const::periphSDA) {
-            // if it's mapped, check that current peripheral clock pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::periphSCL) & 0b00000010)) {
-                // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pin mappings.", 10000);
-            // check that cam data isn't mapped to this I2C channel
-            } else if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::camSDA) & 0b00000010)) {
-                // channels matched, unmap cam data
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera Data.", 10000);
+            // check that opposite I2C type SCL isn't mapped to this I2C channel
+            switch(btnRequest) {
+            case OF_Const::camSCL:
+                if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSCL)) & OF_Const::pinIsI2C1)) {
+                    // channels matched, unmap peripheral data
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SCL.", 10000);
+                }
+                break;
+            case OF_Const::periphSCL:
+                if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSCL)) & OF_Const::pinIsI2C1)) {
+                    // channels matched, unmap peripheral data
+                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SCL.", 10000);
+                }
+                break;
             }
-        } else if(btnRequest == OF_Const::periphSCL) {
-            // if it's mapped, check that current peripheral data pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
-               (sender()->property("slot").toInt() & 0b00000010) != (App_Common::inputsMap.value(OF_Const::periphSDA) & 0b00000010)) {
-                // channels mismatched, unmap the other pin
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pin mappings.", 10000);
-            // check that cam clock isn't mapped to this I2C channel
-            } else if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
-                      (sender()->property("slot").toInt() & 0b00000010) == (App_Common::inputsMap.value(OF_Const::camSCL) & 0b00000010)) {
-                // channels matched, unmap cam clock
-                pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera Clock.", 10000);
-            }
+        // if we ever get SPI accessories, we'll need to add them here too.
         }
 
         // Then map the thing, and sync this change to the property value

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -359,10 +359,10 @@ void guiWindow::BoxesUpdate()
             App_Common::inputsMap = App_Common::inputsMap_orig;
 
             // copy presets to inputs map
-            if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
+            if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.type.toStdString()))
                 for(size_t i = 0; i < pinBoxes.count(); ++i)
-                    if(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i) > OF_Const::btnUnmapped)
-                        App_Common::inputsMap[App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)] = i;
+                    if(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).at(i) > OF_Const::btnUnmapped)
+                        App_Common::inputsMap[App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).at(i)] = i;
         }
 
         return;
@@ -374,9 +374,9 @@ void guiWindow::BoxesUpdate()
             box->setEnabled(false), box->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if available, copy preset layout to pinboxes
-        if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.boardType.toStdString()))
+        if(App_Common::OFPresets.boardsPresetsMap.count(App_Common::board.type.toStdString()))
             for(size_t i = 0; i < pinBoxes.count(); ++i)
-                pinBoxes.at(i)->setCurrentIndex(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).at(i)+1);
+                pinBoxes.at(i)->setCurrentIndex(App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).at(i)+1);
 
         return;
     }
@@ -463,8 +463,8 @@ QString guiWindow::PrettifyName(QString name)
         name = "Unnamed Device";
 
     // append name of board to gun name string.
-    if(App_Common::OFPresets.boardNames.count(App_Common::board.boardType.toStdString()))
-         return name + " | " + App_Common::OFPresets.boardNames.at(App_Common::board.boardType.toStdString());
+    if(App_Common::OFPresets.boardNames.count(App_Common::board.type.toStdString()))
+         return name + " | " + App_Common::OFPresets.boardNames.at(App_Common::board.type.toStdString());
     else return name + " | " + App_Common::OFPresets.boardNames.at("generic");
 }
 
@@ -786,7 +786,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinLabel.clear();
             }
 
-            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.boardType.toStdString()).size(); ++i) {
+            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).size(); ++i) {
                 pinBoxes << new QComboBox();
                 pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinBoxes.at(i)->setProperty("slot", i);
@@ -827,19 +827,19 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
             }
 
-            if(App_Common::board.versionNumber.indexOf('-') > -1)
+            if(App_Common::board.version.indexOf('-') > -1)
                 ui->versionLabel->setText(QString("FW v<tt>%1<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/commit/%2'><span style=' text-decoration: underline; color:#8ab4f8;'>%2</span></a></tt>")
-                                                 .arg(App_Common::board.versionNumber.left(App_Common::board.versionNumber.indexOf('-')+1), App_Common::board.versionNumber.mid(App_Common::board.versionNumber.indexOf('-')+1)));
-            else ui->versionLabel->setText("FW v<tt>" + App_Common::board.versionNumber + "</tt>");
+                                                 .arg(App_Common::board.version.left(App_Common::board.version.indexOf('-')+1), App_Common::board.version.mid(App_Common::board.version.indexOf('-')+1)));
+            else ui->versionLabel->setText("FW v<tt>" + App_Common::board.version + "</tt>");
 
             // update presets box if this board has any
             ui->presetsBox->clear();
 
-            if(App_Common::OFPresets.boardsAltPresets.count(App_Common::board.boardType.toStdString())) {
+            if(App_Common::OFPresets.boardsAltPresets.count(App_Common::board.type.toStdString())) {
                 ui->presetsBox->setHidden(false);
                 ui->presetsBox->setEnabled(true);
 
-                auto iter = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.boardType.toStdString());
+                auto iter = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.type.toStdString());
                 for(auto i = iter.first; i != iter.second; ++i)
                     ui->presetsBox->addItem(i->second.name);
             } else {
@@ -853,33 +853,33 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             LabelsUpdate();
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
-            if(App_Common::OFPresets.boardsBoxPositions.count(App_Common::board.boardType.toStdString())) {
-                QFile resource(":/boardPics/" + App_Common::board.boardType);
+            if(App_Common::OFPresets.boardsBoxPositions.count(App_Common::board.type.toStdString())) {
+                QFile resource(":/boardPics/" + App_Common::board.type);
                 resource.open(QIODevice::ReadOnly);
                 origBoardPicFile = resource.readAll();
 
                 for(int i = 0; i < pinBoxes.count(); ++i) {
-                    if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posLeft) {
+                    if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) & OF_Const::posLeft) {
                         ui->PinsLeft->addWidget(pinBoxes.at(i),
-                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posLeft,
                                                 0);
                         ui->PinsLeft->addWidget(pinLabel.at(i),
-                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posLeft,
+                                                App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posLeft,
                                                 1);
-                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posRight) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) & OF_Const::posRight) {
                         ui->PinsRight->addWidget(pinBoxes.at(i),
-                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posRight,
                                                  1);
                         ui->PinsRight->addWidget(pinLabel.at(i),
-                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posRight,
+                                                 App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posRight,
                                                  0);
-                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) & OF_Const::posMiddle) {
+                    } else if(App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) & OF_Const::posMiddle) {
                         ui->PinsCenterSub->addWidget(pinBoxes.at(i),
                                                      1,
-                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posMiddle);
                         ui->PinsCenterSub->addWidget(pinLabel.at(i),
                                                      0,
-                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.boardType.toStdString()).at(i) ^ OF_Const::posMiddle);
+                                                     App_Common::OFPresets.boardsBoxPositions.at(App_Common::board.type.toStdString()).at(i) ^ OF_Const::posMiddle);
                     }
                 }
             } else {
@@ -1276,7 +1276,7 @@ void guiWindow::on_presetsBox_currentIndexChanged(int index)
             pinBoxes.at(i)->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // set pinboxes to alt preset values (and let the index changed signal handle the rest)
-        auto preset = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.boardType.toStdString()).first;
+        auto preset = App_Common::OFPresets.boardsAltPresets.equal_range(App_Common::board.type.toStdString()).first;
         for(int i = 0; i < index; ++i)
             preset++;
 
@@ -2290,7 +2290,7 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
     if(!path.isEmpty()) {
         QFile fileIn(path);
         if(fileIn.open(QFile::ReadOnly)) {
-            if(fileIn.readLine().trimmed() == App_Common::board.boardType) {
+            if(fileIn.readLine().trimmed() == App_Common::board.type) {
                 if(!ui->customPinsEnabled->isChecked()) ui->customPinsEnabled->setChecked(true);
                 // clear current mapping
                 for(const auto &box : std::as_const(pinBoxes))
@@ -2331,7 +2331,7 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
     if(!path.isEmpty()) {
         QFile fileOut(path);
         if(fileOut.open(QFile::WriteOnly)) {
-            fileOut.write(App_Common::board.boardType + '\n');
+            fileOut.write(App_Common::board.type + '\n');
 
             for(auto &pair : App_Common::OFPresets.boardInputs_Strings) {
                 if(pair.second > OF_Const::btnUnmapped && App_Common::inputsMap.value(pair.second) > OF_Const::btnUnmapped) {

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -25,7 +25,9 @@
 
 #include "appcommon.h"
 #include "appcali.h"
+#ifdef OFAPP_DEBUG
 #include "appdebug.h"
+#endif
 #include "appserial.h"
 #include "apppreviewer.h"
 

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -293,7 +293,6 @@ private:
     /// @details    Pinboxes stores the state of each pin to one function
     QVector<QComboBox*> pinBoxes;
     QVector<QLabel*> pinLabel;
-    QVector<QWidget*> padding;
 
     /// @brief      Test "Buttons" in the test screen representing each button
     QVector<QLabel*> testLabel;

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -31,6 +31,8 @@ AppBoardsPreviewer::AppBoardsPreviewer(QWidget *parent)
 {
     ui->setupUi(this);
 
+    ui->line->setVisible(false);
+
     //boldFont.setBold(true);
     boldFont.setPointSize(12);
 
@@ -39,7 +41,8 @@ AppBoardsPreviewer::AppBoardsPreviewer(QWidget *parent)
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     for(auto &item : App_Common::OFPresets.boardNames)
-        if(strcmp(item.first.data(), "generic"))
+        // until ESP32 has a working pin capabilities descriptor, just don't show them for now.
+        if(strcmp(item.first.data(), "generic") && item.first.find("esp32") == std::string::npos)
             ui->boardSelector->addItem(item.second);
 }
 
@@ -74,38 +77,63 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
 {
     for(auto &board : App_Common::OFPresets.boardNames) {
         if(!strcmp(board.second, arg1.toLocal8Bit().constData())) {
+            if(board.first.find("esp32") != std::string::npos) {
+                ui->subTextLabel->setText("<p>Compatible with the "
+                                          "<a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32'><span style=' text-decoration: underline; color:#8ab4f8;'>ESP-IDF fork of the OpenFIRE Firmware</span></a> by <i>Alessandro Satanassi.</i><br>"
+                                          "Any issues should be reported <b><a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues'><span style=' text-decoration: underline; color:#8ab4f8;'>here!</span></a></b></p>");
+                boardType = OF_Const::boardESP32;
+            } else {
+                ui->subTextLabel->setText("<p>Compatible with "
+                                          "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware'><span style=' text-decoration: underline; color:#8ab4f8;'>upstream OpenFIRE Firmware</span></a> by <i>Team OpenFIRE.</i></p>");
+                boardType = OF_Const::boardRP;
+            }
+
+            ui->line->setVisible(true);
+
             // Clears old board layout items
             if(pinDefaultFunc.count()) {
-                for(uint8_t i = 0; i < pinDefaultFunc.count(); i++)
+                for(uint8_t i = 0; i < pinDefaultFunc.count(); ++i)
                     delete pinDefaultFunc.at(i);
-                for(uint8_t i = 0; i < padding.count(); i++)
-                    delete padding.at(i);
-                for(uint8_t i = 0; i < pinLabel.count(); i++)
+                for(uint8_t i = 0; i < pinLabel.count(); ++i)
                     delete pinLabel.at(i);
 
                 pinDefaultFunc.clear();
-                padding.clear();
                 pinLabel.clear();
             }
 
-            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(board.first).size(); i++) {
+            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(board.first).size(); ++i) {
                 pinDefaultFunc << new QLabel();
                 pinDefaultFunc.at(i)->setFont(boldFont);
                 pinDefaultFunc.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinDefaultFunc.at(i)->setProperty("slot", i);
                 pinDefaultFunc.at(i)->installEventFilter(this);
 
-                padding << new QWidget();
-                padding.at(i)->setMinimumHeight(25);
-
-                // I2C channel coloring
-                if(i & 0b0000010)
-                    pinLabel  << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                // check if this board has pin capability overrides
+                if(App_Common::OFPresets.mcuCapableMaps.count(board.first.c_str())) {
+                    // I2C channel coloring
+                    if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinCanI2C) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1)
+                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                    } else {
+                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                    }
+                } else {
+                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinCanI2C) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinIsI2C1)
+                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                    } else {
+                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                    }
+                }
 
                 pinLabel.at(i)->setEnabled(false);
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\nBlue pin numbers are members of I2C0\nOrange are members of I2C1").arg(i));
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\n"
+                                                   "Blue pin numbers are members of I2C0.\n"
+                                                   "Orange are members of I2C1.\n"
+                                                   "Gray cannot use I2C devices.").arg(i));
             }
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h
@@ -113,7 +141,7 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
             resource.open(QIODevice::ReadOnly);
             origBoardPicFile = resource.readAll();
 
-            for(int i = 0; i < pinDefaultFunc.count(); i++) {
+            for(int i = 0; i < pinDefaultFunc.count(); ++i) {
                 if(App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) & OF_Const::posLeft) {
                     ui->PinsLeft->addWidget(pinDefaultFunc.at(i),
                                             App_Common::OFPresets.boardsBoxPositions.at(board.first).at(i) ^ OF_Const::posLeft, 0, Qt::AlignRight);
@@ -139,22 +167,15 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
             boardPic.load(origBoardPicFile);
             boardPic.renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
 
-            int prevPadCount = 0;
-            for(int i = 1, padCount = 0; i < ui->PinsLeft->rowCount(); i++) {
-                ui->PinsLeft->setRowMinimumHeight(i, 28);
-                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsLeft->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                    prevPadCount = padCount;
-                }
-            }
-            for(int i = 1, padCount = prevPadCount; i < ui->PinsRight->rowCount(); i++) {
-                ui->PinsRight->setRowMinimumHeight(i, 28);
-                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr) {
-                    ui->PinsRight->addWidget(padding.at(padCount), i, 0);
-                    padCount++;
-                }
-            }
+            for(int i = 1; i < ui->PinsLeft->rowCount(); ++i)
+                if(ui->PinsLeft->itemAtPosition(i, 0) == nullptr)
+                    ui->PinsLeft->setRowMinimumHeight(i, 25);
+                else ui->PinsLeft->setRowMinimumHeight(i, 28);
+
+            for(int i = 1; i < ui->PinsRight->rowCount(); ++i)
+                if(ui->PinsRight->itemAtPosition(i, 0) == nullptr)
+                    ui->PinsRight->setRowMinimumHeight(i, 25);
+                else ui->PinsRight->setRowMinimumHeight(i, 28);
         }
     }
 }

--- a/src/apppreviewer.h
+++ b/src/apppreviewer.h
@@ -59,7 +59,8 @@ private:
     /// @brief      Objects that makes up the elements of the board view tab
     QVector<QLabel*> pinDefaultFunc;
     QVector<QLabel*> pinLabel;
-    QVector<QWidget*> padding;
+    QVector<QLabel*> pinCapabilityMarks;
+    int boardType;
 };
 
 #endif // APPPREVIEWER_H

--- a/src/apppreviewer.ui
+++ b/src/apppreviewer.ui
@@ -17,13 +17,13 @@
    <iconset resource="../img/vectors.qrc">
     <normaloff>:/icon/icon.png</normaloff>:/icon/icon.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
    <item>
     <layout class="QHBoxLayout" name="selectorLayout">
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -58,6 +58,31 @@
       <layout class="QGridLayout" name="PinsRight"/>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="subTextLabel">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -95,11 +95,15 @@ bool AppSerial::GetSettings(const QString &portName)
                     emit Serial_ProgressUpdate(1, "Getting Board Info");
 
                     ////* Opening board message bits *////
-                    App_Common::board.versionNumber = buffer.takeFirst().constData();
-                    printf("Version number: %s\n", App_Common::board.versionNumber.constData());
+                    App_Common::board.version = buffer.takeFirst().constData();
+                    printf("Version number: %s\n", App_Common::board.version.constData());
 
-                    App_Common::board.boardType = buffer.takeFirst().constData();
-                    printf("Board type: %s\n", App_Common::board.boardType.constData());
+                    App_Common::board.type = buffer.takeFirst().constData();
+                    printf("Board type: %s\n", App_Common::board.type.constData());
+
+                    if(App_Common::board.type.contains("esp32"))
+                         App_Common::board.arch = App_Common::OFPresets.boardArchs[OF_Const::boardESP32];
+                    else App_Common::board.arch = App_Common::OFPresets.boardArchs[OF_Const::boardRP];
 
                     memcpy(&App_Common::tinyUSBtable, buffer.takeFirst().constData(), sizeof(App_Common::tinyUSBtable_s));
                     memcpy(&App_Common::tinyUSBtable_orig, &App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s));


### PR DESCRIPTION
Pin capabilities allows a dev to define what functions a pin can apply, with support for overrides based on the board codename if any are available (rn used for the Pico boards) as its pins map seems to contradict the datasheet.

The main benefit is to futureproof in RP2350-series support, with the bonus that the ESP fork firmware can also be supported (with some added as of TeamOpenFIRE/OpenFIRE-Boards#5). ESP currently doesn't have a working pin capabilities descriptor nor any overrides, so for now the ESP boards are disabled in the previewer and will crash when syncing an ESP fork'd board atm. That part should be the responsibility of the fork maintainer.

At least for RP2040 devices, to the user, current pin mapping bits functionality remains the same as before - so I2C channel clashes and mismatches will still be detected as appropriate. This part could probably be disabled for ESP devices since they seem to be able to remap I2C to whichever pins (again, details are ultimately up to the fork's maintainer).