### PR TITLE
Upend CI/CD one more time, add Windows MinGW and MSVC artifacts

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -75,11 +75,11 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
-        cmake -B ${{ github.workspace }}/build
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
+        cmake -B "${{ github.workspace }}/build"
+        -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}"
+        -DOFAPP_GITHASH="${{steps.get-short-sha.outputs.id}}"
         -DCMAKE_INSTALL_PREFIX=/usr
-        -S ${{ github.workspace }}
+        -S "${{ github.workspace }}"
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,4 +1,4 @@
-name: CMake - Windows & Linux
+name: CMake - Linux AppImages
 
 on:
   push:
@@ -13,58 +13,29 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
         qt_version: [5.15.2, 6.7.3, 6.8.3]
         build_type: [Debug, Release]
         include:
-          - os: windows-latest
-            file: build/out
-            qt_host: windows
-            qt_arch: win64_mingw
-            qt_version: 6.8.3
-            qt6_modules: "qtserialport"
-            qt_tools: tools_mingw1310
-            install_prefix: '-G "MinGW Makefiles"'
-            pretty: "Windows Artifact (MinGW)"
-          - os: windows-latest
-            file: build/out
-            qt_host: windows
-            qt_arch: win64_msvc2022_64
-            qt_version: 6.8.3
-            qt6_modules: "qtserialport"
-            pretty: "Windows Artifact (MSVC)"
           - os: ubuntu-22.04
-            file: OpenFIRE_App-x86_64.AppImage
             qt_host: linux
             qt_arch: gcc_64
             qt_version: 5.15.2
-            qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: x86_64
-            install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux x86 AppImage"
           - os: ubuntu-22.04
-            file: OpenFIRE_App-x86_64.AppImage
             qt_host: linux
             qt_arch: linux_gcc_64
             qt_version: 6.8.3
-            qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: x86_64
-            install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux x86 AppImage"
           - os: ubuntu-22.04-arm
-            file: OpenFIRE_App-aarch64.AppImage
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
             qt_version: 6.7.3
-            qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: aarch64
-            install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux ARM AppImage"
         exclude:
-          - os: windows-latest
-            qt_version: 5.15.2
-          - os: windows-latest
-            qt_version: 6.7.3
           - os: ubuntu-22.04
             qt_version: 6.7.3
           - os: ubuntu-22.04-arm
@@ -96,8 +67,7 @@ jobs:
         version: '${{ matrix.qt_version }}'
         host: '${{ matrix.qt_host }}'
         arch: '${{ matrix.qt_arch }}'
-        modules: '${{ matrix.qt6_modules }}'
-        tools: '${{ matrix.qt_tools }}'
+        modules: 'qtserialport qtwaylandcompositor'
         archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
         cache: true
 
@@ -108,28 +78,19 @@ jobs:
         cmake -B ${{ github.workspace }}/build
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
-        ${{ matrix.install_prefix }}
+        -DCMAKE_INSTALL_PREFIX=/usr
         -S ${{ github.workspace }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel
 
-    - name: Cleanup Windows
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }} --strip
-        windeployqt ${{ github.workspace }}/${{ matrix.file }}/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
-        mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
-
     - name: Install linuxdeploy
-      if: ${{ matrix.os != 'windows-latest' }}
       uses: pcolby/install-linuxdeploy@v1
       with:
         plugins: qt appimage
 
     - name: Setup AppImage
-      if: ${{ matrix.os != 'windows-latest' }}
       env:
         EXTRA_PLATFORM_PLUGINS: libqwayland-generic.so
         EXTRA_QT_MODULES: waylandcompositor
@@ -137,7 +98,6 @@ jobs:
         make install DESTDIR=AppDir
         install -Dm755 "${{ github.workspace }}/img/ico/openfire.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/org.TeamOpenFIRE.OpenFIREapp.svg"
         "${{ runner.temp }}/linuxdeploy/linuxdeploy-${{ matrix.sys_arch }}.AppImage" --plugin=qt --output appimage --appdir AppDir --desktop-file "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop"
-        cp ${{ matrix.file }} ${{ github.workspace }}
       working-directory: ${{ github.workspace }}/build
 
     - name: Upload Artifact
