### PR TITLE
Bump boards with finalized ESP support; handle 'any SPI/I2C' cases

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -774,16 +774,16 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
             // Clears old board layout items
             if(pinBoxes.count()) {
-                for(uint8_t i = 0; i < pinBoxes.count(); ++i)
+                for(int i = 0; i < pinBoxes.count(); ++i)
                     delete pinBoxes.at(i);
-                for(uint8_t i = 0; i < pinLabel.count(); ++i)
+                for(int i = 0; i < pinLabel.count(); ++i)
                     delete pinLabel.at(i);
 
                 pinBoxes.clear();
                 pinLabel.clear();
             }
 
-            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).size(); ++i) {
+            for(int i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(App_Common::board.type.toStdString()).size(); ++i) {
                 pinBoxes << new QComboBox();
                 pinBoxes.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinBoxes.at(i)->setProperty("slot", i);
@@ -805,25 +805,27 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                     }
 
                     // filter out SCL/SDA if possible.
-                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinCanI2C) {
-                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2CSCL) {
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                        } else {
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                        }
+                    if(!(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinAnyI2C)) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinCanI2C) {
+                            if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2CSCL) {
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                            } else {
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                            }
 
-                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2C1)
-                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
-                    } else {
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
-                    }
+                            if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.type.constData()).at(i) & OF_Const::pinIsI2C1)
+                                pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                            else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                        } else {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                            pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                        }
+                    } else pinLabel << new QLabel(QString("<font color=#BE00B0>«GPIO%1»</font>").arg(i));
                 } else {
                     // clear out analog options for digital pins
                     // (entrylist is offset by one, as "Unmapped" == -1 in our enum)
@@ -834,27 +836,30 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                     }
 
                     // filter out SCL/SDA if possible.
-                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinCanI2C) {
-                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2CSCL) {
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                        } else {
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                        }
+                    if(!(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinAnyI2C)) {
+                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinCanI2C) {
+                            if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2CSCL) {
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                            } else {
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                                SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                            }
 
-                        if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2C1)
-                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
-                        else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
-                    } else {
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
-                        SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
-                        pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
-                    }
+                            if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(i) & OF_Const::pinIsI2C1)
+                                pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
+                            else pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
+                        } else {
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSDA+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::camSCL+1,     false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSDA+1,  false);
+                            SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::periphSCL+1,  false);
+                            pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
+                        }
+                    } else pinLabel << new QLabel(QString("<font color=#BE00B0>«GPIO%1»</font>").arg(i));
                 }
 
+                // NOTE: only change/remove this if non-RP boards properly implements on-board clock pulse generation.
                 if(App_Common::board.arch != App_Common::OFPresets.boardArchs[OF_Const::boardRP])
                     SetComboBoxItemEnabled(pinBoxes.at(i), OF_Const::wiiClockGen+1, false);
 
@@ -863,16 +868,24 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
                 pinLabel.at(i)->setEnabled(false);
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1.\n\n"
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin No. %1.\n\n"
                                                    "Blue pin numbers are members of I2C0.\n"
                                                    "Orange are members of I2C1.\n"
+                                                   "Purple pin numbers can automatically select any I2C channel in software.\n"
                                                    "Gray cannot use I2C devices.").arg(i));
             }
 
-            if(App_Common::board.version.indexOf('-') > -1)
-                ui->versionLabel->setText(QString("FW v<tt>%1<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/commit/%2'><span style=' text-decoration: underline; color:#8ab4f8;'>%2</span></a></tt>")
-                                                 .arg(App_Common::board.version.left(App_Common::board.version.indexOf('-')+1), App_Common::board.version.mid(App_Common::board.version.indexOf('-')+1)));
-            else ui->versionLabel->setText("FW v<tt>" + App_Common::board.version + "</tt>");
+            if(App_Common::board.version.indexOf('-') > -1) {
+                QString orgName;
+
+                if(App_Common::board.arch == App_Common::OFPresets.boardArchs[OF_Const::boardRP])
+                    orgName = "TeamOpenFIRE";
+                else if(App_Common::board.arch == App_Common::OFPresets.boardArchs[OF_Const::boardESP32_S3])
+                    orgName = "alessandro-satanassi";
+
+                ui->versionLabel->setText(QString("FW <tt>v%1<a href='https://github.com/%2/OpenFIRE-Firmware/commit/%3'><span style=' text-decoration: underline; color:#8ab4f8;'>%3</span></a></tt>")
+                                                 .arg(App_Common::board.version.left(App_Common::board.version.indexOf('-')+1), orgName, App_Common::board.version.mid(App_Common::board.version.indexOf('-')+1)));
+            } else ui->versionLabel->setText("FW <tt>v" + App_Common::board.version + "</tt>");
 
             // update presets box if this board has any
             ui->presetsBox->clear();
