### PR TITLE
Initial Multiple OLED displays support

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1600,10 +1600,18 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 {
     App_Common::boolSettings[App_Common::dataCurrent][OF_Const::i2cOLED] = arg1;
     ui->oledGroup->setEnabled(arg1);
+    if(arg1)
+        ui->i2cGroup->setVisible(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::displayOLEDType] == OF_Const::displaySSD1306_I2C
+                                                                                                                ? true : false);
 
     DiffUpdate();
 }
 
+void guiWindow::on_i2cOLEDtypeBox_currentIndexChanged(int index)
+{
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::displayOLEDType] = index+1;
+    ui->i2cGroup->setVisible(index == OF_Const::displaySSD1306_I2C-1 ? true : false);
+}
 
 void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)
 {

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -958,6 +958,8 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->tempShutoffBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown]);
 
             ui->i2cOLEDtoggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLED]);
+            // index offset shift (TODO: might be changed)
+            if(App_Common::settingsTable[App_Common::dataOrig][OF_Const::displayOLEDType]) ui->i2cOLEDtypeBox->setCurrentIndex(App_Common::settingsTable[App_Common::dataOrig][OF_Const::displayOLEDType]-1);
             ui->oledAltAddrsToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLEDaltAddr]);
 
             ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcount]);
@@ -1609,6 +1611,7 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 
 void guiWindow::on_i2cOLEDtypeBox_currentIndexChanged(int index)
 {
+    // index offset shift (TODO: might be changed)
     App_Common::settingsTable[App_Common::dataCurrent][OF_Const::displayOLEDType] = index+1;
     ui->i2cGroup->setVisible(index == OF_Const::displaySSD1306_I2C-1 ? true : false);
 }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -958,8 +958,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->tempShutoffBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown]);
 
             ui->i2cOLEDtoggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLED]);
-            // index offset shift (TODO: might be changed)
-            if(App_Common::settingsTable[App_Common::dataOrig][OF_Const::displayOLEDType]) ui->i2cOLEDtypeBox->setCurrentIndex(App_Common::settingsTable[App_Common::dataOrig][OF_Const::displayOLEDType]-1);
+            if(App_Common::settingsTable[App_Common::dataOrig][OF_Const::i2cOLED]) ui->i2cOLEDtypeBox->setCurrentIndex(App_Common::settingsTable[App_Common::dataOrig][OF_Const::i2cOLEDType]);
             ui->oledAltAddrsToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::i2cOLEDaltAddr]);
 
             ui->neopixelStrandLengthBox->setValue(App_Common::settingsTable[App_Common::dataOrig][OF_Const::customLEDcount]);
@@ -1603,7 +1602,7 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
     App_Common::boolSettings[App_Common::dataCurrent][OF_Const::i2cOLED] = arg1;
     ui->oledGroup->setEnabled(arg1);
     if(arg1)
-        ui->i2cGroup->setVisible(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::displayOLEDType] == OF_Const::displaySSD1306_I2C
+        ui->i2cGroup->setVisible(App_Common::settingsTable[App_Common::dataCurrent][OF_Const::i2cOLEDType] == OF_Const::I2Cdisp_SSD1306
                                                                                                                 ? true : false);
 
     DiffUpdate();
@@ -1612,8 +1611,8 @@ void guiWindow::on_i2cOLEDtoggle_stateChanged(int arg1)
 void guiWindow::on_i2cOLEDtypeBox_currentIndexChanged(int index)
 {
     // index offset shift (TODO: might be changed)
-    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::displayOLEDType] = index+1;
-    ui->i2cGroup->setVisible(index == OF_Const::displaySSD1306_I2C-1 ? true : false);
+    App_Common::settingsTable[App_Common::dataCurrent][OF_Const::i2cOLEDType] = index;
+    ui->i2cGroup->setVisible(index == OF_Const::I2Cdisp_SSD1306 ? true : false);
 }
 
 void guiWindow::on_oledAltAddrsToggle_stateChanged(int arg1)

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -131,6 +131,8 @@ private slots:
 
     void on_i2cOLEDtoggle_stateChanged(int arg1);
 
+    void on_i2cOLEDtypeBox_currentIndexChanged(int index);
+
     void on_oledAltAddrsToggle_stateChanged(int arg1);
 
     void on_tinyUSBLayoutToggle_stateChanged(int arg1);