@@ -146,7 +106,7 @@ jobs:
         # Artifact name
         name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }} # optional, default is artifact
         # A file, directory or wildcard pattern that describes what to upload
-        path: ${{ matrix.file }}
+        path: OpenFIRE_App-${{matrix.sys_arch}}.AppImage
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -98,15 +98,15 @@ jobs:
         make install DESTDIR=AppDir
         install -Dm755 "${{ github.workspace }}/img/ico/openfire.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/org.TeamOpenFIRE.OpenFIREapp.svg"
         "${{ runner.temp }}/linuxdeploy/linuxdeploy-${{ matrix.sys_arch }}.AppImage" --plugin=qt --output appimage --appdir AppDir --desktop-file "${{ github.workspace }}/org.TeamOpenFIRE.OpenFIREapp.desktop"
+        mv "OpenFIRE_App-${{matrix.sys_arch}}.AppImage" "${{ github.workspace }}"
       working-directory: ${{ github.workspace }}/build
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         # Artifact name
-        name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }} # optional, default is artifact
-        # A file, directory or wildcard pattern that describes what to upload
-        path: OpenFIRE_App-${{matrix.sys_arch}}.AppImage
+        name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }}
+        path: "OpenFIRE_App-${{matrix.sys_arch}}.AppImage"
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -113,7 +113,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }} --strip
-        Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend --release --compiler-runtime
+        windeployqt ${{ github.workspace }}/${{ matrix.file }}/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
         mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
 
     - name: Install linuxdeploy

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Cleanup Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }}
+        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }} --strip
         ${{ github.workspace }}\Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
         mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -115,13 +115,13 @@ jobs:
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel
 
     - name: Install linuxdeploy
-      if: ${{ matrix.os != 'windows-2019' }}
+      if: ${{ matrix.os != 'windows-latest' }}
       uses: pcolby/install-linuxdeploy@v1
       with:
         plugins: qt appimage
 
     - name: Setup AppImage
-      if: ${{ matrix.os != 'windows-2019' }}
+      if: ${{ matrix.os != 'windows-latest' }}
       env:
         EXTRA_PLATFORM_PLUGINS: libqwayland-generic.so
         EXTRA_QT_MODULES: waylandcompositor

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -18,19 +18,16 @@ jobs:
         build_type: [Debug, Release]
         include:
           - os: windows-latest
-            c_compiler: cc
-            cpp_compiler: c++
             file: build
             qt_host: windows
             qt_arch: win64_llvm_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
             qt_extra_archives: llvm
+            qt_tools: tools_mingw1310
             install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
           - os: ubuntu-22.04
-            c_compiler: clang
-            cpp_compiler: clang++
             file: OpenFIRE_App-x86_64.AppImage
             qt_host: linux
             qt_arch: gcc_64
@@ -40,8 +37,6 @@ jobs:
             install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux x86 AppImage"
           - os: ubuntu-22.04
-            c_compiler: clang
-            cpp_compiler: clang++
             file: OpenFIRE_App-x86_64.AppImage
             qt_host: linux
             qt_arch: linux_gcc_64
@@ -51,8 +46,6 @@ jobs:
             install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux x86 AppImage"
           - os: ubuntu-22.04-arm
-            c_compiler: clang
-            cpp_compiler: clang++
             file: OpenFIRE_App-aarch64.AppImage
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
@@ -98,6 +91,7 @@ jobs:
         host: '${{ matrix.qt_host }}'
         arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
+        tools: '${{ matrix.qt_tools }}'
         archives: 'qtbase qtwayland qttranslations qttools qtsvg icu ${{ matrix.qt_extra_archives }}'
         cache: true
 