@@ -1124,72 +1137,74 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
             pinBoxes.at(App_Common::inputsMap.value(btnRequest))->setCurrentIndex(OF_Const::btnUnmapped+1);
 
         // if function is I2C, check for other things
-        // I2C Data Members
-        if(btnRequest == OF_Const::camSDA || btnRequest == OF_Const::periphSDA) {
-            // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(btnRequest+1) > OF_Const::btnUnmapped &&
-               (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest+1)) & OF_Const::pinIsI2C1)) {
-                // channels mismatched, unmap the other pin
-                if(btnRequest == OF_Const::camSDA) {
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
-                } else {
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+        if(!(App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.toStdString()).at(sender()->property("slot").toInt()) & OF_Const::pinAnyI2C)) {
+            // I2C Data Members
+            if(btnRequest == OF_Const::camSDA || btnRequest == OF_Const::periphSDA) {
+                // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
+                if(App_Common::inputsMap.value(btnRequest+1) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest+1)) & OF_Const::pinIsI2C1)) {
+                    // channels mismatched, unmap the other pin
+                    if(btnRequest == OF_Const::camSDA) {
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                    } else {
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                    }
                 }
+                // check that opposite I2C type SDA isn't mapped to this I2C channel
+                switch(btnRequest) {
+                case OF_Const::camSDA:
+                    if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
+                        (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSDA)) & OF_Const::pinIsI2C1)) {
+                        // channels matched, unmap peripheral data
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SDA.", 10000);
+                    }
+                    break;
+                case OF_Const::periphSDA:
+                    if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
+                        (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSDA)) & OF_Const::pinIsI2C1)) {
+                        // channels matched, unmap peripheral data
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SDA.", 10000);
+                    }
+                    break;
+                }
+            } else if(btnRequest == OF_Const::camSCL || btnRequest == OF_Const::periphSCL) {
+                // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
+                if(App_Common::inputsMap.value(btnRequest-1) > OF_Const::btnUnmapped &&
+                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest-1)) & OF_Const::pinIsI2C1)) {
+                    // channels mismatched, unmap the other pin
+                    if(btnRequest == OF_Const::camSCL) {
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                    } else {
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                    }
+                }
+                // check that opposite I2C type SCL isn't mapped to this I2C channel
+                switch(btnRequest) {
+                case OF_Const::camSCL:
+                    if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
+                        (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSCL)) & OF_Const::pinIsI2C1)) {
+                        // channels matched, unmap peripheral data
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SCL.", 10000);
+                    }
+                    break;
+                case OF_Const::periphSCL:
+                    if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
+                        (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSCL)) & OF_Const::pinIsI2C1)) {
+                        // channels matched, unmap peripheral data
+                        pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
+                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SCL.", 10000);
+                    }
+                    break;
+                }
+            // if we ever get SPI accessories, we'll need to add them here too.
             }
-            // check that opposite I2C type SDA isn't mapped to this I2C channel
-            switch(btnRequest) {
-            case OF_Const::camSDA:
-                if(App_Common::inputsMap.value(OF_Const::periphSDA) > OF_Const::btnUnmapped &&
-                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSDA)) & OF_Const::pinIsI2C1)) {
-                    // channels matched, unmap peripheral data
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SDA.", 10000);
-                }
-                break;
-            case OF_Const::periphSDA:
-                if(App_Common::inputsMap.value(OF_Const::camSDA) > OF_Const::btnUnmapped &&
-                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSDA)) & OF_Const::pinIsI2C1)) {
-                    // channels matched, unmap peripheral data
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SDA.", 10000);
-                }
-                break;
-            }
-        } else if(btnRequest == OF_Const::camSCL || btnRequest == OF_Const::periphSCL) {
-            // if it's mapped, check that this I2C type's pair pin isn't mapped to the opposite I2C channel
-            if(App_Common::inputsMap.value(btnRequest-1) > OF_Const::btnUnmapped &&
-               (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) != (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(btnRequest-1)) & OF_Const::pinIsI2C1)) {
-                // channels mismatched, unmap the other pin
-                if(btnRequest == OF_Const::camSCL) {
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
-                } else {
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
-                }
-            }
-            // check that opposite I2C type SCL isn't mapped to this I2C channel
-            switch(btnRequest) {
-            case OF_Const::camSCL:
-                if(App_Common::inputsMap.value(OF_Const::periphSCL) > OF_Const::btnUnmapped &&
-                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::periphSCL)) & OF_Const::pinIsI2C1)) {
-                    // channels matched, unmap peripheral data
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SCL.", 10000);
-                }
-                break;
-            case OF_Const::periphSCL:
-                if(App_Common::inputsMap.value(OF_Const::camSCL) > OF_Const::btnUnmapped &&
-                    (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (App_Common::OFPresets.mcuCapableMaps.at(App_Common::board.arch.constData()).at(App_Common::inputsMap.value(OF_Const::camSCL)) & OF_Const::pinIsI2C1)) {
-                    // channels matched, unmap peripheral data
-                    pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                    ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SCL.", 10000);
-                }
-                break;
-            }
-        // if we ever get SPI accessories, we'll need to add them here too.
         }
 
         // Then map the thing, and sync this change to the property value

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -44,8 +44,7 @@ AppBoardsPreviewer::AppBoardsPreviewer(QWidget *parent)
     boardPic.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     for(auto &item : App_Common::OFPresets.boardNames)