--- a/src/appmainwindow.ui
+++ b/src/appmainwindow.ui
@@ -33,7 +33,7 @@
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -49,14 +49,14 @@
          <string>COM Port:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QComboBox" name="comPortSelector">
         <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContents</enum>
+         <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
         </property>
         <property name="placeholderText">
          <string>[No devices currently available]</string>
@@ -76,14 +76,14 @@
        <string notr="true"/>
       </property>
       <property name="alignment">
-       <set>Qt::AlignCenter</set>
+       <set>Qt::AlignmentFlag::AlignCenter</set>
       </property>
      </widget>
     </item>
     <item>
      <widget class="Line" name="line">
       <property name="orientation">
-       <enum>Qt::Horizontal</enum>
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -100,20 +100,20 @@
        <string notr="true"/>
       </property>
       <property name="alignment">
-       <set>Qt::AlignCenter</set>
+       <set>Qt::AlignmentFlag::AlignCenter</set>
       </property>
       <property name="openExternalLinks">
        <bool>true</bool>
       </property>
       <property name="textInteractionFlags">
-       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="tabPosition">
-       <enum>QTabWidget::South</enum>
+       <enum>QTabWidget::TabPosition::South</enum>
       </property>
       <property name="currentIndex">
        <number>0</number>
@@ -153,19 +153,19 @@
         <item>
          <widget class="QScrollArea" name="pinsScrollArea">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
           <widget class="QWidget" name="pinsScrollContents">
            <property name="geometry">
@@ -221,7 +221,7 @@
           <property name="bottomMargin">
            <number>6</number>
           </property>
-          <item alignment="Qt::AlignBottom">
+          <item alignment="Qt::AlignmentFlag::AlignBottom">
            <widget class="QCheckBox" name="customPinsEnabled">
             <property name="enabled">
              <bool>true</bool>
@@ -255,7 +255,7 @@
           <item>
            <spacer name="horizontalSpacer_14">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -274,14 +274,14 @@
              <iconset theme="edit-copy"/>
             </property>
             <property name="popupMode">
-             <enum>QToolButton::InstantPopup</enum>
+             <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonTextBesideIcon</enum>
+             <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
             </property>
            </widget>
           </item>
-          <item alignment="Qt::AlignRight|Qt::AlignBottom">
+          <item alignment="Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignBottom">
            <widget class="QComboBox" name="presetsBox">
             <property name="enabled">
              <bool>false</bool>
@@ -321,19 +321,19 @@
         <item>
          <widget class="QScrollArea" name="buttonFuncScroller">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="buttonFuncScrollContents">
            <property name="geometry">
@@ -380,7 +380,7 @@
                  <item>
                   <spacer name="horizontalSpacer_7">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -401,7 +401,7 @@
                     <string>On-Screen Function</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -416,7 +416,7 @@
                     <string>Off-Screen Function</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -431,7 +431,7 @@
                     <string>Gamepad Mode</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -450,7 +450,7 @@
             <item>
              <spacer name="verticalSpacer_4">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -469,7 +469,7 @@
                <item>
                 <spacer name="horizontalSpacer_6">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -552,7 +552,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows the currently loaded Button Mapping settings.&lt;/p&gt;&lt;p&gt;Any enabled button input in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout&lt;/span&gt; can be assigned to output any button from any of the three Input Devices that OpenFIRE presents to any connected device (a Mouse, Keyboard, and Xbox-like Gamepad), depending on the condition that the input is pressed.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -561,7 +561,7 @@
               <bool>true</bool>
              </property>
              <property name="textInteractionFlags">
-              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
              </property>
             </widget>
            </item>
@@ -599,27 +599,27 @@
         <item>
          <widget class="QScrollArea" name="settingsScrollArea">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="settingsScrollContents">
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
+             <y>-492</y>
              <width>944</width>
-             <height>1200</height>
+             <height>1195</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0,0,0,1,0">
@@ -662,10 +662,10 @@
                         <string>Rumble Intensity:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::PlainText</enum>
+                        <enum>Qt::TextFormat::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -684,10 +684,10 @@
                         <bool>true</bool>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> / 255</string>
@@ -706,10 +706,10 @@
                         <string>Rumble Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::PlainText</enum>