@@ -106,8 +100,6 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ github.workspace }}/build
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
         ${{ matrix.install_prefix }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -22,10 +22,10 @@ jobs:
             cpp_compiler: c++
             file: build
             qt_host: windows
-            qt_arch: win64_mingw
+            qt_arch: win64_llvm_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
-            qt_extra_archives: MinGW
+            qt_extra_archives: llvm
             install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
           - os: ubuntu-22.04

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,6 +25,7 @@ jobs:
             qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
+            qt_extra_archives: MinGW
             install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
           - os: ubuntu-22.04
@@ -88,6 +89,7 @@ jobs:
       with:
         version: '${{ matrix.qt_version }}'
         archives: 'qtbase qtwayland qttranslations qttools qtsvg qtserialport icu'
+        cache: true
     - name: Install Qt(6)
       if: ${{ matrix.qt_version != '5.15.2' }}
       uses: jdpurcell/install-qt-action@v5
@@ -96,7 +98,8 @@ jobs:
         host: '${{ matrix.qt_host }}'
         arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
-        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
+        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu ${{ matrix.qt_extra_archives }}'
+        cache: true
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,9 +24,15 @@ jobs:
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
             qt_tools: tools_mingw1310
-            qt_path: mingw_64
             install_prefix: '-G "MinGW Makefiles"'
-            pretty: "Windows Artifact"
+            pretty: "Windows Artifact (MinGW)"
+          - os: windows-latest
+            file: build/out
+            qt_host: windows
+            qt_arch: win64_msvc2022_64
+            qt_version: 6.8.3
+            qt6_modules: "qtserialport"
+            pretty: "Windows Artifact (MSVC)"
           - os: ubuntu-22.04
             file: OpenFIRE_App-x86_64.AppImage
             qt_host: linux

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -18,12 +18,13 @@ jobs:
         build_type: [Debug, Release]
         include:
           - os: windows-latest
-            file: build
+            file: build/out
             qt_host: windows
             qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
             qt_tools: tools_mingw1310
+            qt_path: mingw_64
             install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
           - os: ubuntu-22.04
@@ -107,6 +108,13 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel
+
+    - name: Cleanup Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }}
+        ${{ github.workspace }}\Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
+        mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
 
     - name: Install linuxdeploy
       if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -23,7 +23,6 @@ jobs:
             qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
-            qt6_extra_archives: "MinGW"
             qt_tools: tools_mingw1310
             qt_path: mingw_64
             install_prefix: '-G "MinGW Makefiles"'
@@ -93,7 +92,7 @@ jobs:
         arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
         tools: '${{ matrix.qt_tools }}'
-        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu ${{ matrix.qt6_extra_archives }}'
+        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
         cache: true
 
     - name: Configure CMake
@@ -114,7 +113,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }} --strip
-        Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
+        Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend --release --compiler-runtime
         mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
 
     - name: Install linuxdeploy

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -81,7 +81,7 @@ jobs:
       run: echo "id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Install MinGW
-      if: ${{ matrix.os == 'windows' }}
+      if: ${{ matrix.os == 'windows-2019' }}
       uses: egor-tensin/setup-mingw@v2
 
     # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2019]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
         qt_version: [5.15.2, 6.7.3, 6.8.3]
         build_type: [Debug, Release]
         include:
@@ -61,9 +61,9 @@ jobs:
             install_prefix: -DCMAKE_INSTALL_PREFIX=/usr
             pretty: "Linux ARM AppImage"
         exclude:
-          - os: windows-2019
+          - os: windows-latest
             qt_version: 5.15.2
-          - os: windows-2019
+          - os: windows-latest
             qt_version: 6.7.3
           - os: ubuntu-22.04
             qt_version: 6.7.3

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -18,10 +18,11 @@ jobs:
         build_type: [Debug, Release]
         include:
           - os: windows-2019
-            c_compiler: cl
-            cpp_compiler: cl
+            c_compiler: cc
+            cpp_compiler: c++
             file: build
-            qt_arch: windows
+            qt_host: windows
+            qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
             pretty: "Windows Artifact"
@@ -29,7 +30,8 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             file: OpenFIRE_App-x86_64.AppImage
-            qt_arch: linux
+            qt_host: linux
+            qt_arch: gcc_64
             qt_version: 5.15.2
             qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: x86_64
@@ -39,7 +41,8 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             file: OpenFIRE_App-x86_64.AppImage
-            qt_arch: linux
+            qt_host: linux
+            qt_arch: linux_gcc_64
             qt_version: 6.8.3
             qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: x86_64
@@ -49,7 +52,8 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             file: OpenFIRE_App-aarch64.AppImage
-            qt_arch: linux_arm64
+            qt_host: linux_arm64
+            qt_arch: linux_gcc_arm64
             qt_version: 6.7.3
             qt6_modules: "qtserialport qtwaylandcompositor"
             sys_arch: aarch64