-        // until ESP32 has a working pin capabilities descriptor, just don't show them for now.
-        if(strcmp(item.first.data(), "generic") && item.first.find("esp32") == std::string::npos)
+        if(strcmp(item.first.data(), "generic"))
             ui->boardSelector->addItem(item.second);
 }
 
@@ -121,7 +120,8 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                 ui->subTextLabel->setText("<p>Compatible with the "
                                           "<a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32'><span style=' text-decoration: underline; color:#8ab4f8;'>ESP-IDF fork of the OpenFIRE Firmware</span></a> by <i>Alessandro Satanassi.</i><br>"
                                           "Any issues should be reported <b><a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues'><span style=' text-decoration: underline; color:#8ab4f8;'>here!</span></a></b></p>");
-                boardType = OF_Const::boardESP32;
+                // NOTE: if we get any non-S3 boards, will need to determine if S3 or other arch-type ESP board.
+                boardType = OF_Const::boardESP32_S3;
             } else {
                 ui->subTextLabel->setText("<p>Compatible with "
                                           "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware'><span style=' text-decoration: underline; color:#8ab4f8;'>upstream OpenFIRE Firmware</span></a> by <i>Team OpenFIRE.</i></p>");
@@ -130,7 +130,7 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
 
             ui->line->setVisible(true);
 
-            for(uint8_t i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(board.first).size(); ++i) {
+            for(int i = 0; i < App_Common::OFPresets.boardsPresetsMap.at(board.first).size(); ++i) {
                 pinDefaultFunc << new QLabel();
                 pinDefaultFunc.at(i)->setFont(mainFont);
                 pinDefaultFunc.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -151,26 +151,36 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                     else pinCapabilityMarks.at(i)->setText("<font color=#555555><tt>ADC</tt></font>");
 
                     // I2C channel coloring
-                    if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinCanI2C) {
+                    // check if ESP-style any pin kinda setup
+                    if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinAnyI2C) {
+                        pinLabel << new QLabel(QString("<font color=#BE00B0>«GPIO%1»</font>").arg(i));
+                        pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#BE00B0><tt><b>I2C(*)</b></tt></font>");
+                    // check for channels
+                    } else if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinCanI2C) {
                         if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1) {
                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
                             pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() +
                                                               QString(" <font color=#FF8800><tt><b>I2C%1%2</b></tt></font>")
-                                                                                                     .arg((App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1) >> 3)
-                                                                                                     .arg(App_Common::i2cTypeLabels[(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2CSCL) >> 2]));
+                                                              .arg((App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1) >> 3)
+                                                              .arg(App_Common::i2cTypeLabels[(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2CSCL) >> 2]));
                         } else {
                             pinLabel << new QLabel(QString("<font color=#0099FF>«GPIO%1»</font>").arg(i));
                             pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() +
                                                               QString(" <font color=#0099FF><tt><b>I2C%1%2</b></tt></font>")
-                                                                                                     .arg((App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1) >> 3)
-                                                                                                     .arg(App_Common::i2cTypeLabels[(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2CSCL) >> 2]));
+                                                              .arg((App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2C1) >> 3)
+                                                              .arg(App_Common::i2cTypeLabels[(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsI2CSCL) >> 2]));
                         }
+                    // no I2C capability
                     } else {
                         pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
                         pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#555555><tt>I2C</tt></font>");
                     }
+
                     // SPI
-                    if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinCanSPI)
+                    // check if ESP-style any pin kinda setup
+                    if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinAnySPI)
+                        pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#D1003D><tt>SPI(*)</tt></font>");
+                    else if(App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinCanSPI)
                         pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() +
                                                           QString(" <font color=#009C3A><tt><b>SPI%1%2</b></tt></font>")
                                                                                                  .arg((App_Common::OFPresets.mcuCapableMaps.at(board.first.c_str()).at(i) & OF_Const::pinIsSPI1) >> 4)
@@ -184,7 +194,12 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                     else pinCapabilityMarks.at(i)->setText("<font color=#555555><tt>ADC</tt></font>");
 
                     // I2C channel coloring