+                        <enum>Qt::TextFormat::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -725,10 +725,10 @@
                         <string>Length of Rumble Events</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -741,7 +741,7 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="0" colspan="4" alignment="Qt::AlignHCenter">
+                     <item row="1" column="0" colspan="4" alignment="Qt::AlignmentFlag::AlignHCenter">
                       <widget class="QCheckBox" name="rumbleFFToggle">
                        <property name="toolTip">
                         <string/>
@@ -763,7 +763,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="0" column="0" alignment="Qt::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                    <widget class="QCheckBox" name="rumbleToggle">
                     <property name="toolTip">
                      <string/>
@@ -785,7 +785,7 @@
                  </layout>
                 </widget>
                </item>
-               <item row="0" column="0" alignment="Qt::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                 <widget class="QCheckBox" name="autofireToggle">
                  <property name="toolTip">
                   <string/>
@@ -810,7 +810,7 @@
                   <string>Solenoid</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="0" column="0" alignment="Qt::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                    <widget class="QCheckBox" name="solenoidToggle">
                     <property name="toolTip">
                      <string/>
@@ -865,7 +865,7 @@
                            <string>Temperature Warning Threshold:</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                           </property>
                          </widget>
                         </item>
@@ -875,7 +875,7 @@
                            <string>Temperature Shutoff Threshold:</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                           </property>
                          </widget>
                         </item>
@@ -929,10 +929,10 @@
                         <string>Solenoid ON Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::PlainText</enum>
+                        <enum>Qt::TextFormat::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -948,10 +948,10 @@
                         <string>Solenoid Engagement Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -973,10 +973,10 @@
                         <string>Solenoid Autofire Wait Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -992,10 +992,10 @@
                         <string>Solenoid Autofire Wait Time:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::PlainText</enum>
+                        <enum>Qt::TextFormat::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>
@@ -1008,10 +1008,10 @@
                         <string>Solenoid Hold-to-Autofire Length:</string>
                        </property>
                        <property name="textFormat">
-                        <enum>Qt::PlainText</enum>
+                        <enum>Qt::TextFormat::PlainText</enum>
                        </property>
                        <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
                        <property name="wordWrap">
                         <bool>true</bool>
@@ -1030,10 +1030,10 @@
                         <string>Solenoid Trigger Hold to Autofire Length</string>
                        </property>
                        <property name="buttonSymbols">
-                        <enum>QAbstractSpinBox::PlusMinus</enum>
+                        <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                        </property>
                        <property name="correctionMode">
-                        <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                        </property>
                        <property name="suffix">
                         <string> ms</string>
@@ -1061,7 +1061,7 @@
                <string>Lighting</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
-               <item row="0" column="0" alignment="Qt::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                 <widget class="QCheckBox" name="commonAnodeToggle">
                  <property name="toolTip">
                   <string/>
@@ -1092,7 +1092,7 @@
                      <string>NeoPixel Strand Length: </string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -1180,10 +1180,10 @@
                      <string>NeoPixel Strand Length</string>
                     </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::PlusMinus</enum>
+                     <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                     </property>
                     <property name="correctionMode">
-                     <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                     </property>
                     <property name="suffix">
                      <string> Pixel(s)</string>
@@ -1241,14 +1241,14 @@
                      <string>Changes to NeoPixel settings may require a power cycle to update properly!</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignCenter</set>
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item row="0" column="0" rowspan="2">
                    <spacer name="horizontalSpacer_3">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1264,14 +1264,14 @@
                      <string>Static NeoPixels: </string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item row="0" column="5" rowspan="2">
                    <spacer name="horizontalSpacer_4">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1309,7 +1309,7 @@
                <string>Input</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
-               <item row="0" column="0" alignment="Qt::AlignHCenter">
+               <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                 <widget class="QCheckBox" name="lowButtonsToggle">
                  <property name="toolTip">
                   <string/>
@@ -1349,10 +1349,10 @@
                   <string>Length to activate Hold-to-Pause Menu</string>
                  </property>
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::PlusMinus</enum>
+                  <enum>QAbstractSpinBox::ButtonSymbols::PlusMinus</enum>
                  </property>
                  <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                  <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
                  </property>
                  <property name="suffix">
                   <string> ms</string>
@@ -1368,7 +1368,7 @@
                <item row="1" column="4">
                 <spacer name="horizontalSpacer_2">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1384,10 +1384,10 @@
                   <string>Hold-to-Pause Length:</string>
                  </property>
                  <property name="textFormat">
