### PR TITLE
Added support for faulty temperature sensor.

### DIFF
--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -1964,6 +1964,13 @@ void guiWindow::serialPort_readyRead()
             {
                 unsigned int temp = serial.port.read(1).at(0);
 
+                if (temp == OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE) {
+                    // Sensor error.
+                    ui->tmp36Label->setText("Temperature: FAULT");
+                    ui->tmp36Label->setStyleSheet("color: white; background-color: #FF0000; font: bold");
+                    break;
+                }
+
                 ui->tmp36Label->setText(QString("Temperature: %1°C").arg(temp));
 
                 if(     temp > App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown])


### PR DESCRIPTION
This pull request adds improved error handling for temperature sensor faults in the serial port data processing logic. The main change is the detection of a specific error value and updating the UI accordingly to alert the user.

Temperature sensor error handling:

* In `guiWindow::serialPort_readyRead()` (`src/appmainwindow.cpp`), added logic to check for `OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE` and display a "Temperature: FAULT" message with a red background on the `tmp36Label` to indicate a sensor error.

**ATTENTION:**
This PR requires the following PR merged before (will update submodule once boards is merged):
https://github.com/TeamOpenFIRE/OpenFIRE-Boards/pull/11