-                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinCanI2C) {
+                    // check if ESP-style any pin kinda setup
+                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinAnyI2C) {
+                        pinLabel << new QLabel(QString("<font color=#BE00B0>«GPIO%1»</font>").arg(i));
+                        pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#BE00B0><tt><b>I2C(*)</b></tt></font>");
+                    // check for channels
+                    } else if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinCanI2C) {
                         if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinIsI2C1) {
                             pinLabel << new QLabel(QString("<font color=#FF8800>«GPIO%1»</font>").arg(i));
                             pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() +
@@ -198,12 +213,17 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                                                                                                      .arg((App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinIsI2C1) >> 3)
                                                                                                      .arg(App_Common::i2cTypeLabels[(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinIsI2CSCL) >> 2]));
                         }
+                    // no I2C capability
                     } else {
                         pinLabel << new QLabel(QString("«GPIO%1»").arg(i));
                         pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#555555><tt>I2C</tt></font>");
                     }
+
                     // SPI
-                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinCanSPI)
+                    // check if ESP-style any pin kinda setup
+                    if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinAnySPI)
+                        pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() + " <font color=#D1003D><tt>SPI(*)</tt></font>");
+                    else if(App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinCanSPI)
                         pinCapabilityMarks.at(i)->setText(pinCapabilityMarks.at(i)->text() +
                                                           QString(" <font color=#009C3A><tt><b>SPI%1%2</b></tt></font>")
                                                                                                  .arg((App_Common::OFPresets.mcuCapableMaps.at(App_Common::OFPresets.boardArchs[boardType]).at(i) & OF_Const::pinIsSPI1) >> 4)
@@ -215,14 +235,16 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinLabel.at(i)->setProperty("slot", i);
                 pinLabel.at(i)->installEventFilter(this);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin number %1\n\n"
+                pinLabel.at(i)->setToolTip(QString("GPIO Pin No. %1.\n\n"
                                                    "Blue pin numbers are members of I2C0.\n"
                                                    "Orange are members of I2C1.\n"
+                                                   "Purple pin numbers can automatically select any I2C channel in software.\n"
                                                    "Gray cannot use I2C devices.").arg(i));
 
                 pinCapabilityMarks.at(i)->setToolTip("ADC indicates whether this pin can read Analog Inputs.\n"
                                                      "I2C indicates if this pin can interact with I2C devices, and what channel and type it uses.\n"
-                                                     "SPI indicates if this pin can interact with SPI devices, and what channel and type it uses.");
+                                                     "SPI indicates if this pin can interact with SPI devices, and what channel and type it uses.\n"
+                                                     "(*) means pin can use any type via automated software selectable channels/type.");
             }
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -101,8 +101,8 @@ bool AppSerial::GetSettings(const QString &portName)
                     App_Common::board.type = buffer.takeFirst().constData();
                     printf("Board type: %s\n", App_Common::board.type.constData());
 
-                    if(App_Common::board.type.contains("esp32"))
-                         App_Common::board.arch = App_Common::OFPresets.boardArchs[OF_Const::boardESP32];
+                    if(App_Common::board.type.contains("esp32-s3"))
+                         App_Common::board.arch = App_Common::OFPresets.boardArchs[OF_Const::boardESP32_S3];
                     else App_Common::board.arch = App_Common::OFPresets.boardArchs[OF_Const::boardRP];
 
                     memcpy(&App_Common::tinyUSBtable, buffer.takeFirst().constData(), sizeof(App_Common::tinyUSBtable_s));
@@ -517,8 +517,16 @@ void AppSerial::RequestToReboot()
 
 void AppSerial::RebootToBootldr()
 {
-    // The py script had this backwards. huh.
-    port.setBaudRate(QSerialPort::Baud1200);
-    port.setDataTerminalReady(false);
+    // RP boards with Earle's core can use the 1200 Baud magic number reset
+    if(App_Common::board.type == App_Common::OFPresets.boardArchs[OF_Const::boardRP]) {
+        // The py script had this backwards. huh.
+        port.setBaudRate(QSerialPort::Baud1200);
+        port.setDataTerminalReady(false);
+    // other boards will just need to be told to reboot with an unambiguous message.
+    // client should verify this is intentional by peeking for the second character.
+    } else {
+        char buf[] = { (char)OF_Const::sRebootToBootloader, (char)OF_Const::sRebootToBootloader };
+        OneShotSend(buf, 2);
+    }
     port.close();
 }


### PR DESCRIPTION
This enables previewing and configuring ESP boards without specialized filtering or crashes.

Since ESPs have software selectable I2C/SPI function and channel, exclude boards with this "any SPI/I2C" capability from checking for channel/slot compatibility.