-                  <enum>Qt::PlainText</enum>
+                  <enum>Qt::TextFormat::PlainText</enum>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                  </property>
                  <property name="wordWrap">
                   <bool>true</bool>
@@ -1416,7 +1416,7 @@
                <item row="1" column="0">
                 <spacer name="horizontalSpacer_5">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1426,7 +1426,7 @@
                  </property>
                 </spacer>
                </item>
-               <item row="0" column="1" colspan="3" alignment="Qt::AlignHCenter">
+               <item row="0" column="1" colspan="3" alignment="Qt::AlignmentFlag::AlignHCenter">
                 <widget class="QCheckBox" name="simplePauseToggle">
                  <property name="toolTip">
                   <string/>
@@ -1454,21 +1454,82 @@
                <string>I2C Peripherals</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
-               <item alignment="Qt::AlignHCenter">
-                <widget class="QCheckBox" name="i2cOLEDtoggle">
-                 <property name="whatsThis">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE:&lt;/span&gt; Because this device does not communicate back to the board, the firmware has no way of knowing whether the device successfully initialized or not. If the display is connected properly, but does &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; seem to power on on startup/after syncing settings, then try the &lt;span style=&quot; font-style:italic;&quot;&gt;Use Alternative Device Address&lt;/span&gt; setting before attempting to rewire the device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>I2C OLED Display Toggle</string>
-                 </property>
-                 <property name="text">
-                  <string>Enable OLED Display (SSD1306 128x64)</string>
-                 </property>
-                 <property name="trackable" stdset="0">
-                  <UInt>1</UInt>
-                 </property>
-                </widget>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0,0,1">
+                 <item>
+                  <spacer name="horizontalSpacer_10">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="i2cOLEDtoggle">
+                   <property name="whatsThis">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE:&lt;/span&gt; Because this device does not communicate back to the board, the firmware has no way of knowing whether the device successfully initialized or not. If the display is connected properly, but does &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; seem to power on on startup/after syncing settings, then try the &lt;span style=&quot; font-style:italic;&quot;&gt;Use Alternative Device Address&lt;/span&gt; setting before attempting to rewire the device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="accessibleName">
+                    <string>I2C OLED Display Toggle</string>
+                   </property>
+                   <property name="text">
+                    <string>Enable OLED Display</string>
+                   </property>
+                   <property name="trackable" stdset="0">
+                    <UInt>1</UInt>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="i2cOLEDtypeBox">
+                   <property name="mouseTracking">
+                    <bool>true</bool>
+                   </property>
+                   <property name="whatsThis">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select which type of Monochromatic OLED display to use.&lt;/p&gt;&lt;p&gt;Generally speaking, &lt;span style=&quot; font-style:italic;&quot;&gt;SSD1306&lt;/span&gt; will be marketed as &lt;span style=&quot; font-weight:700;&quot;&gt;0.96&amp;quot;&lt;/span&gt;, and SH1106/1107 are &lt;span style=&quot; font-weight:700;&quot;&gt;1.3&amp;quot;&lt;/span&gt; or &lt;span style=&quot; font-weight:700;&quot;&gt;1.5&amp;quot;&lt;/span&gt;; make sure to confirm from the listing where you purchased your display to ensure it's one of these types.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="accessibleName">
+                    <string>I2C OLED Display Type</string>
+                   </property>
+                   <property name="trackable" stdset="0">
+                    <number>1</number>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>SSD1306 (128x64)</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>SH1106 (128x64)</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>SH1107 (128x64)</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_11">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
                <item>
                 <widget class="QGroupBox" name="oledGroup">
@@ -1476,7 +1537,7 @@
                   <string>SSD1306 OLED Display</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="0" column="0" alignment="Qt::AlignHCenter">
+                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
                    <widget class="QCheckBox" name="oledAltAddrsToggle">
                     <property name="whatsThis">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the display doesn't seem to power on when &lt;span style=&quot; font-style:italic;&quot;&gt;Enable OLED Display&lt;/span&gt; is set on startup/after syncing settings to the device (and you have confirmed that it is wired correctly), enabling this will try a different start address.&lt;/p&gt;&lt;p&gt;The firmware's display component normally defaults to I2C address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3C&lt;/span&gt;, but some 128x64 screens may have device address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3D&lt;/span&gt; instead, which this setting will inform the firmware to try instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1501,7 +1562,7 @@
             <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1531,7 +1592,7 @@
                   <string>For Multiplayer, make sure each gun has its own unique identifier!</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                 </widget>
                </item>