@@ -76,6 +80,10 @@ jobs:
       id: get-short-sha
       run: echo "id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+    - name: Install MinGW
+      if: ${{ matrix.os == 'windows' }}
+      uses: egor-tensin/setup-mingw@v2
+
     # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged
     - name: Install Qt(5)
       if: ${{ matrix.qt_version == '5.15.2' }}
@@ -88,7 +96,8 @@ jobs:
       uses: jdpurcell/install-qt-action@v5
       with:
         version: '${{ matrix.qt_version }}'
-        host: '${{ matrix.qt_arch }}'
+        host: '${{ matrix.qt_host }}'
+        arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
         archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -113,7 +113,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/${{ matrix.file }} --strip
-        ${{ github.workspace }}\Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
+        Qt\${{ matrix.qt_version }}\${{ matrix.qt_path }}\bin\windeployqt.exe ${{ github.workspace }}/${{ matrix.file }}/bin --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
         mv "${{ github.workspace }}/${{ matrix.file }}/bin" "${{ github.workspace }}/${{ matrix.file }}/OpenFIRE App"
 
     - name: Install linuxdeploy

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -20,10 +20,9 @@ jobs:
           - os: windows-latest
             file: build
             qt_host: windows
-            qt_arch: win64_llvm_mingw
+            qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
-            qt_extra_archives: llvm
             qt_tools: tools_mingw1310
             install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
@@ -92,7 +91,7 @@ jobs:
         arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
         tools: '${{ matrix.qt_tools }}'
-        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu ${{ matrix.qt_extra_archives }}'
+        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
         cache: true
 
     - name: Configure CMake

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -23,6 +23,7 @@ jobs:
             qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
+            qt6_extra_archives: "MinGW"
             qt_tools: tools_mingw1310
             qt_path: mingw_64
             install_prefix: '-G "MinGW Makefiles"'
@@ -92,7 +93,7 @@ jobs:
         arch: '${{ matrix.qt_arch }}'
         modules: '${{ matrix.qt6_modules }}'
         tools: '${{ matrix.qt_tools }}'
-        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu'
+        archives: 'qtbase qtwayland qttranslations qttools qtsvg icu ${{ matrix.qt6_extra_archives }}'
         cache: true
 
     - name: Configure CMake

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -17,7 +17,7 @@ jobs:
         qt_version: [5.15.2, 6.7.3, 6.8.3]
         build_type: [Debug, Release]
         include:
-          - os: windows-2019
+          - os: windows-latest
             c_compiler: cc
             cpp_compiler: c++
             file: build
@@ -25,6 +25,7 @@ jobs:
             qt_arch: win64_mingw
             qt_version: 6.8.3
             qt6_modules: "qtserialport"
+            install_prefix: '-G "MinGW Makefiles"'
             pretty: "Windows Artifact"
           - os: ubuntu-22.04
             c_compiler: clang
@@ -79,10 +80,6 @@ jobs:
     - name: Get short SHA
       id: get-short-sha
       run: echo "id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-    - name: Install MinGW
-      if: ${{ matrix.os == 'windows-2019' }}
-      uses: egor-tensin/setup-mingw@v2
 
     # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged
     - name: Install Qt(5)

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,4 +1,4 @@
-name: CMake - Windows & Linux
+name: CMake - Windows 10+
 
 on:
   push:

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -16,15 +16,17 @@ jobs:
         build_type: [Debug, Release]
         win_arch: [win64_msvc2022_64, win64_mingw]
         include:
-          - os: windows-latest
-            win_arch: win64_mingw
+          - win_arch: win64_mingw
             qt_tools: tools_mingw1310
             cmake_gen: "MinGW Makefiles"
             pretty: "Windows Artifact (MinGW)"
-          - os: windows-latest
-            win_arch: win64_msvc2022_64
+          - win_arch: win64_msvc2022_64
             cmake_gen: "Visual Studio 17 2022"
             pretty: "Windows Artifact (MSVC)"