@@ -1546,7 +1607,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <property name="flat">
                   <bool>true</bool>
@@ -1561,7 +1622,7 @@
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start/Select key mappings will default to &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; binds (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) for custom identifiers set here:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignCenter</set>
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -1573,17 +1634,17 @@
                        <string>Product ID:</string>
                       </property>
                       <property name="textFormat">
-                       <enum>Qt::PlainText</enum>
+                       <enum>Qt::TextFormat::PlainText</enum>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                       </property>
                      </widget>
                     </item>
                     <item row="0" column="0">
                      <spacer name="horizontalSpacer_9">
                       <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
+                       <enum>Qt::Orientation::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -1602,7 +1663,7 @@
                        <string>Custom USB Product ID</string>
                       </property>
                       <property name="buttonSymbols">
-                       <enum>QAbstractSpinBox::NoButtons</enum>
+                       <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
                       </property>
                       <property name="prefix">
                        <string>0x</string>
@@ -1624,17 +1685,17 @@
                        <string>Product Name:</string>
                       </property>
                       <property name="textFormat">
-                       <enum>Qt::PlainText</enum>
+                       <enum>Qt::TextFormat::PlainText</enum>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                       </property>
                      </widget>
                     </item>
                     <item row="0" column="3">
                      <spacer name="horizontalSpacer_8">
                       <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
+                       <enum>Qt::Orientation::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -1688,7 +1749,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <property name="flat">
                   <bool>true</bool>
@@ -1703,13 +1764,13 @@
                      <string>Start/Select key mappings will change according to the player identifier set here:</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignCenter</set>
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_8">
-                    <item alignment="Qt::AlignHCenter">
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p1">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1725,7 +1786,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignHCenter">
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p2">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1741,7 +1802,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignHCenter">
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p3">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1757,7 +1818,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item alignment="Qt::AlignHCenter">
+                    <item alignment="Qt::AlignmentFlag::AlignHCenter">
                      <widget class="QRadioButton" name="tUSB_p4">
                       <property name="whatsThis">
                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1778,7 +1839,7 @@
                  </layout>
                 </widget>
                </item>
-               <item alignment="Qt::AlignRight">
+               <item alignment="Qt::AlignmentFlag::AlignRight">
                 <widget class="QCheckBox" name="tinyUSBLayoutToggle">
                  <property name="whatsThis">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines whether to show/use &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Presets&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Custom USB ID Settings.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This can be useful for users with either more than four OpenFIRE lightguns, or simply want to personalize each lightgun, but the &lt;span style=&quot; font-style:italic;&quot;&gt;Simple Presets&lt;/span&gt; may be preferable to some.&lt;/p&gt;&lt;p&gt;All lightguns default to a &lt;span style=&quot; font-style:italic;&quot;&gt;P1 Simple USB ID Preset.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1827,7 +1888,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab has a variety of settings to tweak about the lightgun's force feedback, lighting effects, and how it presents itself to the device.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -1836,7 +1897,7 @@
               <bool>true</bool>
              </property>
              <property name="textInteractionFlags">
-              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
              </property>
             </widget>
            </item>
@@ -1871,19 +1932,19 @@
         <item>
          <widget class="QScrollArea" name="profilesScrollArea">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="profilesScrollContents">
            <property name="geometry">
@@ -1921,7 +1982,7 @@
                     <string>Bottom</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1931,14 +1992,14 @@
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="6">
                   <widget class="Line" name="line_5">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -1948,7 +2009,7 @@
                     <string>TRled</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1958,7 +2019,7 @@
                     <string>Sensitivity</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1968,7 +2029,7 @@
                     <string>TLled</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1978,7 +2039,7 @@
                     <string>Run Mode</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -1988,21 +2049,21 @@
                     <string>Layout</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="22">
                   <widget class="Line" name="line_12">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="16">
                   <widget class="Line" name="line_8">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -2012,21 +2073,21 @@
                     <string>Left</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="12">
                   <widget class="Line" name="line_10">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="14">
                   <widget class="Line" name="line_11">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -2036,14 +2097,14 @@
                     <string>Right</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="20">
                   <widget class="Line" name="line_9">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -2053,14 +2114,14 @@
                     <string>Color</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="4">
                   <widget class="Line" name="line_4">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -2070,21 +2131,21 @@
                     <string/>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="10">
                   <widget class="Line" name="line_7">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="2">
                   <spacer name="horizontalSpacer_15">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2097,10 +2158,10 @@
                  <item row="0" column="3">
                   <widget class="QLabel" name="topOffHeader">
                    <property name="frameShape">