+        # MSVC insists on being weird with its Debug path, and can't be assed to fix it
+        exclude:
+          - win_arch: win64_msvc2022_64
+            build_type: Debug
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,0 +1,77 @@
+name: CMake - Windows & Linux
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      matrix:
+        qt_version: 6.8.3
+        build_type: [Debug, Release]
+        win_arch: [win64_msvc2022_64, win64_mingw]
+        include:
+          - os: windows-latest
+            win_arch: win64_mingw
+            qt_tools: tools_mingw1310
+            cmake_gen: "MinGW Makefiles"
+            pretty: "Windows Artifact (MinGW)"
+          - os: windows-latest
+            win_arch: win64_msvc2022_64
+            cmake_gen: "Visual Studio 17 2022"
+            pretty: "Windows Artifact (MSVC)"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+
+    - name: Get short SHA
+      id: get-short-sha
+      run: echo "id=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
+
+    # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged
+    - name: Install Qt6
+      uses: jdpurcell/install-qt-action@v5
+      with:
+        version: '${{ matrix.qt_version }}'
+        arch: '${{ matrix.win_arch }}'
+        modules: 'qtserialport'
+        tools: '${{ matrix.qt_tools }}'
+        archives: 'qtbase qttranslations qttools qtsvg icu'
+        cache: true
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ github.workspace }}/build
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
+        -G ${{ matrix.cmake_gen }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel
+
+    - name: Deploy Windows App & Libraries
+      run: |
+        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/build/out --strip
+        windeployqt ${{ github.workspace }}/build/out/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
+        mv "${{ github.workspace }}/build/out/bin" "${{ github.workspace }}/build/out/OpenFIRE App"
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        # Artifact name
+        name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }} # optional, default is artifact
+        # A file, directory or wildcard pattern that describes what to upload
+        path: build/out
+
+    - name: Download a Build Artifact
+      uses: actions/download-artifact@v4

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -48,11 +48,11 @@ jobs:
 
     - name: Configure CMake
       run: >
-        cmake -B ${{ github.workspace }}/build
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DOFAPP_GITHASH=${{steps.get-short-sha.outputs.id}}
-        -G ${{ matrix.cmake_gen }}
-        -S ${{ github.workspace }}
+        cmake -B "${{ github.workspace }}/build"
+        -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}"
+        -DOFAPP_GITHASH="${{steps.get-short-sha.outputs.id}}"
+        -G "${{ matrix.cmake_gen }}"
+        -S "${{ github.workspace }}"
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
@@ -60,8 +60,8 @@ jobs:
 
     - name: Deploy Windows App & Libraries
       run: |
-        cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/build/out --strip
-        windeployqt ${{ github.workspace }}/build/out/bin/OpenFIREapp.exe --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
+        cmake --install "${{ github.workspace }}/build" --prefix "${{ github.workspace }}/build/out" --strip
+        windeployqt "${{ github.workspace }}/build/out/bin/OpenFIREapp.exe" --no-translations --no-system-d3d-compiler --no-opengl-sw --no-network --exclude-plugins qnetworklistmanager,qtuiotouchplugin,qsvgicon,qcertonlybackend,qchannelbackend
         mv "${{ github.workspace }}/build/out/bin" "${{ github.workspace }}/build/out/OpenFIRE App"
 
     - name: Upload Artifact

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
 
       matrix:
-        qt_version: 6.8.3
         build_type: [Debug, Release]
         win_arch: [win64_msvc2022_64, win64_mingw]
         include:
@@ -40,7 +39,7 @@ jobs:
     - name: Install Qt6
       uses: jdpurcell/install-qt-action@v5
       with:
-        version: '${{ matrix.qt_version }}'
+        version: '6.8.3'
         arch: '${{ matrix.win_arch }}'
         modules: 'qtserialport'
         tools: '${{ matrix.qt_tools }}'
@@ -69,7 +68,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         # Artifact name
-        name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }} # optional, default is artifact
+        name: OpenFIREapp-${{ matrix.pretty }}-Qt6-${{ matrix.build_type }} # optional, default is artifact
         # A file, directory or wildcard pattern that describes what to upload
         path: build/out
 

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,4 +1,4 @@
-name: CMake - Windows 10+
+name: CMake - Windows 10+ Packages
 
 on:
   push:


### PR DESCRIPTION
Also does all the Qt deployment directly from the workflow, so no need to setup the actual folder for release deployment after the fact.

Seems like this was the cause of #103, as 6.8.2 libraries were being mixed up with a 6.8.3 executable and was causing some funky weirdness. So, uh, closes #103 