-                    <enum>QFrame::NoFrame</enum>
+                    <enum>QFrame::Shape::NoFrame</enum>
                    </property>
                    <property name="frameShadow">
-                    <enum>QFrame::Plain</enum>
+                    <enum>QFrame::Shadow::Plain</enum>
                    </property>
                    <property name="lineWidth">
                     <number>1</number>
@@ -2109,21 +2170,21 @@
                     <string>Top</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="8">
                   <widget class="Line" name="line_6">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="18">
                   <widget class="Line" name="line_3">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                   </widget>
                  </item>
@@ -2133,7 +2194,7 @@
                     <string>Display Ratio</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2148,7 +2209,7 @@
             <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -2188,7 +2249,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows information and settings to tweak about your current calibration profiles.&lt;/p&gt;&lt;p&gt;The table above represents the amount of profiles the current board can store, including currently selected profile, names shown for each profile when using a compatible &lt;span style=&quot; font-style:italic;&quot;&gt;I2C Display,&lt;/span&gt; and colors used for lighting devices when switching to them from &lt;span style=&quot; font-style:italic;&quot;&gt;Pause Mode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -2197,7 +2258,7 @@
               <bool>true</bool>
              </property>
              <property name="textInteractionFlags">
-              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
              </property>
             </widget>
            </item>
@@ -2235,19 +2296,19 @@
         <item>
          <widget class="QScrollArea" name="testScrollArea">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
+           <enum>QFrame::Shadow::Plain</enum>
           </property>
           <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
           <widget class="QWidget" name="testScrollContents">
            <property name="geometry">
@@ -2298,16 +2359,16 @@
                   <item>
                    <widget class="QLabel" name="tmp36Label">
                     <property name="frameShape">
-                     <enum>QFrame::Box</enum>
+                     <enum>QFrame::Shape::Box</enum>
                     </property>
                     <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
+                     <enum>QFrame::Shadow::Raised</enum>
                     </property>
                     <property name="text">
                      <string>Temperature Sensor (N/A)</string>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignCenter</set>
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -2349,7 +2410,7 @@
                      <string/>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignCenter</set>
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -2371,16 +2432,16 @@
                      </size>
                     </property>
                     <property name="verticalScrollBarPolicy">
-                     <enum>Qt::ScrollBarAlwaysOff</enum>
+                     <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                     </property>
                     <property name="horizontalScrollBarPolicy">
-                     <enum>Qt::ScrollBarAlwaysOff</enum>
+                     <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
                     </property>
                     <property name="interactive">
                      <bool>false</bool>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                     <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
                     </property>
                    </widget>
                   </item>
@@ -2455,7 +2516,7 @@
             <item>
              <spacer name="verticalSpacer_3">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -2468,7 +2529,7 @@
             <item>
              <widget class="Line" name="line_2">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
              </widget>
             </item>
@@ -2612,7 +2673,7 @@
     <string>Import Custom Layout...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::TextHeuristicRole</enum>
+    <enum>QAction::MenuRole::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="actionExport_Custom_Layout">
@@ -2623,7 +2684,7 @@
     <string>Export Custom Layout...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::TextHeuristicRole</enum>
+    <enum>QAction::MenuRole::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="actionDebug_Window">


### PR DESCRIPTION
(FW counterpart: TeamOpenFIRE/OpenFIRE-Firmware#139)

This is a VERY (read: barely-functioning atm) implementation of more OLED displays support, adding compatibility with SH1106 and SH1107-driven displays (still only for 128x64 resolution, though).

Relies on a separate boards branch atm.

Marking this as draft as there are still some things I'm unsure about atm; for instance, perhaps we should keep I2C and SPI displays separate instead of all lumped in one setting variable. But should we also allow the user to be able to enable both an I2C and SPI display at the same time?