### PR TITLE
Add Italian translation, update Qt6 CMake translation workflow, and adjust sources for multi‑language support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets LinguistTools Con
 
 set(TS_FILES
         translation/AppTranslations_en_US.ts
+        translation/AppTranslations_it_IT.ts
 )
 
 set(PROJECT_SOURCES
@@ -86,15 +87,16 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         ${CMAKE_CURRENT_SOURCE_DIR}/img/ico/icon.rc
         ${PROJECT_SOURCES}
     )
-    qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
-
+    qt_add_translations(
+        TARGETS OpenFIREapp
+        TS_FILES ${TS_FILES}
+    )
 else()
     add_executable(OpenFIREapp
         ${CMAKE_CURRENT_SOURCE_DIR}/img/ico/icon.rc
         ${PROJECT_SOURCES}
     )
     qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
-
 endif()
 
 target_link_libraries(OpenFIREapp PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::SerialPort)

--- a/src/appcali.cpp
+++ b/src/appcali.cpp
@@ -116,79 +116,79 @@ AppCaliWindow::AppCaliWindow(QWidget *parent, const int &windowMode)
         CaliModeSet(Cali_Init);
         break;
     case modeAlignment:
-        this->setWindowTitle("Alignment Assistant");
+        this->setWindowTitle(tr("Alignment Assistant"));
         ui->graphicsView->setBackgroundBrush(QBrush(QColor("darkslategray")));
 
         if(bitmapText) {
-            headerBitmap->setPixmap(GenerateText({"       Depending on your desired layout,       ",
-                                                  "      your IR emitters should be aligned       ",
-                                                  "         to either one of the two sets         ",
-                                                  "               of colored boxes:               "}));
+            headerBitmap->setPixmap(GenerateText({tr("       Depending on your desired layout,       "),
+                                                  tr("      your IR emitters should be aligned       "),
+                                                  tr("         to either one of the two sets         "),
+                                                  tr("               of colored boxes:               ")}));
             headerBitmap->setPos(scene.sceneRect().center().x()     - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  scene.sceneRect().height() * 0.15  - (headerBitmap->boundingRect().center().y() * headerBitmap->scale()));
 
-            alignmentBitmapLeft = new QGraphicsPixmapItem(GenerateText({"      For Square Layout,     ",
-                                                                        "    the emitters should be   ",
-                                                                        "    placed at the top and    ",
-                                                                        "    bottom of the display;   ",
-                                                                        "each one being aligned to the"}));
+            alignmentBitmapLeft = new QGraphicsPixmapItem(GenerateText({tr("      For Square Layout,     "),
+                                                                        tr("    the emitters should be   "),
+                                                                        tr("    placed at the top and    "),
+                                                                        tr("    bottom of the display;   "),
+                                                                        tr("each one being aligned to the")}));
             alignmentBitmapLeft->setScale(GetTextScale(TextSmall));
             alignmentBitmapLeft->setPos(scene.sceneRect().width() * 0.02,
                                         (scene.sceneRect().height() * 0.3) + (alignmentBitmapLeft->boundingRect().center().y() * alignmentBitmapLeft->scale()));
-            alignmentBitmapColoredLeft = new QGraphicsPixmapItem(GenerateText({"      Red-colored boxes.     "}, QColor(255, 100, 100)));
+            alignmentBitmapColoredLeft = new QGraphicsPixmapItem(GenerateText({tr("      Red-colored boxes.     ")}, QColor(255, 100, 100)));
             alignmentBitmapColoredLeft->setScale(GetTextScale(TextSmall));
             alignmentBitmapColoredLeft->setPos(alignmentBitmapLeft->pos().x(),
                                                alignmentBitmapLeft->pos().y() + (alignmentBitmapLeft->boundingRect().height() * alignmentBitmapLeft->scale()));
 
-            alignmentBitmapRight = new QGraphicsPixmapItem(GenerateText({"     For Diamond Layout,     ",
-                                                                         "the emitters should be placed",
-                                                                         "  at the center of the four  ",
-                                                                         "    edges of the display;    ",
-                                                                         "each one being aligned to the"}));
+            alignmentBitmapRight = new QGraphicsPixmapItem(GenerateText({tr("     For Diamond Layout,     "),
+                                                                         tr("the emitters should be placed"),
+                                                                         tr("  at the center of the four  "),
+                                                                         tr("    edges of the display;    "),
+                                                                         tr("each one being aligned to the")}));
             alignmentBitmapRight->setScale(GetTextScale(TextSmall));
             alignmentBitmapRight->setPos(scene.sceneRect().width()   * 0.98   - (alignmentBitmapRight->boundingRect().width()      * alignmentBitmapRight->scale()),
                                          (scene.sceneRect().height() * 0.3) + (alignmentBitmapRight->boundingRect().center().y() * alignmentBitmapRight->scale()));
-            alignmentBitmapColoredRight = new QGraphicsPixmapItem(GenerateText({"     Green-colored boxes.    "}, QColor(100, 255, 100)));
+            alignmentBitmapColoredRight = new QGraphicsPixmapItem(GenerateText({tr("     Green-colored boxes.    ")}, QColor(100, 255, 100)));
             alignmentBitmapColoredRight->setScale(GetTextScale(TextSmall));
             alignmentBitmapColoredRight->setPos(alignmentBitmapRight->pos().x(),
                                                 alignmentBitmapRight->pos().y() + (alignmentBitmapRight->boundingRect().height() * alignmentBitmapRight->scale()));
 
-            tutorialBitmap = new QGraphicsPixmapItem(GenerateText({"Press ESC to exit alignment tool."}));
+            tutorialBitmap = new QGraphicsPixmapItem(GenerateText({tr("Press ESC to exit alignment tool.")}));
             tutorialBitmap->setScale(GetTextScale(TextSub));
             tutorialBitmap->setPos(scene.sceneRect().width() * 0.05,
                                    (scene.sceneRect().bottom() * 0.9) - (tutorialBitmap->boundingRect().center().y() * tutorialBitmap->scale()));
         } else {
-            headerText->setHtml("<p align=\"justify\">Depending on your desired layout,<br>"
-                                "your IR Emitters should be aligned<br>"
-                                "to either one of the two sets<br>"
-                                "of colored boxes:</p>");
+            headerText->setHtml(tr("<p align=\"justify\">Depending on your desired layout,<br>"
+                                   "your IR Emitters should be aligned<br>"
+                                   "to either one of the two sets<br>"
+                                   "of colored boxes:</p>"));
             headerText->setPos(scene.sceneRect().center().x()      - headerText->boundingRect().center().x(),
                                (scene.sceneRect().height() * 0.25) - headerText->boundingRect().center().y());
 
             alignmentTextLeft = new QGraphicsTextItem();
-            alignmentTextLeft->setHtml("<p align=\"justify\">For <b>Square Layout,</b><br>"
-                                       "the emitters should be<br>"
-                                       "placed at the top and<br>"
-                                       "bottom of the display;<br>"
-                                       "each one being aligned to the<br>"
-                                       "<p style=\"color: tomato\">Red-colored boxes.</p></p>");
+            alignmentTextLeft->setHtml(tr("<p align=\"justify\">For <b>Square Layout,</b><br>"
+                                          "the emitters should be<br>"
+                                          "placed at the top and<br>"
+                                          "bottom of the display;<br>"
+                                          "each one being aligned to the<br>"
+                                          "<p style=\"color: tomato\">Red-colored boxes.</p></p>"));
             alignmentTextLeft->setFont(QFont("Monospace", GetTextScale(TextSub)));
             alignmentTextLeft->setPos(scene.sceneRect().width() * 0.075,
                                       (scene.sceneRect().height() * 0.3) + alignmentTextLeft->boundingRect().center().y());
 
             alignmentTextRight = new QGraphicsTextItem();
-            alignmentTextRight->setHtml("<p align=\"justify\">For <b>Diamond Layout,</b><br>"
-                                        "the emitters should be placed<br>"
-                                        "at the center of the four<br>"
-                                        "edges of the display;<br>"
-                                        "each one being aligned to the</p>"
-                                        "<p style=\"color: palegreen\">Green-colored boxes.</p>");
+            alignmentTextRight->setHtml(tr("<p align=\"justify\">For <b>Diamond Layout,</b><br>"
+                                           "the emitters should be placed<br>"
+                                           "at the center of the four<br>"
+                                           "edges of the display;<br>"
+                                           "each one being aligned to the</p>"
+                                           "<p style=\"color: palegreen\">Green-colored boxes.</p>"));
             alignmentTextRight->setFont(QFont("Monospace", TextSub));
             alignmentTextRight->setPos(scene.sceneRect().width() * 0.70,
                                        (scene.sceneRect().height() * 0.3) + alignmentTextRight->boundingRect().center().y());
 
             tutorialText = new QGraphicsTextItem();
-            tutorialText->setPlainText("Press ESC to exit alignment tool.");
+            tutorialText->setPlainText(tr("Press ESC to exit alignment tool."));
             tutorialText->setFont(QFont("Monospace", TextSub));
             tutorialText->setPos(scene.sceneRect().width() * 0.05,
                                  (scene.sceneRect().bottom() * 0.9) - tutorialText->boundingRect().center().y());
@@ -273,38 +273,38 @@ AppCaliWindow::AppCaliWindow(QWidget *parent, const int &windowMode)
 
         break;
     case modeIRTest:
-        this->setWindowTitle("IR Emitters Test");
+        this->setWindowTitle(tr("IR Emitters Test"));
         ui->graphicsView->setBackgroundBrush(QBrush(QColor("midnightblue")));
 
         qreal scaleX = scene.sceneRect().width() / 1920.0;
         qreal scaleY = scene.sceneRect().height() / 1080.0;
 
         if(bitmapText) {
-            headerBitmap->setPixmap(GenerateText({"     The array of shapes displayed onscreen     ",
-                                                  "represents the emitters that the camera can see.",
-                                                  "   The colored points should move opposite to   ",
-                                                  "     your aim, and the gray circle should be    ",
-                                                  "          lining up with your gun sight.        "}));
+            headerBitmap->setPixmap(GenerateText({tr("     The array of shapes displayed onscreen     "),
+                                                  tr("represents the emitters that the camera can see."),
+                                                  tr("   The colored points should move opposite to   "),
+                                                  tr("     your aim, and the gray circle should be    "),
+                                                  tr("          lining up with your gun sight.        ")}));
             headerBitmap->setPos(scene.sceneRect().center().x()     - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  (scene.sceneRect().bottom() * 0.1) - (headerBitmap->boundingRect().center().y() * headerBitmap->scale()));
             scene.addItem(headerBitmap);
 
-            tutorialBitmap = new QGraphicsPixmapItem(GenerateText({"Press ESC to exit test mode."}));
+            tutorialBitmap = new QGraphicsPixmapItem(GenerateText({tr("Press ESC to exit test mode.")}));
             tutorialBitmap->setScale(GetTextScale(TextSub));
             tutorialBitmap->setPos(scene.sceneRect().center().x() - (tutorialBitmap->boundingRect().center().x() * tutorialBitmap->scale()),
                                    scene.sceneRect().bottom() * 0.85);
             scene.addItem(tutorialBitmap);
         } else {
-            headerText->setHtml("<p align=justify>The array of shapes onscreen<br>"
-                                "represents the emitters that the camera can see.<br>"
-                                "The points should move opposite to your aim,<br>"
-                                "and the gray circle should be lining up with your gun sight.</p>");
+            headerText->setHtml(tr("<p align=justify>The array of shapes onscreen<br>"
+                                   "represents the emitters that the camera can see.<br>"
+                                   "The points should move opposite to your aim,<br>"
+                                   "and the gray circle should be lining up with your gun sight.</p>"));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                (scene.sceneRect().bottom() * 0.1) - headerText->boundingRect().center().y());
             scene.addItem(headerText);
 
             tutorialText = new QGraphicsTextItem();
-            tutorialText->setPlainText("Press ESC to exit test mode.");
+            tutorialText->setPlainText(tr("Press ESC to exit test mode."));
             tutorialText->setFont(QFont("Monospace", GetTextScale(TextSub)));
             tutorialText->setPos(scene.sceneRect().center().x() - tutorialText->boundingRect().center().x(), scene.sceneRect().bottom() * 0.85);
             scene.addItem(tutorialText);
@@ -429,7 +429,7 @@ QPixmap AppCaliWindow::GenerateText(const QStringList &strings, const QColor &ti
 
         for(int i = 0; i < line.length(); i++)
             if(line.at(i) >= '!' && line.at(i) <= '~')
-                painter.drawPixmap(QPoint(8*i, 0), QPixmap(QString(":/testFont/testFont/%1").arg(line.at(i).unicode()), "PNG"));
+                painter.drawPixmap(QPoint(8*i, 0), QPixmap(QString(":/testFont/testFont/%1").arg((int)line.at(i).unicode()), "PNG"));
 
         painter.end();
     }
@@ -476,17 +476,17 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
         topOffset = -1, bottomOffset = -1, leftOffset = -1, rightOffset = -1, topLeftLed = -1, topRightLed = -1;
 
         if(bitmapText) {
-            caliStageBitmap->setPixmap( GenerateText({"Initialize Calibration:"}));
+            caliStageBitmap->setPixmap( GenerateText({tr("Initialize Calibration:")}));
             caliStageBitmap->setPos(scene.sceneRect().center().x()      - (caliStageBitmap->boundingRect().center().x() * caliStageBitmap->scale()),
                                     (scene.sceneRect().height() * 0.25) - (caliStageBitmap->boundingRect().center().y() * caliStageBitmap->scale()));
 
-            headerBitmap->setPixmap(    GenerateText({"Shoot at the target to start calibration."}));
+            headerBitmap->setPixmap(    GenerateText({tr("Shoot at the target to start calibration.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
 
-            tutorialBitmap->setPixmap(  GenerateText({"Calibration can be exited without changes",
-                                                      "  by pressing either Button A, Button B, ",
-                                                      "       or Button C (if available).       "}));
+            tutorialBitmap->setPixmap(  GenerateText({tr("Calibration can be exited without changes"),
+                                                      tr("  by pressing either Button A, Button B, "),
+                                                      tr("       or Button C (if available).       ")}));
             tutorialBitmap->setPos(scene.sceneRect().center().x()     - (tutorialBitmap->boundingRect().center().x() * tutorialBitmap->scale()),
                                    (scene.sceneRect().bottom() * 0.8) - (tutorialBitmap->boundingRect().center().y() * tutorialBitmap->scale()));
 
@@ -495,17 +495,17 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                 profileBitmaps[i]->setPixmap(GenerateText({caliTypesPrefixes.at(i)}));
             }
         } else {
-            caliStageText->setPlainText("Initialize Calibration:");
+            caliStageText->setPlainText(tr("Initialize Calibration:"));
             caliStageText->setPos(scene.sceneRect().center().x()      - caliStageText->boundingRect().center().x(),
                                   (scene.sceneRect().bottom() * 0.25) - caliStageText->boundingRect().center().y());
 
-            headerText->setPlainText("Shoot at the target to start calibration.");
+            headerText->setPlainText(tr("Shoot at the target to start calibration."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
 
-            tutorialText->setHtml("<p align=\"center\">Calibration can be exited without changes<br>"
-                                  "by pressing either <i>Button A,</i> <i>Button B,</i><br>"
-                                  "or <i>Button C (if available).</i></p>");
+            tutorialText->setHtml(tr("<p align=\"center\">Calibration can be exited without changes<br>"
+                                     "by pressing either <i>Button A,</i> <i>Button B,</i><br>"
+                                     "or <i>Button C (if available).</i></p>"));
             tutorialText->setPos(scene.sceneRect().center().x()     - tutorialText->boundingRect().center().x(),
                                  (scene.sceneRect().bottom() * 0.8) - tutorialText->boundingRect().center().y());
         }
@@ -518,34 +518,34 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                               scene.sceneRect().top() - (crosshairItem->boundingRect().center().y()*crosshairItem->scale()));
 
         if(bitmapText) {
-            caliStageBitmap->setPixmap(GenerateText({"Cali Step 1:"}));
+            caliStageBitmap->setPixmap(GenerateText({tr("Cali Step 1:")}));
             caliStageBitmap->setPos(scene.sceneRect().center().x()      - (caliStageBitmap->boundingRect().center().x() * caliStageBitmap->scale()),
                                     (scene.sceneRect().height() * 0.25) - (caliStageBitmap->boundingRect().center().y() * caliStageBitmap->scale()));
 
-            headerBitmap->setPixmap(GenerateText({"Shoot at the top edge of the screen."}));
+            headerBitmap->setPixmap(GenerateText({tr("Shoot at the top edge of the screen.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
 
-            tutorialBitmap->setPixmap(GenerateText({"The calibration process can be reset by pressing",
-                                                    "either Button A or Button B, and can be canceled",
-                                                    "      by pressing Button C (if available).      "}));
+            tutorialBitmap->setPixmap(GenerateText({tr("The calibration process can be reset by pressing"),
+                                                    tr("either Button A or Button B, and can be canceled"),
+                                                    tr("      by pressing Button C (if available).      ")}));
             tutorialBitmap->setPos(scene.sceneRect().center().x()     - (tutorialBitmap->boundingRect().center().x() * tutorialBitmap->scale()),
                                    (scene.sceneRect().bottom() * 0.8) - (tutorialBitmap->boundingRect().center().y() * tutorialBitmap->scale()));
 
             for(int i = 0; i < 6; i++)
                 profileBitmaps[i]->setVisible(true);
         } else {
-            caliStageText->setPlainText("Cali Step 1:");
+            caliStageText->setPlainText(tr("Cali Step 1:"));
             caliStageText->setPos(scene.sceneRect().center().x()      - caliStageText->boundingRect().center().x(),
                                   (scene.sceneRect().bottom() * 0.25) - caliStageText->boundingRect().center().y());
 
-            headerText->setPlainText("Shoot at the top edge of the screen.");
+            headerText->setPlainText(tr("Shoot at the top edge of the screen."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
 
-            tutorialText->setHtml("<p align=\"center\">The calibration process can be reset by pressing<br>"
-                                  "either <i>Button A</i> or <i>Button B,</i><br>"
-                                  "and can be canceled by pressing <i>Button C (if available).</i></p>");
+            tutorialText->setHtml(tr("<p align=\"center\">The calibration process can be reset by pressing<br>"
+                                     "either <i>Button A</i> or <i>Button B,</i><br>"
+                                     "and can be canceled by pressing <i>Button C (if available).</i></p>"));
             tutorialText->setPos(scene.sceneRect().center().x()     - tutorialText->boundingRect().center().x(),
                                  (scene.sceneRect().bottom() * 0.8) - tutorialText->boundingRect().center().y());
         }
@@ -556,15 +556,15 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                               scene.sceneRect().bottom()     - (crosshairItem->boundingRect().center().y()*crosshairItem->scale()));
         
         if(bitmapText) {
-            caliStageBitmap->setPixmap(GenerateText({"Cali Step 2:"}));
+            caliStageBitmap->setPixmap(GenerateText({tr("Cali Step 2:")}));
 
-            headerBitmap->setPixmap(GenerateText({"Shoot at the bottom edge of the screen."}));
+            headerBitmap->setPixmap(GenerateText({tr("Shoot at the bottom edge of the screen.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
         } else {
-            caliStageText->setPlainText("Cali Step 2:");
+            caliStageText->setPlainText(tr("Cali Step 2:"));
 
-            headerText->setPlainText("Shoot at the bottom edge of the screen.");
+            headerText->setPlainText(tr("Shoot at the bottom edge of the screen."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
         }
@@ -575,15 +575,15 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                               scene.sceneRect().center().y() - (crosshairItem->boundingRect().center().y() * crosshairItem->scale()));
 
         if(bitmapText) {
-            caliStageBitmap->setPixmap(GenerateText({"Cali Step 3:"}));
+            caliStageBitmap->setPixmap(GenerateText({tr("Cali Step 3:")}));
 
-            headerBitmap->setPixmap(GenerateText({"Shoot at the left edge of the screen."}));
+            headerBitmap->setPixmap(GenerateText({tr("Shoot at the left edge of the screen.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
         } else {
-            caliStageText->setPlainText("Cali Step 3:");
+            caliStageText->setPlainText(tr("Cali Step 3:"));
 
-            headerText->setPlainText("Shoot at the left edge of the screen.");
+            headerText->setPlainText(tr("Shoot at the left edge of the screen."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
         }
@@ -594,15 +594,15 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                               scene.sceneRect().center().y() - (crosshairItem->boundingRect().center().y()*crosshairItem->scale()));
 
         if(bitmapText) {
-            caliStageBitmap->setPixmap(GenerateText({"Cali Step 4:"}));
+            caliStageBitmap->setPixmap(GenerateText({tr("Cali Step 4:")}));
 
-            headerBitmap->setPixmap(GenerateText({"Shoot at the right edge of the screen."}));
+            headerBitmap->setPixmap(GenerateText({tr("Shoot at the right edge of the screen.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
         } else {
-            caliStageText->setPlainText("Cali Step 4:");
+            caliStageText->setPlainText(tr("Cali Step 4:"));
 
-            headerText->setPlainText("Shoot at the right edge of the screen.");
+            headerText->setPlainText(tr("Shoot at the right edge of the screen."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
         }
@@ -613,15 +613,15 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                               scene.sceneRect().center().y() - (crosshairItem->boundingRect().center().y()*crosshairItem->scale()));
 
         if(bitmapText) {
-            caliStageBitmap->setPixmap(GenerateText({"Cali Step 5:"}));
+            caliStageBitmap->setPixmap(GenerateText({tr("Cali Step 5:")}));
 
-            headerBitmap->setPixmap(GenerateText({"Shoot at the final target in the center."}));
+            headerBitmap->setPixmap(GenerateText({tr("Shoot at the final target in the center.")}));
             headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                  caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
         } else {
-            caliStageText->setPlainText("Cali Step 5:");
+            caliStageText->setPlainText(tr("Cali Step 5:"));
 
-            headerText->setPlainText("Shoot at the final target in the center.");
+            headerText->setPlainText(tr("Shoot at the final target in the center."));
             headerText->setPos(scene.sceneRect().center().x() - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()       + caliStageText->boundingRect().height());
         }
@@ -639,67 +639,67 @@ void AppCaliWindow::CaliModeSet(const int &caliStage)
                topLeftLed   >= -32768  &&  topLeftLed   <= 32768    &&
                topRightLed  >= -32768  &&  topRightLed  <= 32768) {
 
-                caliStageBitmap->setPixmap( GenerateText({"Verify New Calibration:"}));
+                caliStageBitmap->setPixmap( GenerateText({tr("Verify New Calibration:")}));
                 caliStageBitmap->setPos(scene.sceneRect().center().x()      - (caliStageBitmap->boundingRect().center().x() * caliStageBitmap->scale()),
                                         scene.sceneRect().height() * 0.15   - (caliStageBitmap->boundingRect().center().y() * caliStageBitmap->scale()));
 
-                headerBitmap->setPixmap(GenerateText({"    Confirm that the bullseye     ",
-                                                      "   lines up with the gun sight.   ",
-                                                      "If this calibration is acceptable,",
-                                                      "  confirm by pulling the trigger. "}));
+                headerBitmap->setPixmap(GenerateText({tr("    Confirm that the bullseye     "),
+                                                      tr("   lines up with the gun sight.   "),
+                                                      tr("If this calibration is acceptable,"),
+                                                      tr("  confirm by pulling the trigger. ")}));
                 headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                      caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
 
-                tutorialBitmap->setPixmap(GenerateText({"       If this target accuracy isn't desirable,      ",
-                                                        "          press either Button A or Button B          ",
-                                                        "         to restart the calibration process.         ",
-                                                        "",
-                                                        "[You can also exit calibration without saving changes",
-                                                        "        by pressing Button C (if available).]        "}));
+                tutorialBitmap->setPixmap(GenerateText({tr("       If this target accuracy isn't desirable,      "),
+                                                        tr("          press either Button A or Button B          "),
+                                                        tr("         to restart the calibration process.         "),
+                                                        tr(""),
+                                                        tr("[You can also exit calibration without saving changes"),
+                                                        tr("        by pressing Button C (if available).]        ")}));
                 tutorialBitmap->setPos(scene.sceneRect().center().x()       - (tutorialBitmap->boundingRect().center().x() * tutorialBitmap->scale()),
                                        (scene.sceneRect().bottom() * 0.8)   - (tutorialBitmap->boundingRect().center().y() * tutorialBitmap->scale()));
             } else if(topLeftLed == -1 || topRightLed == -1) {
-                caliStageBitmap->setPixmap( GenerateText({"Verify New Calibration:"}));
+                caliStageBitmap->setPixmap( GenerateText({tr("Verify New Calibration:")}));
                 caliStageBitmap->setPos(scene.sceneRect().center().x()      - (caliStageBitmap->boundingRect().center().x() * caliStageBitmap->scale()),
                                         scene.sceneRect().height() * 0.15   - (caliStageBitmap->boundingRect().center().y() * caliStageBitmap->scale()));
 
-                tutorialBitmap->setPixmap(GenerateText({""}));
+                tutorialBitmap->setPixmap(GenerateText({tr("")}));
             } else {
-                caliStageBitmap->setPixmap(GenerateText({"WARNING: Possibly Malformed Calibration!!"}, QColor(225,25,25)));
+                caliStageBitmap->setPixmap(GenerateText({tr("WARNING: Possibly Malformed Calibration!!")}, QColor(225,25,25)));
                 caliStageBitmap->setPos(scene.sceneRect().center().x()      - (caliStageBitmap->boundingRect().center().x() * caliStageBitmap->scale()),
                                         scene.sceneRect().height() * 0.15   - (caliStageBitmap->boundingRect().center().y() * caliStageBitmap->scale()));
 
-                headerBitmap->setPixmap(GenerateText({"  The current pending values for this profile  ",
-                                                      "will likely cause incorrect or broken tracking."},
+                headerBitmap->setPixmap(GenerateText({tr("  The current pending values for this profile  "),
+                                                      tr("will likely cause incorrect or broken tracking.")},
                                                      QColor(225,25,25)));
                 headerBitmap->setPos(scene.sceneRect().center().x() - (headerBitmap->boundingRect().center().x() * headerBitmap->scale()),
                                      caliStageBitmap->pos().y()     + (caliStageBitmap->boundingRect().height()  * caliStageBitmap->scale()));
 
-                tutorialBitmap->setPixmap(GenerateText({"  Press Button A or Button B to restart calibration, ",
-                                                        "   or pull trigger to continue with these settings.  ",
-                                                        "",
-                                                        "[You can also exit calibration without saving changes",
-                                                        "        by pressing Button C (if available).]        "},
+                tutorialBitmap->setPixmap(GenerateText({tr("  Press Button A or Button B to restart calibration, "),
+                                                        tr("   or pull trigger to continue with these settings.  "),
+                                                        tr(""),
+                                                        tr("[You can also exit calibration without saving changes"),
+                                                        tr("        by pressing Button C (if available).]        ")},
                                                        QColor(225,25,25)));
                 tutorialBitmap->setPos(scene.sceneRect().center().x()       - (tutorialBitmap->boundingRect().center().x() * tutorialBitmap->scale()),
                                        (scene.sceneRect().bottom() * 0.8)   - (tutorialBitmap->boundingRect().center().y() * tutorialBitmap->scale()));
             }
         } else {
-            caliStageText->setPlainText("Verify New Calibration:");
+            caliStageText->setPlainText(tr("Verify New Calibration:"));
             caliStageText->setPos(scene.sceneRect().center().x()        - caliStageText->boundingRect().center().x(),
                                   (scene.sceneRect().bottom() * 0.25)   - caliStageText->boundingRect().center().y());
 
-            headerText->setHtml("<p align=\"center\">Confirm that the bullseye lines up with gun sight.<br>"
-                                "If this calibration is acceptable, confirm by pulling the trigger.</p>");
+            headerText->setHtml(tr("<p align=\"center\">Confirm that the bullseye lines up with gun sight.<br>"
+                                   "If this calibration is acceptable, confirm by pulling the trigger.</p>"));
             headerText->setPos(scene.sceneRect().center().x()   - headerText->boundingRect().center().x(),
                                caliStageText->pos().y()         + caliStageText->boundingRect().height());
 
-            tutorialText->setHtml("<p align=\"center\">If the target accuracy isn't desirable,<br>"
-                                  "press either <i>Button A</i> or <i>Button B</i><br>"
-                                  "to restart the calibration process.<br>"
-                                  "<br>"
-                                  "[You can also exit calibration without saving changes<br>"
-                                  "by pressing <i>Button C (if available).</i>]</p>");
+            tutorialText->setHtml(tr("<p align=\"center\">If the target accuracy isn't desirable,<br>"
+                                     "press either <i>Button A</i> or <i>Button B</i><br>"
+                                     "to restart the calibration process.<br>"
+                                     "<br>"
+                                     "[You can also exit calibration without saving changes<br>"
+                                     "by pressing <i>Button C (if available).</i>]</p>"));
             tutorialText->setPos(scene.sceneRect().center().x() - tutorialText->boundingRect().center().x(),
                                  (scene.sceneRect().bottom() * 0.8) - tutorialText->boundingRect().center().y());
         }

--- a/src/appmainwindow.cpp
+++ b/src/appmainwindow.cpp
@@ -51,14 +51,14 @@ guiWindow::guiWindow(QWidget *parent)
         externalProg->start("/usr/bin/groups", args);
         externalProg->waitForFinished();
         if(!externalProg->readAllStandardOutput().contains("dialout")) {
-            QMessageBox::critical(this, "ERROR: User doesn't have serial permissions!",
-                                        "Currently, your user is not allowed to have access to serial devices.\n\n"
+            QMessageBox::critical(this, tr("ERROR: User doesn't have serial permissions!"),
+                                        tr("Currently, your user is not allowed to have access to serial devices.\n\n"
                                         "To add yourself to the right group, run this command in a terminal and then re-login to your session:\n\n"
-                                        "sudo usermod -aG dialout " + qEnvironmentVariable("USER"));
+                                        "sudo usermod -aG dialout ") + qEnvironmentVariable("USER"));
             exit(0);
         }
     } else {
-        QMessageBox::critical(this, "ERROR: Running as root is not allowed!", "Please run the OpenFIRE app as a normal user.");
+        QMessageBox::critical(this, tr("ERROR: Running as root is not allowed!"), tr("Please run the OpenFIRE app as a normal user."));
         exit(2);
     }
 #endif
@@ -158,44 +158,44 @@ guiWindow::guiWindow(QWidget *parent)
             btnFuncBox[slot][1][i].installEventFilter(this);
             switch(slot) {
             case 0:
-                btnFuncBox[slot][0][i].setAccessibleName(QString("Onscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing at the screen.</b></p>"
-                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
-                                                            "three available device outputs that the gun presents to the connected device.</p>")
-                                                            .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setAccessibleName(QString("Onscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing at the screen.</b></p>"
-                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
-                                                            "three available device outputs that the gun presents to the connected device.</p>")
-                                                            .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setAccessibleName(tr("Onscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(tr("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing at the screen.</b></p>"
+                                                       "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                       "three available device outputs that the gun presents to the connected device.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(tr("Onscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(tr("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing at the screen.</b></p>"
+                                                       "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                       "three available device outputs that the gun presents to the connected device.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
                 break;
             case 1:
-                btnFuncBox[slot][0][i].setAccessibleName(QString("Offscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing outside of the screen.</b></p>"
-                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
-                                                            "three available device outputs that the gun presents to the connected device.</p>")
-                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setAccessibleName(QString("Offscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing outside of the screen.</b></p>"
-                                                            "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
-                                                            "three available device outputs that the gun presents to the connected device.</p>")
-                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setAccessibleName(tr("Offscreen Button Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(tr("<p>Select the type of button that <i>%1</i> will function as <b>when the gun is pointing outside of the screen.</b></p>"
+                                                       "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                       "three available device outputs that the gun presents to the connected device.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(tr("Offscreen Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(tr("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is pointing outside of the screen.</b></p>"
+                                                       "<p>Each available input defined in the current <i>Board Layout</i> can be defined as a button press for one of the "
+                                                       "three available device outputs that the gun presents to the connected device.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
                 break;
             case 2:
-                btnFuncBox[slot][0][i].setAccessibleName(QString("Gamepad Mode Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][0][i].setWhatsThis(QString("<p>Select the type of button that <i>%1</i> will function as <b>when the gun set to Gamepad Output Mode.</b></p>"
-                                                            "<p>Only Gamepad-type outputs are available for Gamepad Output Mode, which can be set via "
-                                                            "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
-                                                            "<tt>M0x1</tt>.</p>")
-                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setAccessibleName(QString("Gamepad Mode Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
-                btnFuncBox[slot][1][i].setWhatsThis(QString("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is set to Gamepad Output Mode.</b></p>"
-                                                            "<p>Only Gamepad buttons are available to be mapped for Gamepad Output Mode, which can be set via "
-                                                            "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
-                                                            "<tt>M0x1</tt>.</p>"
-                                                            "<p><b>NOTE:</b> When connected to the MiSTer FPGA device, these mappings will NOT be reflected, "
-                                                            "as OpenFIRE has a hard-coded button layout specifically optimized for the MiSTer ecosystem.</p>")
-                                                        .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setAccessibleName(tr("Gamepad Mode Output Type for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][0][i].setWhatsThis(tr("<p>Select the type of button that <i>%1</i> will function as <b>when the gun set to Gamepad Output Mode.</b></p>"
+                                                       "<p>Only Gamepad-type outputs are available for Gamepad Output Mode, which can be set via "
+                                                       "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
+                                                       "<tt>M0x1</tt>.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setAccessibleName(tr("Gamepad Mode Button Mapping for %1").arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
+                btnFuncBox[slot][1][i].setWhatsThis(tr("<p>Select the output that <i>%1</i> will send to the connected device <b>when the gun is set to Gamepad Output Mode.</b></p>"
+                                                       "<p>Only Gamepad buttons are available to be mapped for Gamepad Output Mode, which can be set via "
+                                                       "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
+                                                       "<tt>M0x1</tt>.</p>"
+                                                       "<p><b>NOTE:</b> When connected to the MiSTer FPGA device, these mappings will NOT be reflected, "
+                                                       "as OpenFIRE has a hard-coded button layout specifically optimized for the MiSTer ecosystem.</p>")
+                                                    .arg(App_Common::OFPresets.boardInputs_sortedStr[i+1]));
                 break;
             }
 
@@ -239,7 +239,7 @@ guiWindow::guiWindow(QWidget *parent)
     ui->presetsBox->setVisible(false);
     ui->solenoidTempBox->setVisible(false);
 
-    statusBar()->showMessage("Welcome to the OpenFIRE app!", 3000);
+    statusBar()->showMessage(tr("Welcome to the OpenFIRE app!"), 3000);
 
     statusProgressBar = new QProgressBar();
     statusProgressBar->setVisible(false);
@@ -411,11 +411,11 @@ void guiWindow::DiffUpdate()
             ++settingsDiff;
 
     if(settingsDiff) {
-        ui->confirmButton->setText("Save and Send Settings");
+        ui->confirmButton->setText(tr("Save and Send Settings"));
         ui->confirmButton->setEnabled(true);
         ui->confirmButton->setIcon(QIcon::fromTheme("document-save"));
     } else {
-        ui->confirmButton->setText("[Nothing To Save]");
+        ui->confirmButton->setText(tr("[Nothing To Save]"));
         ui->confirmButton->setEnabled(false);
         ui->confirmButton->setIcon(QIcon());
     }
@@ -439,10 +439,10 @@ void guiWindow::LabelsUpdate()
 
     ui->tmp36Label->setStyleSheet("");
     if(App_Common::inputsMap.value(OF_Const::tempPin) >= 0) {
-        ui->tmp36Label->setText("Temperature Read...");
+        ui->tmp36Label->setText(tr("Temperature Read..."));
         ui->tmp36Label->setEnabled(true);
     } else {
-        ui->tmp36Label->setText("Temperature Sensor (N/C)");
+        ui->tmp36Label->setText(tr("Temperature Sensor (N/C)"));
         ui->tmp36Label->setEnabled(false);
     }
 
@@ -451,7 +451,7 @@ void guiWindow::LabelsUpdate()
     if(App_Common::inputsMap.value(OF_Const::ledB) >= 0) ui->blueLedTestBtn->setEnabled(true);  else ui->blueLedTestBtn->setEnabled(false);
     if(App_Common::inputsMap.value(OF_Const::analogX) >= 0 && App_Common::inputsMap.value(OF_Const::analogY) >= 0)
         ui->analogGroup->setEnabled(true),  ui->aPosLabel->clear();
-    else ui->analogGroup->setEnabled(false), ui->aPosLabel->setText("Not Connected");
+    else ui->analogGroup->setEnabled(false), ui->aPosLabel->setText(tr("Not Connected"));
 
     ui->boardLabel->setText(PrettifyName(App_Common::tinyUSBtable.tinyUSBname));
 }
@@ -498,7 +498,7 @@ void guiWindow::NewCaliWindow(const int &type) {
     case AppCaliWindow::modeIRTest:
         ui->buttonsTestArea->setEnabled(false);
         ui->confirmButton->setEnabled(false);
-        ui->confirmButton->setText("[Disabled while in Test Mode]");
+        ui->confirmButton->setText(tr("[Disabled while in Test Mode]"));
         ui->confirmButton->setIcon(QIcon());
         ui->pinsTab->setEnabled(false);
         ui->settingsTab->setEnabled(false);
@@ -517,8 +517,8 @@ void guiWindow::NewCaliWindow(const int &type) {
 
 void guiWindow::on_confirmButton_clicked()
 {
-    QMessageBox messageBox(QMessageBox::Information, "Commit Confirmation", "Are these settings okay?", QMessageBox::Yes | QMessageBox::No);
-    messageBox.setInformativeText("These settings will be committed to your lightgun. Is that okay?");
+    QMessageBox messageBox(QMessageBox::Information, tr("Commit Confirmation"), tr("Are these settings okay?"), QMessageBox::Yes | QMessageBox::No);
+    messageBox.setInformativeText(tr("These settings will be committed to your lightgun. Is that okay?"));
 
     if(messageBox.exec() == QMessageBox::Yes) {
         serialActive = true;
@@ -527,7 +527,7 @@ void guiWindow::on_confirmButton_clicked()
         ui->comPortSelector->setEnabled(false);
 
         if(serial.CommitSettings()) {
-            statusBar()->showMessage("Sent settings successfully!", 5000);
+            statusBar()->showMessage(tr("Sent settings successfully!"), 5000);
             ui->confirmButton->setEnabled(false);
             ui->confirmButton->setIcon(QIcon());
 
@@ -568,7 +568,7 @@ void guiWindow::on_confirmButton_clicked()
         ui->tabWidget->setEnabled(true);
         ui->comPortSelector->setEnabled(true);
         serialActive = false;
-    } else { statusBar()->showMessage("Save operation canceled.", 3000); }
+    } else { statusBar()->showMessage(tr("Save operation canceled."), 3000); }
 }
 
 
@@ -630,10 +630,10 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 renameBtn.at(i)->installEventFilter(this);
                 renameBtn.at(i)->setProperty("slot", i);
                 renameBtn.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                renameBtn.at(i)->setAccessibleName(QString("Rename Profile %1").arg(i+1));
-                renameBtn.at(i)->setWhatsThis("<p>Click to rename this Calibration Profile.</p>"
-                                              "<p>Aside from differentiating between different profiles for different displays, "
-                                              "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>");
+                renameBtn.at(i)->setAccessibleName(tr("Rename Profile %1").arg(i+1));
+                renameBtn.at(i)->setWhatsThis(tr("<p>Click to rename this Calibration Profile.</p>"
+                                                 "<p>Aside from differentiating between different profiles for different displays, "
+                                                 "Cali Profile names are displayed in Pause Mode when using a compatible <i>I2C Display.</i></p>"));
                 connect(renameBtn.at(i), &QPushButton::clicked, this, &guiWindow::renameBoxes_clicked);
 
                 selectedProfile << new QRadioButton(QString("%1. %2").arg(i+1).arg(App_Common::profilesTable.at(i).profName));
@@ -656,13 +656,13 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 irSens.at(i)->setProperty("slot", i);
                 irSens.at(i)->setProperty("type", App_Common::pBoxIRsens);
                 irSens.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                irSens.at(i)->setAccessibleName(QString("Camera Sensitivity for Profile %1").arg(i+1));
-                irSens.at(i)->setWhatsThis("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
-                                           "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
-                                           "adjusting this setting higher might fix issues with tracking.<br>"
-                                           "Conversely, setting sensitivity too high may cause indirect IR sources "
-                                           "(such as sunlight or IR bouncing off of reflective surfaces) "
-                                           "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>");
+                irSens.at(i)->setAccessibleName(tr("Camera Sensitivity for Profile %1").arg(i+1));
+                irSens.at(i)->setWhatsThis(tr("<p>This setting determines the sensitivity of the IR Camera for this Calibration Profile.</p>"
+                                              "<p>If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), "
+                                              "adjusting this setting higher might fix issues with tracking.<br>"
+                                              "Conversely, setting sensitivity too high may cause indirect IR sources "
+                                              "(such as sunlight or IR bouncing off of reflective surfaces) "
+                                              "to be picked up instead, causing the cursor to jitter or erratically jump across the screen.</p>"));
                 connect(irSens.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
 
                 runMode << new QComboBox();
@@ -672,12 +672,12 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 runMode.at(i)->setProperty("slot", i);
                 runMode.at(i)->setProperty("type", App_Common::pBoxRunMode);
                 runMode.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                runMode.at(i)->setAccessibleName(QString("Camera Position Averaging Mode for Profile %1").arg(i+1));
-                runMode.at(i)->setWhatsThis("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
-                                            "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
-                                            "at the cost of a small increase in latency; conversely, disabling this position averaging can "
-                                            "reduce latency, at the cost of some added jitter in mouse movement.</p>"
-                                            "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>");
+                runMode.at(i)->setAccessibleName(tr("Camera Position Averaging Mode for Profile %1").arg(i+1));
+                runMode.at(i)->setWhatsThis(tr("<p>This setting determines the cursor Averaging Mode for this Calibration Profile.</p>"
+                                               "<p>The movement of the aiming cursor can be smoothed out by averaging a select number of frames, "
+                                               "at the cost of a small increase in latency; conversely, disabling this position averaging can "
+                                               "reduce latency, at the cost of some added jitter in mouse movement.</p>"
+                                               "<p>The default is <b>1-Frame Avg</b>, which should be the preferred balance for most people.</p>"));
                 connect(runMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
 
                 layoutMode << new QComboBox();
@@ -687,17 +687,17 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 layoutMode.at(i)->setProperty("slot", i);
                 layoutMode.at(i)->setProperty("type", App_Common::pBoxLayout);
                 layoutMode.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                layoutMode.at(i)->setAccessibleName(QString("IR Emitter Layout for Profile %1").arg(i+1));
-                layoutMode.at(i)->setWhatsThis("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
-                                               "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
-                                               "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
-                                               "which uses one emitter at the center of each side of the display.</p>"
-                                               "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
-                                               "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
-                                               "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
-                                               "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
-                                               "<p>If unsure, use <b>Square Layout</b> "
-                                               "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>");
+                layoutMode.at(i)->setAccessibleName(tr("IR Emitter Layout for Profile %1").arg(i+1));
+                layoutMode.at(i)->setWhatsThis(tr("<p>This setting determines the IR Layout to be used with this Calibration Profile.</p>"
+                                                  "<p>Each Cali Profile can be set to use either the <i>Square Layout,</i> "
+                                                  "which uses two pairs of emitters on the top and bottom, and <i>Diamond Layout,</i> "
+                                                  "which uses one emitter at the center of each side of the display.</p>"
+                                                  "<p><i>Square Layout</i> generally has much higher accuracy at any angle and allows for "
+                                                  "playing closer to the screen or using external Fish Eye lenses without viewport distortion, "
+                                                  "while <i>Diamond Layout</i> is for screen compatibility with certain legacy lightgun systems "
+                                                  "(allowing OpenFIRE guns to play with such other lightgun systems on the same display).</p>"
+                                                  "<p>If unsure, use <b>Square Layout</b> "
+                                                  "(unless you also use a different brand of lightgun that needs a diamond IR layout to function).</p>"));
                 connect(layoutMode.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
 
                 aspectRatio << new QComboBox();
@@ -707,16 +707,16 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 aspectRatio.at(i)->setProperty("slot", i);
                 aspectRatio.at(i)->setProperty("type", App_Common::pBoxAR);
                 aspectRatio.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                aspectRatio.at(i)->setAccessibleName(QString("Aspect Ratio Correction for Profile %1").arg(i+1));
-                aspectRatio.at(i)->setWhatsThis("<p>This setting determines the type of Aspect Ratio Correction used for this Profile when <i>4:3 Mode</i> is set.</p>"
-                                                "<p>When <a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
-                                                "<tt>M3x1</tt> is received, the firmware stretches the effective range for fullscreen applications in Windows "
-                                                "that runs in resolutions <b>narrower</b> than the full display width/height; "
-                                                "this setting determines the stretch factor that will be used for these 4:3 applications.</p>"
-                                                "<p>Do note that this restriction exclusively applies to the <b>Windows Operating System ONLY "
-                                                "for legacy applications that DON'T support the monitor's full resolution;</b> <i>Linux-based systems</i> and games run via <i>Wine/Proton</i> "
-                                                "<b>do not need this workaround,</b> except for certain applications like <i>CXBX-Reloaded</i> that don't scale down the effective range correctly for 4:3 content.</p>"
-                                                "<p>If unsure, set to <b>the aspect ratio of your display.</b> Setting to <i>4:3</i> effectively disables range stretching when toggled.</p>");
+                aspectRatio.at(i)->setAccessibleName(tr("Aspect Ratio Correction for Profile %1").arg(i+1));
+                aspectRatio.at(i)->setWhatsThis(tr("<p>This setting determines the type of Aspect Ratio Correction used for this Profile when <i>4:3 Mode</i> is set.</p>"
+                                                   "<p>When <a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands'><span style=' text-decoration: underline; color:#8ab4f8;'>Serial command</span></a> "
+                                                   "<tt>M3x1</tt> is received, the firmware stretches the effective range for fullscreen applications in Windows "
+                                                   "that runs in resolutions <b>narrower</b> than the full display width/height; "
+                                                   "this setting determines the stretch factor that will be used for these 4:3 applications.</p>"
+                                                   "<p>Do note that this restriction exclusively applies to the <b>Windows Operating System ONLY "
+                                                   "for legacy applications that DON'T support the monitor's full resolution;</b> <i>Linux-based systems</i> and games run via <i>Wine/Proton</i> "
+                                                   "<b>do not need this workaround,</b> except for certain applications like <i>CXBX-Reloaded</i> that don't scale down the effective range correctly for 4:3 content.</p>"
+                                                   "<p>If unsure, set to <b>the aspect ratio of your display.</b> Setting to <i>4:3</i> effectively disables range stretching when toggled.</p>"));
                 connect(aspectRatio.at(i), SIGNAL(activated(int)), this, SLOT(profileBoxes_activated(int)));
 
                 color << new QPushButton();
@@ -725,18 +725,18 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
                 color.at(i)->installEventFilter(this);
                 color.at(i)->setProperty("slot", i);
                 color.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                color.at(i)->setAccessibleName(QString("Profile Menu Color for Cali Profile %1").arg(i+1));
-                color.at(i)->setWhatsThis("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
-                                          "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
-                                          "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>");
+                color.at(i)->setAccessibleName(tr("Profile Menu Color for Cali Profile %1").arg(i+1));
+                color.at(i)->setWhatsThis(tr("<p>Open a window to select the color used to represent this profile in <i>Pause Mode.</i></p>"
+                                             "<p>Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, "
+                                             "which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.</p>"));
                 connect(color.at(i), &QPushButton::clicked, this, &guiWindow::colorBoxes_clicked);
 
-                caliBtn << new QPushButton(QString("Calibrate Profile %1").arg(i+1));
+                caliBtn << new QPushButton(tr("Calibrate Profile %1").arg(i+1));
                 caliBtn.at(i)->installEventFilter(this);
                 caliBtn.at(i)->setProperty("slot", i);
                 caliBtn.at(i)->setProperty("trackable", App_Common::trackProfileItem);
-                caliBtn.at(i)->setAccessibleName(QString("Open Calibration Window for Cali Profile %1").arg(i+1));
-                caliBtn.at(i)->setWhatsThis("Click to start the calibration process for this profile.");
+                caliBtn.at(i)->setAccessibleName(tr("Open Calibration Window for Cali Profile %1").arg(i+1));
+                caliBtn.at(i)->setWhatsThis(tr("Click to start the calibration process for this profile."));
                 connect(caliBtn.at(i), &QPushButton::clicked, this, &guiWindow::caliBtns_clicked);
 
                 topOffset.at(i)     ->setAlignment(Qt::AlignCenter);
@@ -845,11 +845,11 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
 
                 pinLabel.at(i)->setEnabled(false);
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin No. %1.\n\n"
-                                                   "Blue pin numbers are members of I2C0.\n"
-                                                   "Orange are members of I2C1.\n"
-                                                   "Purple pin numbers can automatically select any I2C channel in software.\n"
-                                                   "Gray cannot use I2C devices.").arg(i));
+                pinLabel.at(i)->setToolTip(tr("GPIO Pin No. %1.\n\n"
+                                              "Blue pin numbers are members of I2C0.\n"
+                                              "Orange are members of I2C1.\n"
+                                              "Purple pin numbers can automatically select any I2C channel in software.\n"
+                                              "Gray cannot use I2C devices.").arg(i));
             }
 
             if(App_Common::board.version.indexOf('-') > -1) {
@@ -1006,7 +1006,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
             ui->productNameInput->setText(App_Common::tinyUSBtable.tinyUSBname);
 
             ui->tabWidget->setCurrentIndex(0);
-            ui->comPortSelector->setItemText(0, "[Disconnect Current Device]");
+            ui->comPortSelector->setItemText(0, tr("[Disconnect Current Device]"));
 
         } else ui->comPortSelector->setCurrentIndex(0);
 
@@ -1027,7 +1027,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         ui->tabWidget->setEnabled(false);
 
         if(ui->comPortSelector->count() > 0)
-            ui->comPortSelector->setItemText(0, "[Select a Device to Configure]");
+            ui->comPortSelector->setItemText(0, tr("[Select a Device to Configure]"));
 
         if(serial.port.isOpen())
             serial.Disconnect();
@@ -1035,7 +1035,7 @@ void guiWindow::on_comPortSelector_currentTextChanged(const QString &text)
         // reset temp label stylesheet to neutral
         ui->tmp36Label->setStyleSheet("");
         ui->confirmButton->setEnabled(false);
-        ui->confirmButton->setText("[Currently Not Connected]");
+        ui->confirmButton->setText(tr("[Currently Not Connected]"));
         ui->confirmButton->setIcon(QIcon());
     }
     serialActive = false;
@@ -1089,10 +1089,10 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                     // channels mismatched, unmap the other pin
                     if(btnRequest == OF_Const::camSDA) {
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                        ui->statusBar->showMessage(tr("Camera pins are not on the same I2C channel! Please check camera pins' mappings."), 10000);
                     } else {
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                        ui->statusBar->showMessage(tr("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings."), 10000);
                     }
                 }
                 // check that opposite I2C type SDA isn't mapped to this I2C channel
@@ -1102,7 +1102,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                        (pinCapabilityMap->second.at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (pinCapabilityMap->second.at(App_Common::inputsMap.value(OF_Const::periphSDA)) & OF_Const::pinIsI2C1)) {
                         // channels matched, unmap peripheral data
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SDA.", 10000);
+                        ui->statusBar->showMessage(tr("Camera and Peripheral Data pins clashed! Please remap Peripheral SDA."), 10000);
                     }
                     break;
                 case OF_Const::periphSDA:
@@ -1110,7 +1110,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                        (pinCapabilityMap->second.at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (pinCapabilityMap->second.at(App_Common::inputsMap.value(OF_Const::camSDA)) & OF_Const::pinIsI2C1)) {
                         // channels matched, unmap peripheral data
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SDA.", 10000);
+                        ui->statusBar->showMessage(tr("Camera and Peripheral Data pins clashed! Please remap Camera SDA."), 10000);
                     }
                     break;
                 }
@@ -1121,10 +1121,10 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                     // channels mismatched, unmap the other pin
                     if(btnRequest == OF_Const::camSCL) {
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera pins are not on the same I2C channel! Please check camera pins' mappings.", 10000);
+                        ui->statusBar->showMessage(tr("Camera pins are not on the same I2C channel! Please check camera pins' mappings."), 10000);
                     } else {
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSDA))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings.", 10000);
+                        ui->statusBar->showMessage(tr("Peripheral pins are not on the same I2C channel! Please check peripheral pins' mappings."), 10000);
                     }
                 }
                 // check that opposite I2C type SCL isn't mapped to this I2C channel
@@ -1134,7 +1134,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                        (pinCapabilityMap->second.at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (pinCapabilityMap->second.at(App_Common::inputsMap.value(OF_Const::periphSCL)) & OF_Const::pinIsI2C1)) {
                         // channels matched, unmap peripheral data
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::periphSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Peripheral SCL.", 10000);
+                        ui->statusBar->showMessage(tr("Camera and Peripheral Data pins clashed! Please remap Peripheral SCL."), 10000);
                     }
                     break;
                 case OF_Const::periphSCL:
@@ -1142,7 +1142,7 @@ void guiWindow::pinBoxes_currentIndexChanged(int index)
                        (pinCapabilityMap->second.at(sender()->property("slot").toInt()) & OF_Const::pinIsI2C1) == (pinCapabilityMap->second.at(App_Common::inputsMap.value(OF_Const::camSCL)) & OF_Const::pinIsI2C1)) {
                         // channels matched, unmap peripheral data
                         pinBoxes.at(App_Common::inputsMap.value(OF_Const::camSCL))->setCurrentIndex(OF_Const::btnUnmapped+1);
-                        ui->statusBar->showMessage("Camera and Peripheral Data pins clashed! Please remap Camera SCL.", 10000);
+                        ui->statusBar->showMessage(tr("Camera and Peripheral Data pins clashed! Please remap Camera SCL."), 10000);
                     }
                     break;
                 }
@@ -1589,8 +1589,8 @@ void guiWindow::on_invertStaticPixelsBox_stateChanged(int arg1)
 {
     App_Common::boolSettings[App_Common::dataCurrent][OF_Const::invertStaticPixels] = arg1;
 
-    if(arg1) ui->customLEDstaticSpinbox->setPrefix("Last ");
-    else     ui->customLEDstaticSpinbox->setPrefix("First ");
+    if(arg1) ui->customLEDstaticSpinbox->setPrefix(tr("Last "));
+    else     ui->customLEDstaticSpinbox->setPrefix(tr("First "));
 
     DiffUpdate();
 }
@@ -1763,8 +1763,8 @@ void guiWindow::renameBoxes_clicked()
 {
     // TODO: limit character length in the text dialog - for now, just use up to 15 characters.
     QString newLabel = QInputDialog::getText(this,
-                                             "Input Name",
-                                             QString("Set name for Calibration Profile %1").arg(sender()->property("slot").toInt()+1));
+                                             tr("Input Name"),
+                                             tr("Set name for Calibration Profile %1").arg(sender()->property("slot").toInt()+1));
 
     if(!newLabel.isEmpty()) {
         selectedProfile[sender()->property("slot").toInt()]->setText(QString("%1. %2").arg(sender()->property("slot").toInt()+1).arg(newLabel.left(15)));
@@ -1826,7 +1826,7 @@ void guiWindow::on_rumbleTestBtn_clicked()
 {
     char buf[2] = { (char)OF_Const::sTestRumble, true };
     if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Sent a rumble test pulse.", 2500);
+        ui->statusBar->showMessage(tr("Sent a rumble test pulse."), 2500);
 }
 
 
@@ -1834,7 +1834,7 @@ void guiWindow::on_solenoidTestBtn_clicked()
 {
     char buf[2] = { (char)OF_Const::sTestSolenoid, true };
     if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Sent a solenoid test pulse.", 2500);
+        ui->statusBar->showMessage(tr("Sent a solenoid test pulse."), 2500);
 }
 
 
@@ -1842,7 +1842,7 @@ void guiWindow::on_redLedTestBtn_clicked()
 {
     char buf[2] = { (char)OF_Const::sTestLEDR, true };
     if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Red.", 2500);
+        ui->statusBar->showMessage(tr("Set LED to Red."), 2500);
 }
 
 
@@ -1850,7 +1850,7 @@ void guiWindow::on_greenLedTestBtn_clicked()
 {
     char buf[2] = { (char)OF_Const::sTestLEDG, true };
     if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Green.", 2500);
+        ui->statusBar->showMessage(tr("Set LED to Green."), 2500);
 }
 
 
@@ -1858,7 +1858,7 @@ void guiWindow::on_blueLedTestBtn_clicked()
 {
     char buf[2] = { (char)OF_Const::sTestLEDB, true };
     if(serial.OneShotSend(buf, sizeof(buf)))
-        ui->statusBar->showMessage("Set LED to Blue.", 2500);
+        ui->statusBar->showMessage(tr("Set LED to Blue."), 2500);
 }
 
 
@@ -1866,11 +1866,11 @@ void guiWindow::on_testBtn_clicked()
 {
     if(App_Common::profilesTable.at(App_Common::board.selectedProfile).layoutType != App_Common::profilesTable_orig.at(App_Common::board.selectedProfile).layoutType) {
         if(QMessageBox::information(this,
-                                    "Warning: Unsaved Changes",
-                                    "Your current calibration profile has an unsaved IR Layout type change.\n"
-                                    "Test Mode relies on the profile's settings since the last save, and may not work as expected.\n"
-                                    "It is recommended that you save your changes before continuing.\n\n"
-                                    "Continue to Test Mode?",
+                                    tr("Warning: Unsaved Changes"),
+                                    tr("Your current calibration profile has an unsaved IR Layout type change.\n"
+                                       "Test Mode relies on the profile's settings since the last save, and may not work as expected.\n"
+                                       "It is recommended that you save your changes before continuing.\n\n"
+                                       "Continue to Test Mode?"),
                                     QMessageBox::Yes | QMessageBox::No)
             == QMessageBox::Yes) {
             char buf[2] = { (char)OF_Const::sIRTest, true };
@@ -1889,23 +1889,23 @@ void guiWindow::on_clearEepromBtn_clicked()
 {
     // Do we really need all this msgbox setup?
     QMessageBox messageBox;
-    messageBox.setText("Really delete saved data?");
-    messageBox.setInformativeText("This operation will delete all saved data, including:\n\n"
-                                  " - Calibration Profiles\n"
-                                  " - Toggles\n - Settings\n"
-                                  " - Custom Identifiers\n\n"
-                                  "Are you sure about this?");
-    messageBox.setWindowTitle("Delete Confirmation");
+    messageBox.setText(tr("Really delete saved data?"));
+    messageBox.setInformativeText(tr("This operation will delete all saved data, including:\n\n"
+                                     " - Calibration Profiles\n"
+                                     " - Toggles\n - Settings\n"
+                                     " - Custom Identifiers\n\n"
+                                     "Are you sure about this?"));
+    messageBox.setWindowTitle(tr("Delete Confirmation"));
     messageBox.setIcon(QMessageBox::Warning);
     messageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     messageBox.setDefaultButton(QMessageBox::No);
 
     if(messageBox.exec() == QMessageBox::Yes) {
-        ui->statusBar->showMessage("Board reset to initial settings.");
+        ui->statusBar->showMessage(tr("Board reset to initial settings."));
         char buf[2] = { (char)OF_Const::sClearFlash, (char)OF_Const::sClearFlash };
         serial.OneShotSend(buf, sizeof(buf));
         ui->comPortSelector->setCurrentIndex(0);
-    } else ui->statusBar->showMessage("Clear operation canceled.", 3000);
+    } else ui->statusBar->showMessage(tr("Clear operation canceled."), 3000);
 }
 
 
@@ -1931,7 +1931,7 @@ void guiWindow::on_baudResetBtn_clicked()
     // QFile::copy("file", picoPath+"file");
 */
 
-    ui->statusBar->showMessage("Board reset to bootloader.", 5000);
+    ui->statusBar->showMessage(tr("Board reset to bootloader."), 5000);
     ui->comPortSelector->setCurrentIndex(0);
 }
 
@@ -1966,12 +1966,12 @@ void guiWindow::serialPort_readyRead()
 
                 if (temp == OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE) {
                     // Sensor error.
-                    ui->tmp36Label->setText("Temperature: FAULT");
+                    ui->tmp36Label->setText(tr("Temperature: FAULT"));
                     ui->tmp36Label->setStyleSheet("color: white; background-color: #FF0000; font: bold");
                     break;
                 }
 
-                ui->tmp36Label->setText(QString("Temperature: %1°C").arg(temp));
+                ui->tmp36Label->setText(tr("Temperature: %1°C").arg(temp));
 
                 if(     temp > App_Common::settingsTable[App_Common::dataOrig][OF_Const::tempShutdown])
                     ui->tmp36Label->setStyleSheet("color: white;      background-color: #FF0000; font: bold");
@@ -2014,27 +2014,27 @@ void guiWindow::serialPort_readyRead()
                 case (char)OF_Const::sErrCam:
                     if(caliWindow != nullptr)
                         caliWindow->Shutdown();
-                    serial.ShowError("Device Error: Camera not available!",
-                                     "<p>Data received from the board indicates that the camera is in a bad state.<br>"
-                                     "This can happen if, for example, the camera wires are crossed<br>"
-                                     "(data wire to clock pin, clock wire to data pin),<br>"
-                                     "or the camera pins are wired to a different component,<br>"
-                                     "such as a button or Force Feedback output.</p>"
-                                     "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
-                                     "if they should be mapped different GPIO;<br>"
-                                     "Otherwise, the camera wires must be resoldered to resolve this error.</p>"
-                                     "<p>IR Testing and Calibration will not be available while in this state.</p>",
+                    serial.ShowError(tr("Device Error: Camera not available!"),
+                                     tr("<p>Data received from the board indicates that the camera is in a bad state.<br>"
+                                        "This can happen if, for example, the camera wires are crossed<br>"
+                                        "(data wire to clock pin, clock wire to data pin),<br>"
+                                        "or the camera pins are wired to a different component,<br>"
+                                        "such as a button or Force Feedback output.</p>"
+                                        "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
+                                        "if they should be mapped different GPIO;<br>"
+                                        "Otherwise, the camera wires must be resoldered to resolve this error.</p>"
+                                        "<p>IR Testing and Calibration will not be available while in this state.</p>"),
                                      QMessageBox::Critical);
                     break;
                 case (char)OF_Const::sErrPeriphGeneric:
-                    serial.ShowError("Peripheral Device Error!",
-                                     "<p>Data received from the board indicates that an I2C peripheral device failed to initialize.<br>"
-                                     "This can happen if, for example, the peripheral's wires are crossed<br>"
-                                     "(data wire to clock pin, clock wire to data pin),<br>"
-                                     "or the pins for the peripheral are set to a different component,<br>"
-                                     "such as a button or Force Feedback output.</p>"
-                                     "<p>Confirm that the wires for the peripheral are connected to the correct <i>Peripheral I2C</i> pins<br>"
-                                     "in the <i>Boards Layout</i> tab.</p>",
+                    serial.ShowError(tr("Peripheral Device Error!"),
+                                     tr("<p>Data received from the board indicates that an I2C peripheral device failed to initialize.<br>"
+                                        "This can happen if, for example, the peripheral's wires are crossed<br>"
+                                        "(data wire to clock pin, clock wire to data pin),<br>"
+                                        "or the pins for the peripheral are set to a different component,<br>"
+                                        "such as a button or Force Feedback output.</p>"
+                                        "<p>Confirm that the wires for the peripheral are connected to the correct <i>Peripheral I2C</i> pins<br>"
+                                        "in the <i>Boards Layout</i> tab.</p>"),
                                      QMessageBox::Critical);
                     break;
                 default: break;
@@ -2063,8 +2063,8 @@ void guiWindow::serialPort_readyRead()
                 break;
             case (char)OF_Const::sClearFlash:
                 ui->comPortSelector->setCurrentIndex(0);
-                QMessageBox::information(this, "Successfully reset board settings",
-                                         "Please unplug the board and reinsert it into the PC.");
+                QMessageBox::information(this, tr("Successfully reset board settings"),
+                                         tr("Please unplug the board and reinsert it into the PC."));
                 break;
             }
         }
@@ -2080,7 +2080,7 @@ void guiWindow::serialPort_SearchFinished()
         // if comPort only has "Nothing", safe to add items
         if(ui->comPortSelector->count() == 0) {
             if(serial.currentPorts.count()) {
-                ui->comPortSelector->addItem("[Select a Device to Configure]");
+                ui->comPortSelector->addItem(tr("[Select a Device to Configure]"));
                 ui->comPortSelector->setCurrentIndex(0);
                 for(auto &port : std::as_const(serial.currentPorts))
                     ui->comPortSelector->addItem(port.portName()+" (" + port.description() + ')');
@@ -2113,7 +2113,7 @@ void guiWindow::serialPort_SearchFinished()
                         if(ui->comPortSelector->currentText() == newPort.portName()+" (" + newPort.description() + ')')
                             inList = true;
                     if(!inList) {
-                        statusBar()->showMessage("Current board has been disconnected.");
+                        statusBar()->showMessage(tr("Current board has been disconnected."));
                         ui->comPortSelector->removeItem(1);
                     }
 
@@ -2126,7 +2126,7 @@ void guiWindow::serialPort_SearchFinished()
             // TODO: for whatever reason, this path specifically doesn't kick in under Windows VM?
             } else {
                 if(ui->comPortSelector->currentIndex() > 0)
-                    statusBar()->showMessage("Current board has been disconnected.");
+                    statusBar()->showMessage(tr("Current board has been disconnected."));
                 ui->comPortSelector->clear();
             }
         }
@@ -2147,7 +2147,7 @@ void guiWindow::serialPort_progressSet(const int &range)
 }
 
 
-void guiWindow::serialPort_progressUpdate(const int &pos, const char *statusText)
+void guiWindow::serialPort_progressUpdate(const int &pos, const QString& statusText)
 {
     if(statusProgressBar->isVisible())
         statusProgressBar->setValue(pos);
@@ -2200,11 +2200,11 @@ void guiWindow::CaliWindowExiting(const int &mode,
                    rightOffsetNew  >= -32768 && rightOffsetNew  <= 32768 &&
                    topLeftLedNew   >= -32768 && topLeftLedNew   <= 32768 &&
                    topRightLedNew  >= -32768 && topRightLedNew  <= 32768)
-                    ui->statusBar->showMessage("Calibration for Profile " + QString::number(selection+1) + " successful", 5000);
-                else ui->statusBar->showMessage("Calibration for Profile " + QString::number(selection+1) + " returned with malformed values.", 10000);
+                    ui->statusBar->showMessage(tr("Calibration for Profile ") + QString::number(selection+1) + tr(" successful"), 5000);
+                else ui->statusBar->showMessage(tr("Calibration for Profile ") + QString::number(selection+1) + tr(" returned with malformed values."), 10000);
 
                 DiffUpdate();
-        } else ui->statusBar->showMessage("Cancelled Calibration for Profile " + QString::number(selection+1), 10000);
+        } else ui->statusBar->showMessage(tr("Cancelled Calibration for Profile ") + QString::number(selection+1), 10000);
         break;
     }
     case AppCaliWindow::modeIRTest:
@@ -2311,7 +2311,7 @@ void guiWindow::on_actionOpen_IR_Emitter_Alignment_Assistant_triggered()
 void guiWindow::on_actionImport_Custom_Layout_triggered()
 {
     QString path = QFileDialog::getOpenFileName(this,
-                                                "Save New Layout",
+                                                tr("Open New Layout"),
                                                 QDir::homePath(),
                                                 "OpenFIRE Layout Files (*.ofl)");
 
@@ -2340,19 +2340,19 @@ void guiWindow::on_actionImport_Custom_Layout_triggered()
                 if(App_Common::inputsMap.value(OF_Const::rumblePin) >= 0)
                     ui->rumbleToggle->setChecked(App_Common::boolSettings[App_Common::dataOrig][OF_Const::rumble]);
 
-                ui->statusBar->showMessage("Successfully imported custom layout!", 5000);
-            } else QMessageBox::warning(this, "Board Doesn't Match",
-                                              "Custom layout file is not compatible with this board.");
-        } else QMessageBox::warning(this, "File Read Error",
-                                          "Custom layout file could not be read.");
-    } else ui->statusBar->showMessage("Canceled custom layout load operation.", 5000);
+                ui->statusBar->showMessage(tr("Successfully imported custom layout!"), 5000);
+            } else QMessageBox::warning(this, tr("Board Doesn't Match"),
+                                              tr("Custom layout file is not compatible with this board."));
+        } else QMessageBox::warning(this, tr("File Read Error"),
+                                          tr("Custom layout file could not be read."));
+    } else ui->statusBar->showMessage(tr("Canceled custom layout load operation."), 5000);
 }
 
 
 void guiWindow::on_actionExport_Custom_Layout_triggered()
 {
     QString path = QFileDialog::getSaveFileName(this,
-                                                "Save New Layout",
+                                                tr("Save New Layout"),
                                                 QDir::homePath(),
                                                 "OpenFIRE Layout Files (*.ofl)");
 
@@ -2369,10 +2369,10 @@ void guiWindow::on_actionExport_Custom_Layout_triggered()
             }
 
             fileOut.close();
-            ui->statusBar->showMessage("Custom layout export successful!", 5000);
-        } else QMessageBox::warning(this, "File Write Error",
-                                          "Custom layout file could not be written.");
-    } else ui->statusBar->showMessage("Canceled custom layout save operation.", 5000);
+            ui->statusBar->showMessage(tr("Custom layout export successful!"), 5000);
+        } else QMessageBox::warning(this, tr("File Write Error"),
+                                          tr("Custom layout file could not be written."));
+    } else ui->statusBar->showMessage(tr("Canceled custom layout save operation."), 5000);
 }
 
 

--- a/src/appmainwindow.h
+++ b/src/appmainwindow.h
@@ -184,7 +184,7 @@ private slots:
 
     void serialPort_progressSet(const int &);
 
-    void serialPort_progressUpdate(const int &, const char* = nullptr);
+    void serialPort_progressUpdate(const int &, const QString& = nullptr);
 
     void on_actionShow_Unsafe_Settings_toggled(bool arg1);
 

--- a/src/apppreviewer.cpp
+++ b/src/apppreviewer.cpp
@@ -117,14 +117,14 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
     for(auto &board : App_Common::OFPresets.boardNames) {
         if(!strcmp(board.second, arg1.toLocal8Bit().constData())) {
             if(board.first.find("esp32") != std::string::npos) {
-                ui->subTextLabel->setText("<p>Compatible with the "
-                                          "<a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32'><span style=' text-decoration: underline; color:#8ab4f8;'>ESP-IDF fork of the OpenFIRE Firmware</span></a> by <i>Alessandro Satanassi.</i><br>"
-                                          "Any issues should be reported <b><a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues'><span style=' text-decoration: underline; color:#8ab4f8;'>here!</span></a></b></p>");
+                ui->subTextLabel->setText(tr("<p>Compatible with the "
+                                             "<a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32'><span style=' text-decoration: underline; color:#8ab4f8;'>ESP-IDF fork of the OpenFIRE Firmware</span></a> by <i>Alessandro Satanassi.</i><br>"
+                                             "Any issues should be reported <b><a href='https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues'><span style=' text-decoration: underline; color:#8ab4f8;'>here!</span></a></b></p>"));
                 // NOTE: if we get any non-S3 boards, will need to determine if S3 or other arch-type ESP board.
                 boardType = OF_Const::boardESP32_S3;
             } else {
-                ui->subTextLabel->setText("<p>Compatible with "
-                                          "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware'><span style=' text-decoration: underline; color:#8ab4f8;'>upstream OpenFIRE Firmware</span></a> by <i>Team OpenFIRE.</i></p>");
+                ui->subTextLabel->setText(tr("<p>Compatible with "
+                                             "<a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware'><span style=' text-decoration: underline; color:#8ab4f8;'>upstream OpenFIRE Firmware</span></a> by <i>Team OpenFIRE.</i></p>"));
                 boardType = OF_Const::boardRP;
             }
 
@@ -200,16 +200,16 @@ void AppBoardsPreviewer::on_boardSelector_currentTextChanged(const QString &arg1
                 pinLabel.at(i)->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
                 pinLabel.at(i)->setProperty("slot", i);
                 pinLabel.at(i)->installEventFilter(this);
-                pinLabel.at(i)->setToolTip(QString("GPIO Pin No. %1.\n\n"
-                                                   "Blue pin numbers are members of I2C0.\n"
-                                                   "Orange are members of I2C1.\n"
-                                                   "Purple pin numbers can automatically select any I2C channel in software.\n"
-                                                   "Gray cannot use I2C devices.").arg(i));
+                pinLabel.at(i)->setToolTip(tr("GPIO Pin No. %1.\n\n"
+                                              "Blue pin numbers are members of I2C0.\n"
+                                              "Orange are members of I2C1.\n"
+                                              "Purple pin numbers can automatically select any I2C channel in software.\n"
+                                              "Gray cannot use I2C devices.").arg(i));
 
-                pinCapabilityMarks.at(i)->setToolTip("ADC indicates whether this pin can read Analog Inputs.\n"
-                                                     "I2C indicates if this pin can interact with I2C devices, and what channel and type it uses.\n"
-                                                     "SPI indicates if this pin can interact with SPI devices, and what channel and type it uses.\n"
-                                                     "(*) means pin can use any type via automated software selectable channels/type.");
+                pinCapabilityMarks.at(i)->setToolTip(tr("ADC indicates whether this pin can read Analog Inputs.\n"
+                                                        "I2C indicates if this pin can interact with I2C devices, and what channel and type it uses.\n"
+                                                        "SPI indicates if this pin can interact with SPI devices, and what channel and type it uses.\n"
+                                                        "(*) means pin can use any type via automated software selectable channels/type."));
             }
 
             // Drawing the actual board view page by referencing the board maps data from OpenFIREshared.h

--- a/src/appserial.cpp
+++ b/src/appserial.cpp
@@ -92,7 +92,7 @@ bool AppSerial::GetSettings(const QString &portName)
 
                 if(buffer.size() >= 3) {
                     emit Serial_SetProgressRange(6);
-                    emit Serial_ProgressUpdate(1, "Getting Board Info");
+                    emit Serial_ProgressUpdate(1, tr("Getting Board Info"));
 
                     ////* Opening board message bits *////
                     App_Common::board.version = buffer.takeFirst().constData();
@@ -109,15 +109,15 @@ bool AppSerial::GetSettings(const QString &portName)
                     memcpy(&App_Common::tinyUSBtable_orig, &App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s));
                     
                     if(buffer.size()) if(buffer.takeFirst().at(0) == (char)OF_Const::sError)
-                        ShowError("Device Error: Camera not available!",
-                                  "<p>Data received from the board indicates that the camera is in a bad state.<br>"
+                        ShowError(tr("Device Error: Camera not available!"),
+                                  tr("<p>Data received from the board indicates that the camera is in a bad state.<br>"
                                   "This can happen if, for example, the camera wires are crossed<br>"
                                   "(data wire to clock pin, clock wire to data pin),<br>"
                                   "or the camera pins are wired to a different component,<br>"
                                   "such as a button or Force Feedback output.</p>"
                                   "<p>You are able to change the camera pins in the <i>Boards Layout</i> tab<br>"
                                   "if they should be mapped different GPIO;<br>"
-                                  "Otherwise, the camera wires must be resoldered to resolve this error.</p>",
+                                  "Otherwise, the camera wires must be resoldered to resolve this error.</p>"),
                                   QMessageBox::Warning);
 
                     port.clear();
@@ -134,7 +134,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                App_Common::boolSettings[App_Common::dataCurrent],
                                sizeof(App_Common::boolSettings[App_Common::dataCurrent]));
 
-                        emit Serial_ProgressUpdate(2, "Getting Settings (1)");
+                        emit Serial_ProgressUpdate(2, tr("Getting Settings (1)"));
 
                         ////* pins *////
                         if(App_Common::boolSettings[App_Common::dataCurrent][OF_Const::customPins]) {
@@ -155,7 +155,7 @@ bool AppSerial::GetSettings(const QString &portName)
 
                         App_Common::inputsMap = App_Common::inputsMap_orig;
 
-                        emit Serial_ProgressUpdate(3, "Getting Settings (2)");
+                        emit Serial_ProgressUpdate(3, tr("Getting Settings (2)"));
 
                         ////* settings *////
                         port.clear();
@@ -171,7 +171,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                    App_Common::settingsTable[App_Common::dataCurrent],
                                    sizeof(App_Common::settingsTable[App_Common::dataCurrent]));
 
-                            emit Serial_ProgressUpdate(4, "Getting Button Mappings");
+                            emit Serial_ProgressUpdate(4, tr("Getting Button Mappings"));
 
                             ////* buttons *////
                             port.clear();
@@ -187,7 +187,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                        App_Common::inputFuncTable[App_Common::dataCurrent],
                                        sizeof(App_Common::inputFuncTable[App_Common::dataCurrent]));
 
-                                emit Serial_ProgressUpdate(5, "Getting Profiles Data");
+                                emit Serial_ProgressUpdate(5, tr("Getting Profiles Data"));
 
                                 ////* profiles *////
                                 App_Common::profilesTable.clear(), App_Common::profilesTable_orig.clear();
@@ -197,7 +197,7 @@ bool AppSerial::GetSettings(const QString &portName)
                                     if(BatchStoreSettings(nullptr, App_Common::OFPresets.profSettingTypes_Strings, sizeof(float))) {
                                         App_Common::profilesTable_orig = App_Common::profilesTable;
                                         App_Common::board.previousProfile = App_Common::board.selectedProfile;
-                                        emit Serial_ProgressUpdate(6, "Successfully synced data!");
+                                        emit Serial_ProgressUpdate(6, tr("Successfully synced data!"));
                                         port.clear();
                                         return true;
                                     } else return false;
@@ -223,17 +223,17 @@ bool AppSerial::GetSettings(const QString &portName)
                     return false;
                 }
             } else {
-                QMessageBox::warning(nullptr,   "Data hasn't arrived! (Stale state?)",
-                                                "Device was detected, but initial settings request wasn't received in time!\n"
+                QMessageBox::warning(nullptr,   tr("Data hasn't arrived! (Stale state?)"),
+                                                tr("Device was detected, but initial settings request wasn't received in time!\n"
                                                 "This can happen if the app was unexpectedly closed and the gun is in a stale docked state.\n\n"
-                                                "Try selecting the device again.");
+                                                "Try selecting the device again."));
                 RequestToReboot();
                 return false;
             }
         } else {
-            QMessageBox::warning(nullptr,   "Serial port is already in use!",
-                                            "This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
-                                            "Please close the offending application and try selecting this port again.");
+            QMessageBox::warning(nullptr,   tr("Serial port is already in use!"),
+                                            tr("This usually indicates that the port is being used by something else, e.g. Arduino IDE's serial monitor, or another command line app (stty, screen).\n\n"
+                                            "Please close the offending application and try selecting this port again."));
             return false;
         }
     } else return false;
@@ -362,7 +362,7 @@ bool AppSerial::CommitSettings()
         char message[2] = { (char)OF_Const::sCommitStart, true };
         if(OneShotSend(message, sizeof(message), true)) {
             // in case board sends a stale temp/analog state response.
-            emit Serial_ProgressUpdate(0, "Waiting for board...");
+            emit Serial_ProgressUpdate(0, tr("Waiting for board..."));
             do {
                 if(port.read(1).at(0) == (char)OF_Const::sCommitStart) break;
                 if(!port.bytesAvailable()) if(!port.waitForReadyRead(1000)) break;
@@ -370,14 +370,14 @@ bool AppSerial::CommitSettings()
 
             port.clear();
 
-            emit Serial_ProgressUpdate(1, "Sending Toggles...");
+            emit Serial_ProgressUpdate(1, tr("Sending Toggles..."));
             if(!BatchSendSettings(App_Common::boolSettings[App_Common::dataCurrent],
                                   App_Common::OFPresets.boolTypes_Strings,
                                   sizeof(App_Common::boolSettings[App_Common::dataCurrent]) / OF_Const::boolTypesCount))
                 return false;
 
             if(App_Common::boolSettings[OF_Const::customPins]) {
-                emit Serial_ProgressUpdate(2, "Sending Pins Map...");
+                emit Serial_ProgressUpdate(2, tr("Sending Pins Map..."));
                 // convert pins map to temp buffer
                 int8_t inputMapFW[OF_Const::boardInputsCount];
                 for(size_t i = 0; i < OF_Const::boardInputsCount; ++i)
@@ -389,19 +389,19 @@ bool AppSerial::CommitSettings()
                     return false;
             }
 
-            emit Serial_ProgressUpdate(3, "Sending Settings...");
+            emit Serial_ProgressUpdate(3, tr("Sending Settings..."));
             if(!BatchSendSettings(App_Common::settingsTable[App_Common::dataCurrent],
                                   App_Common::OFPresets.settingsTypes_Strings,
                                   sizeof(App_Common::settingsTable[App_Common::dataCurrent]) / OF_Const::settingsTypesCount))
                 return false;
 
-            emit Serial_ProgressUpdate(4, "Sending Buttons...");
+            emit Serial_ProgressUpdate(4, tr("Sending Buttons..."));
             if(!BatchSendSettings(App_Common::inputFuncTable[App_Common::dataCurrent],
                                   App_Common::OFPresets.boardInputs_Strings,
                                   sizeof(App_Common::inputFuncTable[App_Common::dataCurrent]) / BUTTON_COUNT))
                 return false;
 
-            emit Serial_ProgressUpdate(5, "Sending Profile Data...");
+            emit Serial_ProgressUpdate(5, tr("Sending Profile Data..."));
             for(size_t i = 0; i < App_Common::profilesTable.count(); ++i) {
                 if(!BatchSendSettings(&App_Common::profilesTable[i],
                                       App_Common::OFPresets.profSettingTypes_Strings,
@@ -410,7 +410,7 @@ bool AppSerial::CommitSettings()
                     return false;
             }
 
-            emit Serial_ProgressUpdate(6, "Sending TinyUSB ID Data...");
+            emit Serial_ProgressUpdate(6, tr("Sending TinyUSB ID Data..."));
             TXbuf[0] = (char)OF_Const::sCommitID;
             memcpy(&TXbuf[1], (uint8_t*)&App_Common::tinyUSBtable, sizeof(App_Common::tinyUSBtable_s));
             for(size_t sendAttempt = 1;; ++sendAttempt) {
@@ -422,7 +422,7 @@ bool AppSerial::CommitSettings()
                 } else return false;
             }
 
-            emit Serial_ProgressUpdate(7, "Saving...");
+            emit Serial_ProgressUpdate(7, tr("Saving..."));
             if(OneShotSend((char)OF_Const::sSave, true)) {
                 if(char newBuf[2] = {(char)OF_Const::sSave, (char)true}; memcmp(port.read(2).constData(), newBuf, sizeof(newBuf)) == 0) {
                     emit Serial_ProgressUpdate(8);
@@ -506,11 +506,11 @@ void AppSerial::Disconnect()
 
 void AppSerial::RequestToReboot()
 {
-    if(QMessageBox::critical(nullptr, "Reset Board to Bootloader?",
-                                      "<p>The board you selected did not respond to the app properly.</p>"
+    if(QMessageBox::critical(nullptr, tr("Reset Board to Bootloader?"),
+                                      tr("<p>The board you selected did not respond to the app properly.</p>"
                                       "<p>This can usually be resolved by rebooting the microcontroller to its bootloader, and then updating the board to the latest firmware, which can be found at:</p>"
                                       "<p><a href='https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest'><span style=' text-decoration: underline; color:#8ab4f8;'>https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest</span></a></p>"
-                                      "<p>Would you like to reboot this board to apply an update?</p>",
+                                      "<p>Would you like to reboot this board to apply an update?</p>"),
                                       QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
         RebootToBootldr();
 }

--- a/src/appserial.h
+++ b/src/appserial.h
@@ -107,7 +107,7 @@ public:
     void RebootToBootldr();
 
     /// @brief      Show error message popup regarding serial
-    void ShowError(const char* titleText, const char* text, const QMessageBox::Icon icon = QMessageBox::Warning) {
+    void ShowError(const QString& titleText, const QString& text, const QMessageBox::Icon icon = QMessageBox::Warning) {
         if(!syncError.isVisible()) {
             syncError.setWindowTitle(titleText);
             syncError.setText(text);
@@ -127,7 +127,7 @@ signals:
     void Serial_SetProgressRange(const int &);
 
     /// @brief
-    void Serial_ProgressUpdate(const int &, const char* = nullptr);
+    void Serial_ProgressUpdate(const int &, const QString& = nullptr);
 };
 
 #endif // APPSERIAL_H

--- a/translation/AppTranslations_it_IT.ts
+++ b/translation/AppTranslations_it_IT.ts
@@ -1,0 +1,2165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it_IT">
+<context>
+    <name>AppAbout</name>
+    <message>
+        <location filename="../src/appabout.ui" line="17"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="133"/>
+        <source>About OpenFIRE</source>
+        <translation>Informazioni su OpenFIRE</translation>
+    </message>
+    <message>
+        <location filename="../src/appabout.ui" line="70"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="135"/>
+        <source>Made with blood, sweat, and Qt </source>
+        <translation>Fatto con sangue, sudore e Qt </translation>
+    </message>
+    <message>
+        <location filename="../src/appabout.ui" line="88"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="136"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Primary OpenFIRE Firmware maintainership and Desktop App developed by &lt;a href=&quot;https://github.com/SeongGino&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;That One Seong&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;If this software has given you any value,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;La manutenzione principale del firmware OpenFIRE e lo sviluppo dell’app Desktop sono a cura di &lt;a href=&quot;https://github.com/SeongGino&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;That One Seong&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;Se questo software ti è stato utile,&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appabout.ui" line="104"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="137"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://ko-fi.com/thatoneseong&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;/&gt;&lt;img src=&quot;:/icon/donate.svg&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appabout.ui" line="117"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="138"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;Special Thanks:&lt;br/&gt;Samuel Ballantyne, for their work on the original &lt;a href=&quot;https://github.com/samuelballantyne/IR-Light-Gun&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;SAMCO lightgun system&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;Mike Lynch, AKA Prow7, for their enhanced fork and libraries.&lt;br/&gt;&lt;a href=&quot;https://forum.arcadecontrols.com/index.php/board,20.0.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;The ArcadeControls forums&lt;/span&gt;&lt;/a&gt; for their support.&lt;br/&gt;All the early GitHub testers for their feedback.&lt;br/&gt;And You, for enjoying this software!&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;OpenFIRE, as the name implies, is FREE SOFTWARE;&lt;br/&gt;if you have paid for the firmware or this utility, you have been scammed and should demand your money back!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;Ringraziamenti speciali:&lt;br/&gt;Samuel Ballantyne, per il suo lavoro sull&apos;originale &lt;a href=&quot;https://github.com/samuelballantyne/IR-Light-Gun&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;SAMCO lightgun system&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;Mike Lynch, alias Prow7, per il suo fork migliorato e le librerie.&lt;br/&gt;&lt;a href=&quot;https://forum.arcadecontrols.com/index.php/board,20.0.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Il forum di ArcadeControls&lt;/span&gt;&lt;/a&gt; per il supporto.&lt;br/&gt;Tutti i primi tester di GitHub per i loro feedback.&lt;br/&gt;E a Te, per apprezzare questo software!&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;OpenFIRE, come suggerisce il nome, è SOFTWARE GRATUITO;&lt;br/&gt;se hai pagato per il firmware o per questa utility, sei stato truffato e dovresti pretendere il rimborso!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appabout.ui" line="151"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appabout.h" line="139"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Firmware&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/TeamOpenFIRE/OpenFIRE-App&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Desktop Source&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;discord.com/invite/dFw5z6PBQv&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#8ab4f8;&quot;&gt;Discord&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>AppBoardsPreviewer</name>
+    <message>
+        <location filename="../src/apppreviewer.ui" line="14"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_apppreviewer.h" line="141"/>
+        <source>Boards Previewer</source>
+        <translation>Anteprima Schede</translation>
+    </message>
+    <message>
+        <location filename="../src/apppreviewer.ui" line="39"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_apppreviewer.h" line="142"/>
+        <source>Click Here to Select a Board</source>
+        <translation>Clicca qui per selezionare una scheda</translation>
+    </message>
+    <message>
+        <location filename="../src/apppreviewer.cpp" line="120"/>
+        <source>&lt;p&gt;Compatible with the &lt;a href=&apos;https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;ESP-IDF fork of the OpenFIRE Firmware&lt;/span&gt;&lt;/a&gt; by &lt;i&gt;Alessandro Satanassi.&lt;/i&gt;&lt;br&gt;Any issues should be reported &lt;b&gt;&lt;a href=&apos;https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;here!&lt;/span&gt;&lt;/a&gt;&lt;/b&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Compatibile con il &lt;a href=&apos;https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;fork ESP-IDF del Firmware OpenFIRE&lt;/span&gt;&lt;/a&gt; di &lt;i&gt;Alessandro Satanassi.&lt;/i&gt;&lt;br&gt;Eventuali problemi possono essere segnalati &lt;b&gt;&lt;a href=&apos;https://github.com/alessandro-satanassi/OpenFIRE-Firmware-ESP32/issues&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;qui!&lt;/span&gt;&lt;/a&gt;&lt;/b&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/apppreviewer.cpp" line="126"/>
+        <source>&lt;p&gt;Compatible with &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;upstream OpenFIRE Firmware&lt;/span&gt;&lt;/a&gt; by &lt;i&gt;Team OpenFIRE.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Compatibile con &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;il Firmware OpenFIRE upstream&lt;/span&gt;&lt;/a&gt; del &lt;i&gt;Team OpenFIRE.&lt;/i&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/apppreviewer.cpp" line="203"/>
+        <source>GPIO Pin No. %1.
+
+Blue pin numbers are members of I2C0.
+Orange are members of I2C1.
+Purple pin numbers can automatically select any I2C channel in software.
+Gray cannot use I2C devices.</source>
+        <translation>Pin GPIO N. %1.
+
+I pin con numero blu appartengono a I2C0.
+Quelli con numero arancione appartengono a I2C1.
+I pin con numero viola possono selezionare automaticamente qualsiasi canale I2C via software.
+Quelli in grigio non possono utilizzare dispositivi I2C.</translation>
+    </message>
+    <message>
+        <location filename="../src/apppreviewer.cpp" line="209"/>
+        <source>ADC indicates whether this pin can read Analog Inputs.
+I2C indicates if this pin can interact with I2C devices, and what channel and type it uses.
+SPI indicates if this pin can interact with SPI devices, and what channel and type it uses.
+(*) means pin can use any type via automated software selectable channels/type.</source>
+        <translation>ADC indica se questo pin può leggere ingressi analogici.
+I2C indica se questo pin può interagire con dispositivi I2C, e quale canale e tipo utilizza.
+SPI indica se questo pin può interagire con dispositivi SPI, e quale canale e tipo utilizza.
+(*) significa che il pin può usare qualsiasi tipo tramite canali/tipi selezionabili automaticamente via software.</translation>
+    </message>
+</context>
+<context>
+    <name>AppCaliWindow</name>
+    <message>
+        <location filename="../src/appcali.cpp" line="119"/>
+        <source>Alignment Assistant</source>
+        <translation>Assistente di allineamento</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="123"/>
+        <source>       Depending on your desired layout,       </source>
+        <translation>        A seconda del layout desiderato,       </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="124"/>
+        <source>      your IR emitters should be aligned       </source>
+        <translation>   gli emettitori IR devono essere allineati   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="125"/>
+        <source>         to either one of the two sets         </source>
+        <translation>            a uno dei due gruppi               </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="126"/>
+        <source>               of colored boxes:               </source>
+        <translation>            di riquadri colorati:              </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="130"/>
+        <source>      For Square Layout,     </source>
+        <translation>    Per il Layout Square,    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="131"/>
+        <source>    the emitters should be   </source>
+        <translation> gli emettitori devono essere</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="132"/>
+        <source>    placed at the top and    </source>
+        <translation>    posizionati in alto e    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="133"/>
+        <source>    bottom of the display;   </source>
+        <translation>   in basso sullo schermo;   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="134"/>
+        <location filename="../src/appcali.cpp" line="147"/>
+        <source>each one being aligned to the</source>
+        <translation>ciascuno allineato agli altri</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="138"/>
+        <source>      Red-colored boxes.     </source>
+        <translation>  Riquadri di colore rosso.  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="143"/>
+        <source>     For Diamond Layout,     </source>
+        <translation>    Per il Layout Diamond,   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="144"/>
+        <source>the emitters should be placed</source>
+        <translation> gli emettitori devono essere</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="145"/>
+        <source>  at the center of the four  </source>
+        <translation>    al centro dei quattro    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="146"/>
+        <source>    edges of the display;    </source>
+        <translation>     lati dello schermo;     </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="151"/>
+        <source>     Green-colored boxes.    </source>
+        <translation>  Riquadri di colore verde.  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="156"/>
+        <location filename="../src/appcali.cpp" line="191"/>
+        <source>Press ESC to exit alignment tool.</source>
+        <translation>      Premi ESC per uscire.      </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="161"/>
+        <source>&lt;p align=&quot;justify&quot;&gt;Depending on your desired layout,&lt;br&gt;your IR Emitters should be aligned&lt;br&gt;to either one of the two sets&lt;br&gt;of colored boxes:&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;justify&quot;&gt;A seconda del layout desiderato,&lt;br&gt;i tuoi Emettitori IR dovrebbero essere allineati&lt;br&gt;a uno dei due gruppi&lt;br&gt;di riquadri colorati:&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="169"/>
+        <source>&lt;p align=&quot;justify&quot;&gt;For &lt;b&gt;Square Layout,&lt;/b&gt;&lt;br&gt;the emitters should be&lt;br&gt;placed at the top and&lt;br&gt;bottom of the display;&lt;br&gt;each one being aligned to the&lt;br&gt;&lt;p style=&quot;color: tomato&quot;&gt;Red-colored boxes.&lt;/p&gt;&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;justify&quot;&gt;Per il &lt;b&gt;Layout Square,&lt;/b&gt;&lt;br&gt;gli emettitori dovrebbero essere&lt;br&gt;posizionati in alto e&lt;br&gt;in basso sullo schermo;&lt;br&gt;ognuno allineato ai&lt;br&gt;&lt;p style=&quot;color: tomato&quot;&gt;Riquadri di colore rosso.&lt;/p&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="180"/>
+        <source>&lt;p align=&quot;justify&quot;&gt;For &lt;b&gt;Diamond Layout,&lt;/b&gt;&lt;br&gt;the emitters should be placed&lt;br&gt;at the center of the four&lt;br&gt;edges of the display;&lt;br&gt;each one being aligned to the&lt;/p&gt;&lt;p style=&quot;color: palegreen&quot;&gt;Green-colored boxes.&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;justify&quot;&gt;Per il &lt;b&gt;Layout Diamond,&lt;/b&gt;&lt;br&gt;gli emettitori dovrebbero essere posizionati&lt;br&gt;al centro dei quattro&lt;br&gt;lati dello schermo;&lt;br&gt;ognuno allineato ai&lt;/p&gt;&lt;p style=&quot;color: palegreen&quot;&gt;Riquadri di colore verde.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="276"/>
+        <source>IR Emitters Test</source>
+        <translation>Test emettitori IR</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="283"/>
+        <source>     The array of shapes displayed onscreen     </source>
+        <translation>  L&apos;insieme di forme visualizzato sullo schermo </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="284"/>
+        <source>represents the emitters that the camera can see.</source>
+        <translation> rappresenta gli emettitori visti dalla camera. </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="285"/>
+        <source>   The colored points should move opposite to   </source>
+        <translation> I punti colorati devono muoversi al contrario  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="286"/>
+        <source>     your aim, and the gray circle should be    </source>
+        <translation>    della tua mira, e il cerchio grigio deve    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="287"/>
+        <source>          lining up with your gun sight.        </source>
+        <translation>    allinearsi con il mirino della tua arma.    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="292"/>
+        <location filename="../src/appcali.cpp" line="307"/>
+        <source>Press ESC to exit test mode.</source>
+        <translation>    Premi ESC per uscire.   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="298"/>
+        <source>&lt;p align=justify&gt;The array of shapes onscreen&lt;br&gt;represents the emitters that the camera can see.&lt;br&gt;The points should move opposite to your aim,&lt;br&gt;and the gray circle should be lining up with your gun sight.&lt;/p&gt;</source>
+        <translation>&lt;p align=justify&gt;L&apos;insieme di forme sullo schermo&lt;br&gt;rappresenta gli emettitori che la telecamera riesce a vedere.&lt;br&gt;I punti dovrebbero muoversi in direzione opposta alla tua mira,&lt;br&gt;e il cerchio grigio dovrebbe essere allineato con il mirino della tua pistola.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="479"/>
+        <location filename="../src/appcali.cpp" line="498"/>
+        <source>Initialize Calibration:</source>
+        <translation>  Inizia calibrazione: </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="483"/>
+        <location filename="../src/appcali.cpp" line="502"/>
+        <source>Shoot at the target to start calibration.</source>
+        <translation>    Spara al bersaglio per calibrare.    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="487"/>
+        <source>Calibration can be exited without changes</source>
+        <translation>  Puoi uscire senza apportare modifiche  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="488"/>
+        <source>  by pressing either Button A, Button B, </source>
+        <translation>  premendo il Pulsante A, il Pulsante B, </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="489"/>
+        <source>       or Button C (if available).       </source>
+        <translation>    o il Pulsante C (se disponibile).    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="506"/>
+        <source>&lt;p align=&quot;center&quot;&gt;Calibration can be exited without changes&lt;br&gt;by pressing either &lt;i&gt;Button A,&lt;/i&gt; &lt;i&gt;Button B,&lt;/i&gt;&lt;br&gt;or &lt;i&gt;Button C (if available).&lt;/i&gt;&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;center&quot;&gt;È possibile uscire dalla calibrazione senza modifiche&lt;br&gt;premendo &lt;i&gt;Pulsante A,&lt;/i&gt; &lt;i&gt;Pulsante B,&lt;/i&gt;&lt;br&gt;o &lt;i&gt;Pulsante C (se disponibile).&lt;/i&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="521"/>
+        <location filename="../src/appcali.cpp" line="538"/>
+        <source>Cali Step 1:</source>
+        <translation>Step 1 Cali:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="525"/>
+        <location filename="../src/appcali.cpp" line="542"/>
+        <source>Shoot at the top edge of the screen.</source>
+        <translation> Spara al bordo alto dello schermo. </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="529"/>
+        <source>The calibration process can be reset by pressing</source>
+        <translation>La calibrazione puo&apos; essere reimpostata premendo</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="530"/>
+        <source>either Button A or Button B, and can be canceled</source>
+        <translation>   il Pulsante A o B, e puo&apos; essere annullata   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="531"/>
+        <source>      by pressing Button C (if available).      </source>
+        <translation>    premendo il Pulsante C (se disponibile).    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="546"/>
+        <source>&lt;p align=&quot;center&quot;&gt;The calibration process can be reset by pressing&lt;br&gt;either &lt;i&gt;Button A&lt;/i&gt; or &lt;i&gt;Button B,&lt;/i&gt;&lt;br&gt;and can be canceled by pressing &lt;i&gt;Button C (if available).&lt;/i&gt;&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;center&quot;&gt;Il processo di calibrazione può essere resettato premendo&lt;br&gt;il &lt;i&gt;Pulsante A&lt;/i&gt; o il &lt;i&gt;Pulsante B,&lt;/i&gt;&lt;br&gt;e può essere annullato premendo il &lt;i&gt;Pulsante C (se disponibile).&lt;/i&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="559"/>
+        <location filename="../src/appcali.cpp" line="565"/>
+        <source>Cali Step 2:</source>
+        <translation>Step 2 Cali:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="561"/>
+        <location filename="../src/appcali.cpp" line="567"/>
+        <source>Shoot at the bottom edge of the screen.</source>
+        <translation>Spara al bordo inferiore dello schermo.</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="578"/>
+        <location filename="../src/appcali.cpp" line="584"/>
+        <source>Cali Step 3:</source>
+        <translation>Step 3 Cali:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="580"/>
+        <location filename="../src/appcali.cpp" line="586"/>
+        <source>Shoot at the left edge of the screen.</source>
+        <translation>Spara al bordo sinistro dello schermo</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="597"/>
+        <location filename="../src/appcali.cpp" line="603"/>
+        <source>Cali Step 4:</source>
+        <translation>Step 4 Cali:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="599"/>
+        <location filename="../src/appcali.cpp" line="605"/>
+        <source>Shoot at the right edge of the screen.</source>
+        <translation> Spara al bordo destro dello schermo. </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="616"/>
+        <location filename="../src/appcali.cpp" line="622"/>
+        <source>Cali Step 5:</source>
+        <translation>Step 5 Cali:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="618"/>
+        <location filename="../src/appcali.cpp" line="624"/>
+        <source>Shoot at the final target in the center.</source>
+        <translation>  Spara al bersaglio finale al centro.  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="642"/>
+        <location filename="../src/appcali.cpp" line="662"/>
+        <location filename="../src/appcali.cpp" line="688"/>
+        <source>Verify New Calibration:</source>
+        <translation> Verifica calibrazione:</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="646"/>
+        <source>    Confirm that the bullseye     </source>
+        <translation>     Verifica che il bersaglio    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="647"/>
+        <source>   lines up with the gun sight.   </source>
+        <translation>   sia allineato con il mirino.   </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="648"/>
+        <source>If this calibration is acceptable,</source>
+        <translation>Se la calibrazione e&apos; accettabile,</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="649"/>
+        <source>  confirm by pulling the trigger. </source>
+        <translation>  conferma premendo il grilletto. </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="653"/>
+        <source>       If this target accuracy isn&apos;t desirable,      </source>
+        <translation> Se la precisione del bersaglio non e&apos; soddisfacente,</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="654"/>
+        <source>          press either Button A or Button B          </source>
+        <translation>         premi il Pulsante A o il Pulsante B         </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="655"/>
+        <source>         to restart the calibration process.         </source>
+        <translation>      per riavviare il processo di calibrazione.     </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="656"/>
+        <location filename="../src/appcali.cpp" line="666"/>
+        <location filename="../src/appcali.cpp" line="680"/>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="657"/>
+        <location filename="../src/appcali.cpp" line="681"/>
+        <source>[You can also exit calibration without saving changes</source>
+        <translation>    [Puoi anche uscire senza salvare le modifiche    </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="658"/>
+        <location filename="../src/appcali.cpp" line="682"/>
+        <source>        by pressing Button C (if available).]        </source>
+        <translation>      premendo il Pulsante C (se disponibile).]      </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="668"/>
+        <source>WARNING: Possibly Malformed Calibration!!</source>
+        <translation> ATTENZIONE: Calibrazione forse errata!! </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="672"/>
+        <source>  The current pending values for this profile  </source>
+        <translation> I valori attuali in attesa per questo profilo </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="673"/>
+        <source>will likely cause incorrect or broken tracking.</source>
+        <translation>   potrebbero causare un tracciamento errato.  </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="678"/>
+        <source>  Press Button A or Button B to restart calibration, </source>
+        <translation>Premi i Pulsanti A o B per riavviare la calibrazione,</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="679"/>
+        <source>   or pull trigger to continue with these settings.  </source>
+        <translation>  o premi il grilletto per confermare questi valori. </translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="692"/>
+        <source>&lt;p align=&quot;center&quot;&gt;Confirm that the bullseye lines up with gun sight.&lt;br&gt;If this calibration is acceptable, confirm by pulling the trigger.&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;center&quot;&gt;Conferma che il centro del bersaglio sia allineato con il mirino della pistola.&lt;br&gt;Se questa calibrazione è accettabile, conferma premendo il grilletto.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appcali.cpp" line="697"/>
+        <source>&lt;p align=&quot;center&quot;&gt;If the target accuracy isn&apos;t desirable,&lt;br&gt;press either &lt;i&gt;Button A&lt;/i&gt; or &lt;i&gt;Button B&lt;/i&gt;&lt;br&gt;to restart the calibration process.&lt;br&gt;&lt;br&gt;[You can also exit calibration without saving changes&lt;br&gt;by pressing &lt;i&gt;Button C (if available).&lt;/i&gt;]&lt;/p&gt;</source>
+        <translation>&lt;p align=&quot;center&quot;&gt;Se la precisione non è quella desiderata,&lt;br&gt;premi il &lt;i&gt;Pulsante A&lt;/i&gt; o il &lt;i&gt;Pulsante B&lt;/i&gt;&lt;br&gt;per riavviare il processo di calibrazione.&lt;br&gt;&lt;br&gt;[Puoi anche uscire dalla calibrazione senza salvare le modifiche&lt;br&gt;premendo il &lt;i&gt;Pulsante C (se disponibile).&lt;/i&gt;]&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>AppDebugWindow</name>
+    <message>
+        <location filename="../src/appdebug.ui" line="14"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appdebug.h" line="74"/>
+        <source>Serial Debug</source>
+        <translation>Debug Seriale</translation>
+    </message>
+</context>
+<context>
+    <name>AppSerial</name>
+    <message>
+        <location filename="../src/appserial.cpp" line="95"/>
+        <source>Getting Board Info</source>
+        <translation>Lettura informazioni scheda</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="112"/>
+        <source>Device Error: Camera not available!</source>
+        <translation>Errore dispositivo: Telecamera non disponibile!</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="113"/>
+        <source>&lt;p&gt;Data received from the board indicates that the camera is in a bad state.&lt;br&gt;This can happen if, for example, the camera wires are crossed&lt;br&gt;(data wire to clock pin, clock wire to data pin),&lt;br&gt;or the camera pins are wired to a different component,&lt;br&gt;such as a button or Force Feedback output.&lt;/p&gt;&lt;p&gt;You are able to change the camera pins in the &lt;i&gt;Boards Layout&lt;/i&gt; tab&lt;br&gt;if they should be mapped different GPIO;&lt;br&gt;Otherwise, the camera wires must be resoldered to resolve this error.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;I dati ricevuti dalla scheda indicano che la telecamera e&apos; in uno stato di errore.&lt;br&gt;Questo puo&apos; accadere se, ad esempio, i cavi della telecamera sono incrociati&lt;br&gt;(cavo dati sul pin di clock, cavo clock sul pin dati),&lt;br&gt;oppure se i pin della telecamera sono collegati a un componente diverso,&lt;br&gt;come un pulsante o un&apos;uscita Force Feedback.&lt;/p&gt;&lt;p&gt;Puoi cambiare i pin della telecamera nella scheda &lt;i&gt;Boards Layout&lt;/i&gt;&lt;br&gt;se devono essere mappati su GPIO diversi;&lt;br&gt;Altrimenti, i cavi della telecamera devono essere risaldati per risolvere questo errore.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="137"/>
+        <source>Getting Settings (1)</source>
+        <translation>Lettura impostazioni (1)</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="158"/>
+        <source>Getting Settings (2)</source>
+        <translation>Lettura impostazioni (2)</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="174"/>
+        <source>Getting Button Mappings</source>
+        <translation>Lettura mappatura pulsanti</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="190"/>
+        <source>Getting Profiles Data</source>
+        <translation>Lettura dati profili</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="200"/>
+        <source>Successfully synced data!</source>
+        <translation>Dati sincronizzati con successo!</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="226"/>
+        <source>Data hasn&apos;t arrived! (Stale state?)</source>
+        <translation>I dati non sono arrivati! (Stato obsoleto?)</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="227"/>
+        <source>Device was detected, but initial settings request wasn&apos;t received in time!
+This can happen if the app was unexpectedly closed and the gun is in a stale docked state.
+
+Try selecting the device again.</source>
+        <translation>Dispositivo rilevato, ma la richiesta iniziale delle impostazioni non è stata ricevuta in tempo!
+Questo può accadere se l&apos;app è stata chiusa inaspettatamente e la pistola si trova in uno stato docked obsoleto.
+
+Prova a selezionare nuovamente il dispositivo.</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="234"/>
+        <source>Serial port is already in use!</source>
+        <translation>La porta seriale è già in uso!</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="235"/>
+        <source>This usually indicates that the port is being used by something else, e.g. Arduino IDE&apos;s serial monitor, or another command line app (stty, screen).
+
+Please close the offending application and try selecting this port again.</source>
+        <translation>Questo di solito indica che la porta è già utilizzata da qualcos&apos;altro, ad es. il monitor seriale di Arduino IDE o un&apos;altra applicazione da riga di comando (stty, screen).
+
+Chiudi l&apos;applicazione in conflitto e prova a selezionare nuovamente questa porta.</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="365"/>
+        <source>Waiting for board...</source>
+        <translation>In attesa della scheda...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="373"/>
+        <source>Sending Toggles...</source>
+        <translation>Invio opzioni...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="380"/>
+        <source>Sending Pins Map...</source>
+        <translation>Invio mappa dei pin...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="392"/>
+        <source>Sending Settings...</source>
+        <translation>Invio impostazioni...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="398"/>
+        <source>Sending Buttons...</source>
+        <translation>Invio pulsanti...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="404"/>
+        <source>Sending Profile Data...</source>
+        <translation>Invio dati profilo...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="413"/>
+        <source>Sending TinyUSB ID Data...</source>
+        <translation>Invio dati ID TinyUSB...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="425"/>
+        <source>Saving...</source>
+        <translation>Salvataggio in corso...</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="509"/>
+        <source>Reset Board to Bootloader?</source>
+        <translation>Riavvia la scheda in modalità Bootloader?</translation>
+    </message>
+    <message>
+        <location filename="../src/appserial.cpp" line="510"/>
+        <source>&lt;p&gt;The board you selected did not respond to the app properly.&lt;/p&gt;&lt;p&gt;This can usually be resolved by rebooting the microcontroller to its bootloader, and then updating the board to the latest firmware, which can be found at:&lt;/p&gt;&lt;p&gt;&lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Would you like to reboot this board to apply an update?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;La scheda che hai selezionato non ha risposto correttamente all&apos;app.&lt;/p&gt;&lt;p&gt;Questo problema di solito puo&apos; essere risolto riavviando il microcontrollore nel suo bootloader, per poi aggiornare la scheda all&apos;ultimo firmware, che puo&apos; essere trovato su:&lt;/p&gt;&lt;p&gt;&lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/releases/latest&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Vuoi riavviare questa scheda per applicare un aggiornamento?&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>guiWindow</name>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="49"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1624"/>
+        <source>COM Port:</source>
+        <translation>Porta COM:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="135"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1632"/>
+        <source>Board Layout</source>
+        <translation>Layout Scheda</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="248"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1627"/>
+        <source>Enable to use custom pins mapping, or disable to use the default mappings for the current board.</source>
+        <translation>Abilita per utilizzare la mappatura dei pin personalizzata, oppure disabilita per usare quella predefinita della scheda corrente.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="251"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1629"/>
+        <source>Use Custom Pins</source>
+        <translation>Usa pin personalizzati</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="271"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1630"/>
+        <source>User Layouts</source>
+        <translation>Layout Utente</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="290"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1631"/>
+        <source>Select Layout Preset</source>
+        <translation>Seleziona preset di layout</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="581"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1962"/>
+        <source>Gun Settings</source>
+        <translation>Impostazioni Gun</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="772"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1694"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the rumble motor is enabled.&lt;/p&gt;&lt;p&gt;Under normal conditions, the rumble motor will actuate when shooting offscreen &lt;span style=&quot; font-style:italic;&quot;&gt;(i.e. when the cursor is at the edge of the display)&lt;/span&gt;, and can also provide feedback in various sections of the Pause Menu interface.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Imposta se il motore rumble è abilitato.&lt;/p&gt;&lt;p&gt;In condizioni normali, il motore rumble si azionerà quando si spara fuori dallo schermo &lt;span style=&quot; font-style:italic;&quot;&gt;(ovvero quando il cursore si trova al bordo del display)&lt;/span&gt;, e può anche fornire un feedback in varie sezioni dell&apos;interfaccia del Menu Pausa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="775"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1697"/>
+        <source>Rumble Toggle</source>
+        <translation>Attiva/Disattiva Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="778"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1699"/>
+        <source>Rumble Enabled</source>
+        <translation>Rumble abilitato</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="819"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1716"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set if the solenoid is enabled.&lt;/p&gt;&lt;p&gt;Under normal circumstances, the solenoid actuates when shooting at the display; the &amp;quot;engaged&amp;quot; duration is set in &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Interval&lt;/span&gt;. When depressed for the length of &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length&lt;/span&gt;, the solenoid will fire rapidly for as long as the trigger is held, with &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval&lt;/span&gt; determining state of the &amp;quot;engaged&amp;quot; duration and pause between engagements calculated by &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Fast Interval * Autofire Wait Factor.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Note that the &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; setting conflicts with solenoid functionality, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Imposta se il solenoide è abilitato.&lt;/p&gt;&lt;p&gt;In circostanze normali, il solenoide si aziona quando si spara allo schermo; la durata di &amp;quot;attivazione&amp;quot; è definita in &lt;span style=&quot; font-style:italic;&quot;&gt;Durata Impulso Solenoide&lt;/span&gt;. Quando viene tenuto premuto il grilletto per la durata di &lt;span style=&quot; font-style:italic;&quot;&gt;Durata pressione grilletto per autofire del solenoide&lt;/span&gt;, il solenoide sparerà rapidamente finché il grilletto rimane premuto, con la frequenza &lt;span style=&quot; font-style:italic;&quot;&gt;Durata Impulso Solenoide +Intervallo Autofire Solenoide &lt;/span&gt; che determina lo stato della durata di &amp;quot;attivazione&amp;quot; e la pausa tra i cicli&lt;/p&gt;&lt;p&gt;Nota che l&apos;impostazione &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF (Usa Rumble come Force Feedback principale)&lt;/span&gt; va in conflitto con la funzionalità del solenoide, e verrà disabilitata se questa è attiva.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="822"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1719"/>
+        <source>Solenoid Toggle</source>
+        <translation>Attiva/Disattiva solenoide</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="825"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1721"/>
+        <source>Solenoid Enabled</source>
+        <translation>Solenoide abilitato</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="794"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1704"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable for rapid solenoid feedback while the trigger is pressed.&lt;/p&gt;&lt;p&gt;When enabled, the solenoid will always fire off automatically, as if the trigger has been held when using normal solenoid force feedback.&lt;/p&gt;&lt;p&gt;Note: if &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF&lt;/span&gt; is enabled, this option will provide continuous rumble motor feedback instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Abilita per un feedback continuo e rapido del solenoide mentre il grilletto è premuto.&lt;/p&gt;&lt;p&gt;Quando abilitato, il solenoide scatterà sempre in automatico, come se il grilletto fosse già stato tenuto premuto durante l&apos;uso del normale force feedback del solenoide.&lt;/p&gt;&lt;p&gt;Nota: se l&apos;impostazione &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble FF (Usa Rumble come Force Feedback principale)&lt;/span&gt; è abilitata, questa opzione fornirà invece un feedback continuo del motore rumble.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="797"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1707"/>
+        <source>Autofire Toggle</source>
+        <translation>Attivazione/Disattivazione autofire</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="800"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1709"/>
+        <source>Autofire Enabled</source>
+        <translation>Autofire abilitato</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="803"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1710"/>
+        <source>1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="750"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1684"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the rumble motor will be used for onscreen trigger feedback; taking the place of the solenoid feedback, rather than using the default off-screen motor feedback. Naturally, this requires &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; to be enabled.&lt;/p&gt;&lt;p&gt;Note that &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; takes priority over this setting, and will be disabled if this is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina se il motore rumble verrà utilizzato per il feedback del grilletto a schermo, prendendo il posto del feedback del solenoide anziché utilizzare il feedback predefinito del motore fuori dallo schermo. Naturalmente, questo richiede che il &lt;span style=&quot; font-style:italic;&quot;&gt;Rumble&lt;/span&gt; sia abilitato.&lt;/p&gt;&lt;p&gt;Nota che il &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoide&lt;/span&gt; ha la priorità su questa impostazione e verrà disabilitato se questa è attiva.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="753"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1687"/>
+        <source>Rumble-based Force Feedback Toggle</source>
+        <translation>Attiva/Disattiva Force Feedback tramite Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1438"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1878"/>
+        <source>Simple Pause Menu Toggle</source>
+        <translation>Attiva/Disattiva menu di pausa semplice</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1441"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1880"/>
+        <source>Simple Pause Menu</source>
+        <translation>Menu pausa semplice</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1406"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1868"/>
+        <source>Pause Mode Hold-to-Activate Toggle</source>
+        <translation>Attiva/Disattiva modalità pausa con pressione prolungata</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1409"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1870"/>
+        <source>Hold to Pause Enabled</source>
+        <translation>Abilita pausa con pressione prolungata</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1070"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1778"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines if the 4-pin RGB LED module uses a &lt;span style=&quot; font-style:italic;&quot;&gt;Common Anode&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Common Cathode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enable&lt;/span&gt; if your 4-pin LED is a Common Anode type (with common connected to 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disable&lt;/span&gt; if your 4-pin LED is a Common Cathode (with common connected to GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina se il modulo LED RGB 4-pin utilizza un &lt;span style=&quot; font-style:italic;&quot;&gt;Anodo comune&lt;/span&gt; o un &lt;span style=&quot; font-style:italic;&quot;&gt;Catodo comune.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Abilita&lt;/span&gt; se il tuo LED 4-pin è di tipo ad anodo comune (con il comune collegato a 5V).&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Disabilita&lt;/span&gt; se il tuo LED 4-pin è a catodo comune (con il comune collegato a GND).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1073"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1781"/>
+        <source>4-Pin RGB LED Common Anode Toggle</source>
+        <translation>Attivazione/Disattivazione LED RGB 4-pin ad anodo comune</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1318"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1843"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how &lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; behaves during normal use.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled, &lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Button A&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Button B&lt;/span&gt; will perform different functions when aiming off-screen, instead actuating the functions of &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; respectively.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; all buttons will perform the same functions, regardless of aiming off-screen or not.&lt;/p&gt;&lt;p&gt;Enabled is recommended for lightguns &lt;span style=&quot; font-weight:700;&quot;&gt;with two or less sub buttons.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina il comportamento del &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante A&lt;/span&gt; e del &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante B&lt;/span&gt; durante il normale utilizzo.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando abilitata, &lt;/span&gt;il &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante A&lt;/span&gt; e il &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante B&lt;/span&gt; eseguiranno funzioni diverse quando si punta fuori dallo schermo, azionando rispettivamente le funzioni di &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; e &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt;.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando disabilitata,&lt;/span&gt; tutti i pulsanti eseguiranno le stesse funzioni, indipendentemente dal fatto che si punti o meno fuori dallo schermo.&lt;/p&gt;&lt;p&gt;L&apos;attivazione è consigliata per le lightgun &lt;span style=&quot; font-weight:700;&quot;&gt;con due o meno pulsanti secondari.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1321"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1846"/>
+        <source>Low Buttons Mode Toggle</source>
+        <translation>Attiva/Disattiva modalità pulsanti &apos;fuori schermo&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1324"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1848"/>
+        <source>Low Buttons Mode</source>
+        <translation>Modalità pulsanti &apos;fuori schermo&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="734"/>
+        <location filename="../src/appmainwindow.ui" line="957"/>
+        <location filename="../src/appmainwindow.ui" line="982"/>
+        <location filename="../src/appmainwindow.ui" line="1039"/>
+        <location filename="../src/appmainwindow.ui" line="1358"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1679"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1750"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1760"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1772"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1859"/>
+        <source> ms</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="662"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1658"/>
+        <source>Rumble Intensity:</source>
+        <translation>Intensità Rumble:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="678"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1663"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the intensity of rumble force feedback events. Scales from 0 (disabled) to 255 (maximum).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina l&apos;intensità degli eventi di force feedback del rumble. Scala da 0 (disabilitato) a 255 (massimo).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 255 (100%)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="681"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1666"/>
+        <source>Rumble Intensity Amount</source>
+        <translation>Livello intensità Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="693"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1668"/>
+        <source> / 255</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="706"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1669"/>
+        <source>Rumble Length:</source>
+        <translation>Durata Impulso Rumble:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="722"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1674"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When Rumble is enabled, this setting determines the length of how long the rumble motor is activated when pulling the trigger offscreen, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando il Rumble è abilitato, questa impostazione determina la durata di attivazione del motore rumble quando si preme il grilletto fuori dallo schermo, in millisecondi.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 150 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="725"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1677"/>
+        <source>Length of Rumble Events</source>
+        <translation>Durata impulso Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="945"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1745"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time the solenoid is engaged when the trigger is held, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando il &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoide&lt;/span&gt; è abilitato, questa impostazione determina la durata di attivazione del solenoide quando si tiene premuto il grilletto, in millisecondi.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 45 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1027"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1767"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled and &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; is disabled, this setting determines the time it takes to hold the trigger after a &lt;span style=&quot; font-style:italic;&quot;&gt;single shot&lt;/span&gt; solenoid activation before transitioning to a sustained fire feedback, in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando il &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoide&lt;/span&gt; è abilitato e l&apos;&lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; è disabilitato, questa impostazione determina il tempo per cui il grilletto deve essere tenuto premuto dopo l&apos;attivazione del solenoide a &lt;span style=&quot; font-style:italic;&quot;&gt;colpo singolo&lt;/span&gt; prima di passare a un feedback di fuoco continuo, in millisecondi.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1030"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1770"/>
+        <source>Solenoid Trigger Hold to Autofire Length</source>
+        <translation>Durata pressione del grilletto per l&apos;autofire del solenoide in ms</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1384"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1860"/>
+        <source>Hold-to-Pause Length:</source>
+        <translation>Tempo pressione per pausa:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1346"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1854"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Hold To Pause&lt;/span&gt; mode is enabled, this setting determines how long (in milliseconds) should the buttons be held before Pause Mode activates.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 2500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando la modalità &lt;span style=&quot; font-style:italic;&quot;&gt;Tieni premuto per Pausa&lt;/span&gt; è abilitata, questa impostazione determina per quanto tempo (in millisecondi) i pulsanti debbano essere tenuti premuti prima che la Modalità Pausa si attivi.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 2500 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1349"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1857"/>
+        <source>Length to activate Hold-to-Pause Menu</source>
+        <translation>Tempo pressione per menu pausa</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1086"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1784"/>
+        <source>NeoPixels</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1092"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1785"/>
+        <source>NeoPixel Strand Length: </source>
+        <translation>Lunghezza striscia NeoPixel: </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1177"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1811"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs are in the NeoPixel chain. More than one NeoPixel can be daisychained together, starting from the Pixel that&apos;s directly connected to &lt;span style=&quot; font-style:italic;&quot;&gt;NeoPixel Pin.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina quanti LED sono presenti nella catena NeoPixel. Più NeoPixel possono essere collegati in cascata (daisychain), a partire dal pixel che è direttamente connesso al &lt;span style=&quot; font-style:italic;&quot;&gt;Pin NeoPixel.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1180"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1814"/>
+        <source>NeoPixel Strand Length</source>
+        <translation>Lunghezza striscia NeoPixel</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1189"/>
+        <location filename="../src/appmainwindow.ui" line="1217"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1816"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1827"/>
+        <source> Pixel(s)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1264"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1830"/>
+        <source>Static NeoPixels: </source>
+        <translation>NeoPixel statici: </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1211"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1822"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many LEDs in the NeoPixel chain are statically colored. &lt;/p&gt;&lt;p&gt;These first (x) Pixels &lt;span style=&quot; font-weight:700;&quot;&gt;won&apos;t be affected&lt;/span&gt; by menu elements or Serial LED events. Which colors for which Pixels can be set using the &lt;span style=&quot; font-style:italic;&quot;&gt;Static Color&lt;/span&gt; boxes.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina quanti LED nella catena NeoPixel sono colorati in modo statico. &lt;/p&gt;&lt;p&gt;Questi primi (x) pixel &lt;span style=&quot; font-weight:700;&quot;&gt;non saranno influenzati&lt;/span&gt; dagli elementi del menu o dagli eventi Serial LED. Quali colori assegnare a quali pixel può essere impostato utilizzando le caselle &lt;span style=&quot; font-style:italic;&quot;&gt;Colore statico&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1214"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1825"/>
+        <source>Amount of NeoPixels using Static Colors</source>
+        <translation>Numero di NeoPixel statici</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1220"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1828"/>
+        <location filename="../src/appmainwindow.cpp" line="1593"/>
+        <source>First </source>
+        <translation>Primi </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1115"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1790"/>
+        <source>First NeoPixel Static Color</source>
+        <translation>Primo colore statico NeoPixel</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="62"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1625"/>
+        <source>[No devices currently available]</source>
+        <translation>[Nessun dispositivo disponibile]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="303"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1654"/>
+        <source>Button Mapping</source>
+        <translation>Mappatura Pulsanti</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="363"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1633"/>
+        <source>Digital Inputs</source>
+        <translation>Ingressi Digitali</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="401"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1634"/>
+        <source>On-Screen Function</source>
+        <translation>Azione dentro schermo</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="416"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1635"/>
+        <source>Off-Screen Function</source>
+        <translation>Azione fuori schermo</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="431"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1636"/>
+        <source>Gamepad Mode</source>
+        <translation>Modalità Gamepad</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="466"/>
+        <location filename="../src/appmainwindow.ui" line="2326"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1637"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1986"/>
+        <source>Analog Stick</source>
+        <translation>Stick Analogico</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="485"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1638"/>
+        <source>Send Analog Stick As:</source>
+        <translation>Usa Stick Analogico come:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="492"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1644"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If an analog stick is enabled in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout,&lt;/span&gt; this determines which type of Button Output it uses.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Gamepad Analog Stick&lt;/span&gt; will use either the Left or Right analog stick of the Gamepad device, depending on the circumstances and/or whether &lt;span style=&quot; font-style:italic;&quot;&gt;Gamepad Output Mode&lt;/span&gt; is set via Serial. The other two settings will translate the stick&apos;s analog movements into either digital &lt;span style=&quot; font-weight:700;&quot;&gt;Gamepad D-Pad&lt;/span&gt; or &lt;span style=&quot; font-weight:700;&quot;&gt;Keyboard Arrow Key&lt;/span&gt; presses.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; Gamepad Analog Stick&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se uno stick analogico è abilitato nell&apos;attuale &lt;span style=&quot; font-style:italic;&quot;&gt;Layout Scheda,&lt;/span&gt; questo determina quale tipo di Output Pulsanti utilizza.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Stick Analogico Gamepad&lt;/span&gt; utilizzerà lo stick analogico sinistro o destro del dispositivo Gamepad, a seconda delle circostanze e/o se la &lt;span style=&quot; font-style:italic;&quot;&gt;Modalità Output Gamepad&lt;/span&gt; è impostata via Seriale. Le altre due impostazioni tradurranno i movimenti analogici dello stick in pressioni digitali del &lt;span style=&quot; font-weight:700;&quot;&gt;D-Pad del Gamepad&lt;/span&gt; o dei &lt;span style=&quot; font-weight:700;&quot;&gt;Tasti Freccia della Tastiera&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; Stick Analogico Gamepad&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="495"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1647"/>
+        <source>Analog Stick Output Mode</source>
+        <translation>Modalità Output Stick Analogico</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="502"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1639"/>
+        <source>Gamepad Analog Stick (Left/Right)</source>
+        <translation>Stick Analogico Gamepad (Sinistro/Destro)</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="507"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1640"/>
+        <source>Gamepad D-Pad</source>
+        <translation>D-Pad Gamepad</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="512"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1641"/>
+        <source>Keyboard Arrows</source>
+        <translation>Frecce Tastiera</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="546"/>
+        <location filename="../src/appmainwindow.ui" line="552"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1651"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1653"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows the currently loaded Button Mapping settings.&lt;/p&gt;&lt;p&gt;Any enabled button input in the current &lt;span style=&quot; font-style:italic;&quot;&gt;Board Layout&lt;/span&gt; can be assigned to output any button from any of the three Input Devices that OpenFIRE presents to any connected device (a Mouse, Keyboard, and Xbox-like Gamepad), depending on the condition that the input is pressed.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa scheda mostra le impostazioni di Mappatura Pulsanti attualmente caricate.&lt;/p&gt;&lt;p&gt;Qualsiasi ingresso pulsante abilitato nell&apos;attuale &lt;span style=&quot; font-style:italic;&quot;&gt;Layout Scheda&lt;/span&gt; può essere assegnato per generare l&apos;output di un qualsiasi pulsante appartenente a uno dei tre Dispositivi di Input che OpenFIRE presenta a qualsiasi dispositivo connesso (Mouse, Tastiera e Gamepad in stile Xbox), a seconda della condizione in cui il pulsante viene premuto.&lt;/p&gt;&lt;p&gt;Passa il mouse su un&apos;opzione per visualizzare qui informazioni dettagliate al riguardo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="865"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1724"/>
+        <source>Temperature Warning Threshold:</source>
+        <translation>Soglia di Pericolo Temperatura:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="875"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1725"/>
+        <source>Temperature Shutoff Threshold:</source>
+        <translation>Soglia di Spegnimento per Temperatura:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="885"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1727"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the point at which solenoid activations will force longer OFF periods between sustained fire/autofire shots, in &lt;span style=&quot; font-style:italic;&quot;&gt;degrees Celsius.&lt;/span&gt; Generally speaking, the higher this is set, the longer the solenoid will maintain full sustained fire speeds.&lt;/p&gt;&lt;p&gt;Once this point is hit, the solenoid firing rate is reduced until the temperature monitor reads at least five (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;below&lt;/span&gt; this threshold. The &amp;quot;reduced&amp;quot; firing rate is automatically calculated as &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Solenoid ON Fast Length * 4&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Setting this value too high may reduce the lifespan of the connected solenoid!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo determina il punto in cui le attivazioni del solenoide forzeranno periodi di pausa (OFF) più lunghi tra i colpi a fuoco continuo/automatico, in &lt;span style=&quot; font-style:italic;&quot;&gt;gradi Celsius.&lt;/span&gt; In generale, più alto è questo valore, più a lungo il solenoide manterrà la massima cadenza di fuoco continuo.&lt;/p&gt;&lt;p&gt;Una volta raggiunto questo punto, la cadenza di fuoco del solenoide viene ridotta finché il monitor della temperatura non rileva almeno cinque (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;al di sotto&lt;/span&gt; di questa soglia. La cadenza di fuoco &amp;quot;ridotta&amp;quot; viene calcolata automaticamente come &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Intervallo Autofire Solenoide * 4&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Attenzione: Impostare questo valore troppo alto potrebbe ridurre la vita utile del solenoide collegato!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="888"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1730"/>
+        <source>Temperature Warning Threshold</source>
+        <translation>Soglia di Pericolo Temperatura</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="891"/>
+        <location filename="../src/appmainwindow.ui" line="910"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1732"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1739"/>
+        <source>°C</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="904"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1734"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines the point at which the solenoid will stop activating, in &lt;span style=&quot; font-style:italic;&quot;&gt;degrees Celsius.&lt;/span&gt; Generally speaking, the higher the temperature threshold, the longer the solenoid will activate at reduced sustained fire speeds.&lt;/p&gt;&lt;p&gt;Once this point is triggered, solenoid activations will not be allowed for either single or sustained shots until the temperature monitor reads at least five (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;below&lt;/span&gt; this threshold.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Warning: Setting this value too high WILL reduce the lifespan of the connected solenoid!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina il punto in cui il solenoide smetterà di attivarsi, in &lt;span style=&quot; font-style:italic;&quot;&gt;gradi Celsius.&lt;/span&gt; In generale, maggiore è la soglia di temperatura, più a lungo il solenoide si attiverà a cadenza di fuoco continuo ridotta.&lt;/p&gt;&lt;p&gt;Una volta raggiunto questo punto, le attivazioni del solenoide non saranno consentite né per i colpi singoli né per quelli continui finché il monitor della temperatura non rileva almeno cinque (5)°C &lt;span style=&quot; font-weight:700;&quot;&gt;al di sotto&lt;/span&gt; di questa soglia.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Attenzione: Impostare questo valore troppo alto RIDURRÀ la vita utile del solenoide collegato!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="907"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1737"/>
+        <source>Temperature Shutoff Threshold</source>
+        <translation>Soglia di Spegnimento per Temperatura</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="929"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1740"/>
+        <source>Solenoid ON Length:</source>
+        <translation>Durata Impulso Solenoide:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="948"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1748"/>
+        <source>Solenoid Engagement Length</source>
+        <translation>Durata Impulso Solenoide in ms</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="970"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1755"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid&lt;/span&gt; is enabled, this setting determines the amount of time between solenoid activations when the trigger is held in &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; mode (or after holding the trigger for &lt;span style=&quot; font-style:italic;&quot;&gt;Solenoid Hold Length),&lt;/span&gt; in milliseconds.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Default:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 80 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando &lt;span style=&quot; font-style:italic;&quot;&gt;il Solenoide&lt;/span&gt; è abilitato, questa impostazione determina l&apos;intervallo di tempo tra le attivazioni del solenoide quando il grilletto viene tenuto premuto in modalità &lt;span style=&quot; font-style:italic;&quot;&gt;Autofire&lt;/span&gt; (o dopo aver tenuto premuto il grilletto per la &lt;span style=&quot; font-style:italic;&quot;&gt;Durata Pressione grillettp per autofire del Solenoide),&lt;/span&gt; in millisecondi.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;Predefinito:&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt; 80 (ms)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="973"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1758"/>
+        <source>Solenoid Autofire Wait Length</source>
+        <translation>Intervallo Autofire Solenoide in ms</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="992"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1761"/>
+        <source>Solenoid Autofire Wait Time:</source>
+        <translation>Intervallo Autofire Solenoide:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1112"/>
+        <location filename="../src/appmainwindow.ui" line="1134"/>
+        <location filename="../src/appmainwindow.ui" line="1156"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1787"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1794"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1801"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to set the color for this Pixel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clicca per impostare il colore di questo Pixel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1118"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1792"/>
+        <source>Static Color 1</source>
+        <translation>Colore statico 1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1137"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1797"/>
+        <source>Second NeoPixel Static Color</source>
+        <translation>Colore statico del secondo NeoPixel</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1140"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1799"/>
+        <source>Static Color 2</source>
+        <translation>Colore statico 2</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1159"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1804"/>
+        <source>Third NeoPixel Static Color</source>
+        <translation>Colore statico del terzo NeoPixel</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1162"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1806"/>
+        <source>Static Color 3</source>
+        <translation>Colore statico 3</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1241"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1829"/>
+        <source>Changes to NeoPixel settings may require a power cycle to update properly!</source>
+        <translation>Le modifiche alle impostazioni NeoPixel potrebbero richiedere lo spegnimento e la riaccensione per essere applicate correttamente!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1287"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1832"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enabling this setting will have statically illuminated pixels set to the &lt;span style=&quot; font-style:italic;&quot;&gt;last&lt;/span&gt; X Pixel(s), rather than the default &lt;span style=&quot; font-style:italic;&quot;&gt;first&lt;/span&gt; X Pixel(s).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Abilitando questa impostazione, i pixel illuminati in modo statico verranno impostati sugli &lt;span style=&quot; font-style:italic;&quot;&gt;ultimi&lt;/span&gt; X Pixel, anziché sui &lt;span style=&quot; font-style:italic;&quot;&gt;primi&lt;/span&gt; X Pixel predefiniti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1290"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1835"/>
+        <source>Set Static Pixels to First/Last Pixels Toggle</source>
+        <translation>Attiva/Disattiva settaggio Pixel Statici ai Primi/Ultimi Pixel</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1293"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1837"/>
+        <source>Invert Static Colors</source>
+        <translation>Inverti Colori Statici</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1403"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1865"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how to trigger Pause Mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode can be activated by holding &lt;span style=&quot; font-style:italic;&quot;&gt;Trigger&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Button A &lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;while no IR points are visible.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Mode can be activated by pressing the Pause Mode hotkey (Button C + Select).&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons.&lt;/span&gt; Note that regardless of setting, Pause Mode can always be accessed by pressing the Home Button (if set).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina come attivare la Modalità Pausa.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando abilitata,&lt;/span&gt; la Modalità Pausa può essere attivata tenendo premuti il &lt;span style=&quot; font-style:italic;&quot;&gt;Grilletto&lt;/span&gt; e il &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante A &lt;/span&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;mentre non ci sono punti IR visibili.&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando disabilitata,&lt;/span&gt; la Modalità Pausa può essere attivata premendo la scorciatoia della Modalità Pausa (Pulsante C + Select).&lt;/p&gt;&lt;p&gt;L&apos;abilitazione è consigliata per le pistole &lt;span style=&quot; font-weight:700;&quot;&gt;con meno di due pulsanti secondari.&lt;/span&gt; Nota che, indipendentemente dall&apos;impostazione, è sempre possibile accedere alla Modalità Pausa premendo il Pulsante Home (se impostato).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1435"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1875"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how Pause Mode functions.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Enabled,&lt;/span&gt; Pause Mode will use a scrolling menu layout - navigate by using &lt;span style=&quot; font-style:italic;&quot;&gt;Button A/B&lt;/span&gt; to select, and press Trigger to activate.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;When Disabled,&lt;/span&gt; Pause Menu options are activated with hotkeys.&lt;/p&gt;&lt;p&gt;Enabled is recommended for guns &lt;span style=&quot; font-weight:700;&quot;&gt;with less than two sub buttons,&lt;/span&gt; but &lt;span style=&quot; font-weight:700;&quot;&gt;requires an LED or OLED Display for visual feedback!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa impostazione determina il funzionamento della Modalità Pausa.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando abilitata,&lt;/span&gt; la Modalità Pausa utilizzerà un layout a menu scorrevole - naviga usando il &lt;span style=&quot; font-style:italic;&quot;&gt;Pulsante A/B&lt;/span&gt; per selezionare e premi il Grilletto per attivare.&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Quando disabilitata,&lt;/span&gt; le opzioni del Menu Pausa vengono attivate tramite scorciatoie.&lt;/p&gt;&lt;p&gt;L&apos;abilitazione è consigliata per le pistole &lt;span style=&quot; font-weight:700;&quot;&gt;con meno di due pulsanti secondari,&lt;/span&gt; ma &lt;span style=&quot; font-weight:700;&quot;&gt;richiede un Display LED o OLED per il feedback visivo!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1454"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1881"/>
+        <source>I2C Peripherals</source>
+        <translation>Periferiche I2C</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1460"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1883"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SDA)&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Peripheral I2C (SCL)&lt;/span&gt; pins are set, enable use of an SSD1306 OLED display.&lt;/p&gt;&lt;p&gt;The OLED display can be used to navigate on-gun settings, visualize special modes, and display Ammo &amp;amp; Life counts in compatible software.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE:&lt;/span&gt; Because this device does not communicate back to the board, the firmware has no way of knowing whether the device successfully initialized or not. If the display is connected properly, but does &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; seem to power on on startup/after syncing settings, then try the &lt;span style=&quot; font-style:italic;&quot;&gt;Use Alternative Device Address&lt;/span&gt; setting before attempting to rewire the device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se i pin &lt;span style=&quot; font-style:italic;&quot;&gt;della Periferica I2C (SDA)&lt;/span&gt; e &lt;span style=&quot; font-style:italic;&quot;&gt;Periferica I2C (SCL)&lt;/span&gt; sono impostati, abilita l&apos;uso di un display OLED SSD1306.&lt;/p&gt;&lt;p&gt;Il display OLED può essere utilizzato per navigare nelle impostazioni sulla pistola, visualizzare modalità speciali e mostrare i contatori di Munizioni &amp;amp; Vita nei software compatibili.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTA:&lt;/span&gt; Poiché questo dispositivo non comunica a ritroso con la scheda, il firmware non ha modo di sapere se il dispositivo si sia inizializzato correttamente o meno. Se il display è collegato correttamente, ma &lt;span style=&quot; font-weight:700;&quot;&gt;non&lt;/span&gt; sembra accendersi all&apos;avvio/dopo la sincronizzazione delle impostazioni, prova ad abilitare &lt;span style=&quot; font-style:italic;&quot;&gt;Usa Indirizzo Dispositivo Alternativo&lt;/span&gt; prima di tentare di ricablare il dispositivo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1463"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1886"/>
+        <source>I2C OLED Display Toggle</source>
+        <translation>Attiva/Disattiva Display OLED I2C</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1466"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1888"/>
+        <source>Enable OLED Display (SSD1306 128x64)</source>
+        <translation>Abilita Display OLED (SSD1306 128x64)</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1476"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1889"/>
+        <source>SSD1306 OLED Display</source>
+        <translation>Display OLED SSD1306</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1482"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1891"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the display doesn&apos;t seem to power on when &lt;span style=&quot; font-style:italic;&quot;&gt;Enable OLED Display&lt;/span&gt; is set on startup/after syncing settings to the device (and you have confirmed that it is wired correctly), enabling this will try a different start address.&lt;/p&gt;&lt;p&gt;The firmware&apos;s display component normally defaults to I2C address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3C&lt;/span&gt;, but some 128x64 screens may have device address &lt;span style=&quot; font-weight:700;&quot;&gt;0x3D&lt;/span&gt; instead, which this setting will inform the firmware to try instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Se il display non sembra accendersi quando &lt;span style=&quot; font-style:italic;&quot;&gt;Abilita Display OLED&lt;/span&gt; è impostato all&apos;avvio/dopo aver sincronizzato le impostazioni col dispositivo (e hai verificato che sia cablato correttamente), abilitando questa opzione verrà tentato un indirizzo di avvio diverso.&lt;/p&gt;&lt;p&gt;Il componente display del firmware normalmente usa di default l&apos;indirizzo I2C &lt;span style=&quot; font-weight:700;&quot;&gt;0x3C&lt;/span&gt;, ma alcuni schermi 128x64 potrebbero avere invece l&apos;indirizzo dispositivo &lt;span style=&quot; font-weight:700;&quot;&gt;0x3D&lt;/span&gt;, che questa impostazione indicherà al firmware di provare in alternativa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1485"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1894"/>
+        <source>I2C OLED Device Alternate Address Toggle</source>
+        <translation>Attiva/Disattiva Indirizzo Alternativo Dispositivo OLED I2C</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1488"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1896"/>
+        <source>Use Alternative Device Address</source>
+        <translation>Usa Indirizzo Dispositivo Alternativo</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1517"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1897"/>
+        <source>TinyUSB Identifier</source>
+        <translation>Identificatore TinyUSB</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1531"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1898"/>
+        <source>For Multiplayer, make sure each gun has its own unique identifier!</source>
+        <translation>Per il Multiplayer, assicurati che ogni LightGun abbia un ID unico!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1561"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1900"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start/Select key mappings will default to &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; binds (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) for custom identifiers set here:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le mappature dei tasti Start/Select utilizzeranno come predefinite i settaggi del &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; (&lt;span style=&quot; font-weight:700;&quot;&gt;Key_1&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-weight:700;&quot;&gt;Key_5&lt;/span&gt;) per gli identificatori personalizzati impostati qui:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1573"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1901"/>
+        <source>Product ID:</source>
+        <translation>ID LightGun:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1599"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1903"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the custom Product ID that the microcontroller reports when connected to any given device, in base 16 hexadecimal (0-F)&lt;/p&gt;&lt;p&gt;Custom Product IDs &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;Note: The USB Vendor ID is hard-coded into the firmware, &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;0xF143.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo determina l&apos;ID Prodotto personalizzato che il microcontrollore comunica quando viene connesso a un qualsiasi dispositivo, in esadecimale a base 16 (0-F).&lt;/p&gt;&lt;p&gt;ID Prodotto personalizzati &lt;span style=&quot; font-weight:700;&quot;&gt;sono necessari&lt;/span&gt; per distinguere le diverse lightgun nelle applicazioni in grado di indirizzare singolarmente più dispositivi mouse.&lt;/p&gt;&lt;p&gt;Nota: Il Vendor ID USB è codificato in modo fisso (hard-coded) nel firmware, &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;0xF143.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1602"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1906"/>
+        <source>Custom USB Product ID</source>
+        <translation>ID prodotto USB personalizzato</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1608"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1908"/>
+        <source>0x</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1624"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1909"/>
+        <source>Product Name:</source>
+        <translation>Nome LightGUN:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1653"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1914"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This dictates the custom Product Name that the microcontroller reports when connected to any given device.&lt;/p&gt;&lt;p&gt;Custom Product Names are helpful (and in some cases, &lt;span style=&quot; font-weight:700;&quot;&gt;required&lt;/span&gt;) to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo definisce il Nome della LightGun personalizzato che il microcontrollore comunica quando viene connesso a un qualsiasi dispositivo.&lt;/p&gt;&lt;p&gt;I Nomi delle LightGun personalizzati sono utili (e in alcuni casi, &lt;span style=&quot; font-weight:700;&quot;&gt;necessari&lt;/span&gt;) per distinguere le diverse lightgun nelle applicazioni in grado di indirizzare singolarmente più dispositivi mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1656"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1917"/>
+        <source>Custom USB Product Name</source>
+        <translation>Nome LightGun USB personalizzato</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1668"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1919"/>
+        <source>(15 Characters)</source>
+        <translation>(15 caratteri)</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1703"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1921"/>
+        <source>Start/Select key mappings will change according to the player identifier set here:</source>
+        <translation>La mappatura dei tasti Start/Select cambierà in base all&apos;identificatore del giocatore impostato qui:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1715"/>
+        <location filename="../src/appmainwindow.ui" line="1731"/>
+        <location filename="../src/appmainwindow.ui" line="1747"/>
+        <location filename="../src/appmainwindow.ui" line="1763"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1923"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1930"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1937"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1944"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines the Product ID and Name that the microcontroller reports when connected to any given device, in decimal (with its hexadecimal equivalent).&lt;/p&gt;&lt;p&gt;Different Identifiers &lt;span style=&quot; font-weight:700;&quot;&gt;are required&lt;/span&gt; to distinguish different lightguns in applications that can individually address multiple mouse devices.&lt;/p&gt;&lt;p&gt;When using any &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Preset,&lt;/span&gt; the &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; &amp;amp; &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; keyboard mappings (used by default) will be changed to reflect the player slot preset used (e.g. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;1 &amp;amp; 5,&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; will emit &lt;span style=&quot; font-style:italic;&quot;&gt;2 &amp;amp; 6,&lt;/span&gt; etc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo determina l&apos;ID Prodotto e il Nome che il microcontrollore comunica quando viene connesso a un qualsiasi dispositivo, in decimale (con il relativo equivalente esadecimale).&lt;/p&gt;&lt;p&gt;Identificatori differenti &lt;span style=&quot; font-weight:700;&quot;&gt;sono necessari&lt;/span&gt; per distinguere le diverse lightgun nelle applicazioni in grado di indirizzare singolarmente più dispositivi mouse.&lt;/p&gt;&lt;p&gt;Quando si utilizza un qualsiasi &lt;span style=&quot; font-style:italic;&quot;&gt;Preset ID USB semplice,&lt;/span&gt; le mappature della tastiera per &lt;span style=&quot; font-style:italic;&quot;&gt;Start&lt;/span&gt; e &lt;span style=&quot; font-style:italic;&quot;&gt;Select&lt;/span&gt; (utilizzate come predefinite) verranno modificate per riflettere lo slot del giocatore utilizzato dal preset (es. &lt;span style=&quot; font-style:italic;&quot;&gt;P1&lt;/span&gt; invierà &lt;span style=&quot; font-style:italic;&quot;&gt;1 e 5,&lt;/span&gt; &lt;span style=&quot; font-style:italic;&quot;&gt;P2&lt;/span&gt; invierà &lt;span style=&quot; font-style:italic;&quot;&gt;2 e 6,&lt;/span&gt; ecc.).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1718"/>
+        <location filename="../src/appmainwindow.ui" line="1734"/>
+        <location filename="../src/appmainwindow.ui" line="1750"/>
+        <location filename="../src/appmainwindow.ui" line="1766"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1926"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1933"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1940"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1947"/>
+        <source>Simple USB Identifier Presets</source>
+        <translation>Preset semplici per l&apos;identificatore USB</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1721"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1928"/>
+        <source>P1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1737"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1935"/>
+        <source>P2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1753"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1942"/>
+        <source>P3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1769"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1949"/>
+        <source>P4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1784"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1951"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This determines whether to show/use &lt;span style=&quot; font-style:italic;&quot;&gt;Simple USB ID Presets&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;Custom USB ID Settings.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This can be useful for users with either more than four OpenFIRE lightguns, or simply want to personalize each lightgun, but the &lt;span style=&quot; font-style:italic;&quot;&gt;Simple Presets&lt;/span&gt; may be preferable to some.&lt;/p&gt;&lt;p&gt;All lightguns default to a &lt;span style=&quot; font-style:italic;&quot;&gt;P1 Simple USB ID Preset.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo determina se mostrare/utilizzare i &lt;span style=&quot; font-style:italic;&quot;&gt;Preset ID USB semplici&lt;/span&gt; o le &lt;span style=&quot; font-style:italic;&quot;&gt;Impostazioni ID USB personalizzate.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Questo può essere utile per gli utenti che possiedono più di quattro lightgun OpenFIRE, o che desiderano semplicemente personalizzare ogni lightgun, ma i &lt;span style=&quot; font-style:italic;&quot;&gt;Preset semplici&lt;/span&gt; potrebbero essere preferibili per alcuni.&lt;/p&gt;&lt;p&gt;Tutte le lightgun sono impostate come predefinite su un &lt;span style=&quot; font-style:italic;&quot;&gt;Preset ID USB semplice P1.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1787"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1954"/>
+        <source>Toggle Advanced USB ID Settings</source>
+        <translation>Attiva/Disattiva impostazioni USB ID avanzate</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1790"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1956"/>
+        <source>Advanced View</source>
+        <translation>Visualizzazione avanzata</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1821"/>
+        <location filename="../src/appmainwindow.ui" line="1827"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1959"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1961"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab has a variety of settings to tweak about the lightgun&apos;s force feedback, lighting effects, and how it presents itself to the device.&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa scheda contiene diverse impostazioni per regolare il force feedback della lightgun, gli effetti di illuminazione e il modo in cui si presenta al dispositivo.&lt;/p&gt;&lt;p&gt;Passa il mouse sopra un&apos;opzione per visualizzare qui informazioni dettagliate a riguardo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2133"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1976"/>
+        <source>Display Ratio</source>
+        <translation>Display</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2277"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1983"/>
+        <source>Inputs Test</source>
+        <translation>Test Ingressi</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2283"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1984"/>
+        <source>Buttons</source>
+        <translation>Pulsanti</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2307"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1985"/>
+        <source>Temperature Sensor (N/A)</source>
+        <translation>Sensore di Temperatura (N/D)</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2524"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1999"/>
+        <location filename="../src/appmainwindow.cpp" line="1038"/>
+        <source>[Currently Not Connected]</source>
+        <translation>[Attualmente Non Connesso]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2558"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="2002"/>
+        <source>View</source>
+        <translation>Visualizza</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2582"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1609"/>
+        <source>&amp;OpenFIRE Documentation on the Repo...</source>
+        <translation>Documentazione &amp;OpenFIRE sul Repo...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2593"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1613"/>
+        <source>OpenFIRE &amp;Serial Usage Docs on the Wiki...</source>
+        <translation>Uso della &amp;Seriale OpenFIRE sulla Wiki...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2634"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1620"/>
+        <source>Debug Window</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2642"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1621"/>
+        <source>OpenFIRE on the Web</source>
+        <translation>OpenFIRE sul Web</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2655"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1622"/>
+        <source>View Compatible Boards</source>
+        <translation>Visualizza Schede Compatibili</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2663"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1623"/>
+        <source>Show Unsafe Settings</source>
+        <translation>Mostra Impostazioni Non Sicure</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1853"/>
+        <location filename="../src/appmainwindow.ui" line="1913"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1963"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1982"/>
+        <source>Calibration Profiles</source>
+        <translation>Profili di calibrazione</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="641"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1655"/>
+        <source>Force Feedback</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="647"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1656"/>
+        <source>Rumble</source>
+        <translation>Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="756"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1689"/>
+        <source>Use Rumble as primary Force Feedback</source>
+        <translation>Usa Rumble come Force Feedback principale</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="810"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1711"/>
+        <source>Solenoid</source>
+        <translation>Solenoide</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1008"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1762"/>
+        <source>Solenoid Hold-to-Autofire Length:</source>
+        <translation>Durata pressione grilletto per autofire del solenoide:</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1061"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1773"/>
+        <source>Lighting</source>
+        <translation>Illuminazione</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1076"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1783"/>
+        <source>4-Pin RGB Common Anode</source>
+        <translation>RGB 4-pin ad anodo comune</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1309"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1838"/>
+        <source>Input</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1337"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1849"/>
+        <source>UI and UX</source>
+        <translation>UI e UX</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1988"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1970"/>
+        <source>Layout</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2012"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1971"/>
+        <source>Left</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2036"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1972"/>
+        <source>Right</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1921"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1964"/>
+        <source>Bottom</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1978"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1969"/>
+        <source>Run Mode</source>
+        <translation>Modalità</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1948"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1966"/>
+        <source>TRled</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1968"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1968"/>
+        <source>TLled</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2109"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1975"/>
+        <source>Top</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2053"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1973"/>
+        <source>Color</source>
+        <translation>Colore</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="1958"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1967"/>
+        <source>Sensitivity</source>
+        <translation>Sensibilità</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2182"/>
+        <location filename="../src/appmainwindow.ui" line="2188"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1979"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1981"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tab shows information and settings to tweak about your current calibration profiles.&lt;/p&gt;&lt;p&gt;The table above represents the amount of profiles the current board can store, including currently selected profile, names shown for each profile when using a compatible &lt;span style=&quot; font-style:italic;&quot;&gt;I2C Display,&lt;/span&gt; and colors used for lighting devices when switching to them from &lt;span style=&quot; font-style:italic;&quot;&gt;Pause Mode.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hover over an option to view detailed info about it here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questa scheda mostra informazioni e impostazioni per regolare i profili di calibrazione correnti.&lt;/p&gt;&lt;p&gt;La tabella sopra mostra il numero di profili che la scheda corrente può memorizzare, incluso il profilo attualmente selezionato, i nomi visualizzati per ciascun profilo quando si utilizza un &lt;span style=&quot; font-style:italic;&quot;&gt;display I2C&lt;/span&gt; compatibile e i colori utilizzati per i dispositivi di illuminazione quando si passa ad essi dalla &lt;span style=&quot; font-style:italic;&quot;&gt;Modalità Pausa&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;Passa il mouse sopra un&apos;opzione per visualizzare qui informazioni dettagliate a riguardo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2217"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1998"/>
+        <source>Gun Tests</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2396"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1988"/>
+        <source>Feedback Tests</source>
+        <translation>Test Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2404"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1989"/>
+        <source>Test Rumble Motor</source>
+        <translation>Test motore Rumble</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2411"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1990"/>
+        <source>Test Solenoid</source>
+        <translation>Test Solenoide</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2422"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1991"/>
+        <source>Test Red LED</source>
+        <translation>Test LED rosso</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2429"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1992"/>
+        <source>Test Green LED</source>
+        <translation>Test LED verde</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2436"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1993"/>
+        <source>Test Blue LED</source>
+        <translation>Test LED blu</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2448"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1994"/>
+        <source>Open IR Camera Tester...</source>
+        <translation>Apri Tester telecamera IR...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2478"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1995"/>
+        <source>Board Actions</source>
+        <translation>Azioni scheda</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2500"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1997"/>
+        <source>Clear Save Memory [!]</source>
+        <translation>Cancella memoria di salvataggio [!]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2487"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1996"/>
+        <source>Reboot to Bootloader</source>
+        <translation>Riavvia in modalità Bootloader</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2541"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="2000"/>
+        <source>About</source>
+        <translation>Informazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2547"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="2001"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Aiuto</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2574"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1608"/>
+        <source>&amp;About OpenFIRE...</source>
+        <translation>&amp;Informazioni su OpenFIRE...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2585"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1611"/>
+        <source>Alt+D</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2596"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1615"/>
+        <source>Alt+S</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2604"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1617"/>
+        <source>Open &amp;IR Emitter Alignment Assistant</source>
+        <translation>Apri &amp;Assistente allineamento emettitori IR</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2612"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1618"/>
+        <source>Import Custom Layout...</source>
+        <translation>Importa layout personalizzato...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.ui" line="2623"/>
+        <location filename="../build/Desktop_Qt_6_9_0_MinGW_64_bit-Debug/OpenFIREapp_autogen/include/ui_appmainwindow.h" line="1619"/>
+        <source>Export Custom Layout...</source>
+        <translation>Esporta layout personalizzato...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="54"/>
+        <source>ERROR: User doesn&apos;t have serial permissions!</source>
+        <translation>ERRORE: L&apos;utente non ha i permessi per la porta seriale!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="55"/>
+        <source>Currently, your user is not allowed to have access to serial devices.
+
+To add yourself to the right group, run this command in a terminal and then re-login to your session:
+
+sudo usermod -aG dialout </source>
+        <translation>Attualmente, il tuo utente non ha i permessi per accedere ai dispositivi seriali.
+
+Per aggiungere il tuo utente al gruppo corretto, esegui questo comando in un terminale e poi effettua nuovamente l&apos;accesso alla sessione:
+
+sudo usermod -aG dialout </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="61"/>
+        <source>ERROR: Running as root is not allowed!</source>
+        <translation>ERRORE: L&apos;esecuzione come root non è consentita!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="61"/>
+        <source>Please run the OpenFIRE app as a normal user.</source>
+        <translation>Per favore avvia l’app OpenFIRE come utente normale.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="161"/>
+        <source>Onscreen Button Output Type for %1</source>
+        <translation>Tipo di output pulsante a schermo per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="162"/>
+        <source>&lt;p&gt;Select the type of button that &lt;i&gt;%1&lt;/i&gt; will function as &lt;b&gt;when the gun is pointing at the screen.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Each available input defined in the current &lt;i&gt;Board Layout&lt;/i&gt; can be defined as a button press for one of the three available device outputs that the gun presents to the connected device.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona il tipo di pulsante che &lt;i&gt;%1&lt;/i&gt; simulerà &lt;b&gt;quando la pistola è puntata verso lo schermo.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Ogni input disponibile definito nell&apos;attuale &lt;i&gt;Layout Scheda&lt;/i&gt; può essere configurato come la pressione di un pulsante per uno dei tre output disponibili che la pistola presenta al dispositivo connesso.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="166"/>
+        <source>Onscreen Button Mapping for %1</source>
+        <translation>Mappatura pulsante a schermo per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="167"/>
+        <source>&lt;p&gt;Select the output that &lt;i&gt;%1&lt;/i&gt; will send to the connected device &lt;b&gt;when the gun is pointing at the screen.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Each available input defined in the current &lt;i&gt;Board Layout&lt;/i&gt; can be defined as a button press for one of the three available device outputs that the gun presents to the connected device.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona l&apos;output che &lt;i&gt;%1&lt;/i&gt; invierà al dispositivo connesso &lt;b&gt;quando la pistola è puntata verso lo schermo.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Ogni input disponibile definito nell&apos;attuale &lt;i&gt;Layout Scheda&lt;/i&gt; può essere configurato come la pressione di un pulsante per uno dei tre output disponibili che la pistola presenta al dispositivo connesso.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="173"/>
+        <source>Offscreen Button Output Type for %1</source>
+        <translation>Tipo di output pulsante fuori schermo per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="174"/>
+        <source>&lt;p&gt;Select the type of button that &lt;i&gt;%1&lt;/i&gt; will function as &lt;b&gt;when the gun is pointing outside of the screen.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Each available input defined in the current &lt;i&gt;Board Layout&lt;/i&gt; can be defined as a button press for one of the three available device outputs that the gun presents to the connected device.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona il tipo di pulsante che &lt;i&gt;%1&lt;/i&gt; simulerà &lt;b&gt;quando la pistola è puntata fuori dallo schermo.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Ogni input disponibile definito nell&apos;attuale &lt;i&gt;Layout Scheda&lt;/i&gt; può essere configurato come la pressione di un pulsante per uno dei tre output disponibili che la pistola presenta al dispositivo connesso.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="178"/>
+        <source>Offscreen Button Mapping for %1</source>
+        <translation>Mappatura pulsante fuori schermo per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="179"/>
+        <source>&lt;p&gt;Select the output that &lt;i&gt;%1&lt;/i&gt; will send to the connected device &lt;b&gt;when the gun is pointing outside of the screen.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Each available input defined in the current &lt;i&gt;Board Layout&lt;/i&gt; can be defined as a button press for one of the three available device outputs that the gun presents to the connected device.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona l&apos;output che &lt;i&gt;%1&lt;/i&gt; invierà al dispositivo connesso &lt;b&gt;quando la pistola è puntata fuori dallo schermo.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Ogni input disponibile definito nell&apos;attuale &lt;i&gt;Layout Scheda&lt;/i&gt; può essere configurato come la pressione di un pulsante per uno dei tre output disponibili che la pistola presenta al dispositivo connesso.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="185"/>
+        <source>Gamepad Mode Output Type for %1</source>
+        <translation>Tipo di output modalità Gamepad per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="186"/>
+        <source>&lt;p&gt;Select the type of button that &lt;i&gt;%1&lt;/i&gt; will function as &lt;b&gt;when the gun set to Gamepad Output Mode.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Only Gamepad-type outputs are available for Gamepad Output Mode, which can be set via &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Serial command&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M0x1&lt;/tt&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona il tipo di pulsante che &lt;i&gt;%1&lt;/i&gt; simulerà &lt;b&gt;quando la pistola è impostata in Modalità Output Gamepad.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Solo gli output di tipo Gamepad sono disponibili per la Modalità Output Gamepad, che può essere impostata tramite il &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Comando seriale&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M0x1&lt;/tt&gt;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="191"/>
+        <source>Gamepad Mode Button Mapping for %1</source>
+        <translation>Mappatura pulsante modalità Gamepad per %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="192"/>
+        <source>&lt;p&gt;Select the output that &lt;i&gt;%1&lt;/i&gt; will send to the connected device &lt;b&gt;when the gun is set to Gamepad Output Mode.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Only Gamepad buttons are available to be mapped for Gamepad Output Mode, which can be set via &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Serial command&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M0x1&lt;/tt&gt;.&lt;/p&gt;&lt;p&gt;&lt;b&gt;NOTE:&lt;/b&gt; When connected to the MiSTer FPGA device, these mappings will NOT be reflected, as OpenFIRE has a hard-coded button layout specifically optimized for the MiSTer ecosystem.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Seleziona l&apos;output che &lt;i&gt;%1&lt;/i&gt; invierà al dispositivo connesso &lt;b&gt;quando la pistola è impostata in Modalità Output Gamepad.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Solo i pulsanti Gamepad sono disponibili per essere mappati per la Modalità Output Gamepad, che può essere impostata tramite il &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Comando seriale&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M0x1&lt;/tt&gt;.&lt;/p&gt;&lt;p&gt;&lt;b&gt;NOTA:&lt;/b&gt; Quando connessa al dispositivo MiSTer FPGA, queste mappature NON verranno riflesse, poiché OpenFIRE ha un layout di pulsanti hard-coded ottimizzato specificamente per l&apos;ecosistema MiSTer.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="242"/>
+        <source>Welcome to the OpenFIRE app!</source>
+        <translation>Benvenuto nell&apos;app OpenFIRE!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="414"/>
+        <source>Save and Send Settings</source>
+        <translation>Salva e invia impostazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="418"/>
+        <source>[Nothing To Save]</source>
+        <translation>[Niente da salvare]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="442"/>
+        <source>Temperature Read...</source>
+        <translation>Lettura temperatura...</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="445"/>
+        <source>Temperature Sensor (N/C)</source>
+        <translation>Sensore temperatura (N/C)</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="454"/>
+        <source>Not Connected</source>
+        <translation>Non connesso</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="501"/>
+        <source>[Disabled while in Test Mode]</source>
+        <translation>[Disabilitato in modalità Test]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="520"/>
+        <source>Commit Confirmation</source>
+        <translation>Conferma modifiche</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="520"/>
+        <source>Are these settings okay?</source>
+        <translation>Queste impostazioni sono corrette?</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="521"/>
+        <source>These settings will be committed to your lightgun. Is that okay?</source>
+        <translation>Queste impostazioni verranno salvate sulla lightgun. Continuare?</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="530"/>
+        <source>Sent settings successfully!</source>
+        <translation>Impostazioni inviate con successo!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="571"/>
+        <source>Save operation canceled.</source>
+        <translation>Operazione di salvataggio annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="633"/>
+        <source>Rename Profile %1</source>
+        <translation>Rinomina profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="634"/>
+        <source>&lt;p&gt;Click to rename this Calibration Profile.&lt;/p&gt;&lt;p&gt;Aside from differentiating between different profiles for different displays, Cali Profile names are displayed in Pause Mode when using a compatible &lt;i&gt;I2C Display.&lt;/i&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Clicca per rinominare questo Profilo di Calibrazione.&lt;/p&gt;&lt;p&gt;Oltre a distinguere tra diversi profili per schermi diversi, i nomi dei Profili di Calibrazione vengono visualizzati in Modalità Pausa quando si utilizza un &lt;i&gt;Display I2C&lt;/i&gt; compatibile.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="659"/>
+        <source>Camera Sensitivity for Profile %1</source>
+        <translation>Sensibilità fotocamera per profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="660"/>
+        <source>&lt;p&gt;This setting determines the sensitivity of the IR Camera for this Calibration Profile.&lt;/p&gt;&lt;p&gt;If the camera seems to have trouble picking up IR emitters (and is causing coarse cursor movement), adjusting this setting higher might fix issues with tracking.&lt;br&gt;Conversely, setting sensitivity too high may cause indirect IR sources (such as sunlight or IR bouncing off of reflective surfaces) to be picked up instead, causing the cursor to jitter or erratically jump across the screen.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Questa impostazione determina la sensibilità della Telecamera IR per questo Profilo di Calibrazione.&lt;/p&gt;&lt;p&gt;Se la telecamera sembra avere problemi a rilevare gli emettitori IR (e causa un movimento a scatti del cursore), aumentare questa impostazione potrebbe risolvere i problemi di tracciamento.&lt;br&gt;Al contrario, impostare la sensibilità troppo alta potrebbe far sì che vengano rilevate sorgenti IR indirette (come la luce del sole o gli IR che rimbalzano su superfici riflettenti), causando il tremolio del cursore o salti irregolari da una parte all&apos;altra dello schermo.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="675"/>
+        <source>Camera Position Averaging Mode for Profile %1</source>
+        <translation>Modalità stabilizzazione fotocamera per profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="676"/>
+        <source>&lt;p&gt;This setting determines the cursor Averaging Mode for this Calibration Profile.&lt;/p&gt;&lt;p&gt;The movement of the aiming cursor can be smoothed out by averaging a select number of frames, at the cost of a small increase in latency; conversely, disabling this position averaging can reduce latency, at the cost of some added jitter in mouse movement.&lt;/p&gt;&lt;p&gt;The default is &lt;b&gt;1-Frame Avg&lt;/b&gt;, which should be the preferred balance for most people.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Questa impostazione determina la Modalità di Media del cursore per questo Profilo di Calibrazione.&lt;/p&gt;&lt;p&gt;Il movimento del cursore di mira può essere reso più fluido calcolando la media di un numero selezionato di frame, a costo di un piccolo aumento della latenza; al contrario, disabilitare questa media della posizione può ridurre la latenza, a costo di un maggiore tremolio nel movimento del mouse.&lt;/p&gt;&lt;p&gt;L&apos;impostazione predefinita è &lt;b&gt;1-Frame Avg&lt;/b&gt;, che dovrebbe rappresentare il bilanciamento ideale per la maggior parte delle persone.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="690"/>
+        <source>IR Emitter Layout for Profile %1</source>
+        <translation>Layout emettitori IR per profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="691"/>
+        <source>&lt;p&gt;This setting determines the IR Layout to be used with this Calibration Profile.&lt;/p&gt;&lt;p&gt;Each Cali Profile can be set to use either the &lt;i&gt;Square Layout,&lt;/i&gt; which uses two pairs of emitters on the top and bottom, and &lt;i&gt;Diamond Layout,&lt;/i&gt; which uses one emitter at the center of each side of the display.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Square Layout&lt;/i&gt; generally has much higher accuracy at any angle and allows for playing closer to the screen or using external Fish Eye lenses without viewport distortion, while &lt;i&gt;Diamond Layout&lt;/i&gt; is for screen compatibility with certain legacy lightgun systems (allowing OpenFIRE guns to play with such other lightgun systems on the same display).&lt;/p&gt;&lt;p&gt;If unsure, use &lt;b&gt;Square Layout&lt;/b&gt; (unless you also use a different brand of lightgun that needs a diamond IR layout to function).&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Questa impostazione determina il Layout IR da utilizzare con questo Profilo di Calibrazione.&lt;/p&gt;&lt;p&gt;Ogni Profilo di Calibrazione può essere impostato per utilizzare il &lt;i&gt;Layout Square,&lt;/i&gt; che impiega due coppie di emettitori in alto e in basso, o il &lt;i&gt;Layout Diamond,&lt;/i&gt; che impiega un emettitore al centro di ogni lato dello schermo.&lt;/p&gt;&lt;p&gt;Il &lt;i&gt;Layout Square&lt;/i&gt; ha generalmente una precisione molto più alta a qualsiasi angolazione e permette di giocare più vicini allo schermo o di utilizzare lenti Fish Eye esterne senza distorsione del campo visivo, mentre il &lt;i&gt;Layout Diamond&lt;/i&gt; serve per la compatibilità dello schermo con alcuni sistemi di lightgun legacy (permettendo alle pistole OpenFIRE di giocare insieme ad altri sistemi di lightgun sullo stesso schermo).&lt;/p&gt;&lt;p&gt;Se non sei sicuro, usa il &lt;b&gt;Layout Square&lt;/b&gt; (a meno che tu non utilizzi anche un&apos;altra marca di lightgun che necessita di un layout IR a diamante per funzionare).&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="710"/>
+        <source>Aspect Ratio Correction for Profile %1</source>
+        <translation>Correzione rapporto d&apos;aspetto per profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="711"/>
+        <source>&lt;p&gt;This setting determines the type of Aspect Ratio Correction used for this Profile when &lt;i&gt;4:3 Mode&lt;/i&gt; is set.&lt;/p&gt;&lt;p&gt;When &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Serial command&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M3x1&lt;/tt&gt; is received, the firmware stretches the effective range for fullscreen applications in Windows that runs in resolutions &lt;b&gt;narrower&lt;/b&gt; than the full display width/height; this setting determines the stretch factor that will be used for these 4:3 applications.&lt;/p&gt;&lt;p&gt;Do note that this restriction exclusively applies to the &lt;b&gt;Windows Operating System ONLY for legacy applications that DON&apos;T support the monitor&apos;s full resolution;&lt;/b&gt; &lt;i&gt;Linux-based systems&lt;/i&gt; and games run via &lt;i&gt;Wine/Proton&lt;/i&gt; &lt;b&gt;do not need this workaround,&lt;/b&gt; except for certain applications like &lt;i&gt;CXBX-Reloaded&lt;/i&gt; that don&apos;t scale down the effective range correctly for 4:3 content.&lt;/p&gt;&lt;p&gt;If unsure, set to &lt;b&gt;the aspect ratio of your display.&lt;/b&gt; Setting to &lt;i&gt;4:3&lt;/i&gt; effectively disables range stretching when toggled.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Questa impostazione determina il tipo di Correzione del Rapporto d&apos;Aspetto utilizzata per questo Profilo quando la &lt;i&gt;Modalità 4:3&lt;/i&gt; è impostata.&lt;/p&gt;&lt;p&gt;Quando viene ricevuto il &lt;a href=&apos;https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/wiki/MAMEHOOKER-Documentation#m---mode-commands&apos;&gt;&lt;span style=&apos; text-decoration: underline; color:#8ab4f8;&apos;&gt;Comando seriale&lt;/span&gt;&lt;/a&gt; &lt;tt&gt;M3x1&lt;/tt&gt;, il firmware estende l&apos;area effettiva per le applicazioni a schermo intero in Windows che vengono eseguite a risoluzioni &lt;b&gt;più strette&lt;/b&gt; rispetto all&apos;intera larghezza/altezza dello schermo; questa impostazione determina il fattore di estensione che verrà utilizzato per queste applicazioni in 4:3.&lt;/p&gt;&lt;p&gt;Tieni presente che questa restrizione si applica esclusivamente al &lt;b&gt;Sistema Operativo Windows SOLO per le applicazioni legacy che NON supportano l&apos;intera risoluzione del monitor;&lt;/b&gt; i &lt;i&gt;sistemi basati su Linux&lt;/i&gt; e i giochi eseguiti tramite &lt;i&gt;Wine/Proton&lt;/i&gt; &lt;b&gt;non hanno bisogno di questo workaround,&lt;/b&gt; ad eccezione di alcune applicazioni come &lt;i&gt;CXBX-Reloaded&lt;/i&gt; che non ridimensionano correttamente l&apos;area effettiva per i contenuti in 4:3.&lt;/p&gt;&lt;p&gt;Se non sei sicuro, imposta &lt;b&gt;il rapporto d&apos;aspetto del tuo schermo.&lt;/b&gt; L&apos;impostazione su &lt;i&gt;4:3&lt;/i&gt; disabilita a tutti gli effetti l&apos;estensione dell&apos;area quando attivata.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="728"/>
+        <source>Profile Menu Color for Cali Profile %1</source>
+        <translation>Colore menu per profilo di calibrazione %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="729"/>
+        <source>&lt;p&gt;Open a window to select the color used to represent this profile in &lt;i&gt;Pause Mode.&lt;/i&gt;&lt;/p&gt;&lt;p&gt;Each profile can be assigned a color used to identify them when switching profiles on the lightgun itself, which is emitted by a 4-pin RGB LED and/or an active NeoPixel strand.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Apri una finestra per selezionare il colore utilizzato per rappresentare questo profilo in &lt;i&gt;Modalità Pausa.&lt;/i&gt;&lt;/p&gt;&lt;p&gt;A ogni profilo può essere assegnato un colore utilizzato per identificarlo quando si passa da un profilo all&apos;altro sulla lightgun stessa, il quale viene emesso da un LED RGB a 4 pin e/o da una striscia NeoPixel attiva.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="734"/>
+        <source>Calibrate Profile %1</source>
+        <translation>Calibra profilo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="738"/>
+        <source>Open Calibration Window for Cali Profile %1</source>
+        <translation>Apri finestra di calibrazione per il profilo di calibrazione %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="739"/>
+        <source>Click to start the calibration process for this profile.</source>
+        <translation>Clicca per avviare il processo di calibrazione per questo profilo.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="848"/>
+        <source>GPIO Pin No. %1.
+
+Blue pin numbers are members of I2C0.
+Orange are members of I2C1.
+Purple pin numbers can automatically select any I2C channel in software.
+Gray cannot use I2C devices.</source>
+        <translation>Pin GPIO N. %1.
+
+I numeri di pin blu appartengono a I2C0.
+Quelli arancioni appartengono a I2C1.
+I numeri di pin viola possono selezionare automaticamente qualsiasi canale I2C via software.
+Quelli grigi non possono utilizzare dispositivi I2C.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1009"/>
+        <source>[Disconnect Current Device]</source>
+        <translation>[Disconnetti dispositivo corrente]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1030"/>
+        <location filename="../src/appmainwindow.cpp" line="2083"/>
+        <source>[Select a Device to Configure]</source>
+        <translation>[Seleziona un dispositivo da configurare]</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1092"/>
+        <location filename="../src/appmainwindow.cpp" line="1124"/>
+        <source>Camera pins are not on the same I2C channel! Please check camera pins&apos; mappings.</source>
+        <translation>I pin della fotocamera non sono sullo stesso canale I2C! Verifica la mappatura dei pin della fotocamera.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1095"/>
+        <location filename="../src/appmainwindow.cpp" line="1127"/>
+        <source>Peripheral pins are not on the same I2C channel! Please check peripheral pins&apos; mappings.</source>
+        <translation>I pin della periferica non sono sullo stesso canale I2C! Verifica la mappatura dei pin della periferica.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1105"/>
+        <source>Camera and Peripheral Data pins clashed! Please remap Peripheral SDA.</source>
+        <translation>I pin dati della fotocamera e della periferica sono in conflitto! Rimappa il pin SDA della periferica.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1113"/>
+        <source>Camera and Peripheral Data pins clashed! Please remap Camera SDA.</source>
+        <translation>I pin dati della fotocamera e della periferica sono in conflitto! Rimappa il pin SDA della fotocamera.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1137"/>
+        <source>Camera and Peripheral Data pins clashed! Please remap Peripheral SCL.</source>
+        <translation>I pin dati della fotocamera e della periferica sono in conflitto! Rimappa il pin SCL della periferica.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1145"/>
+        <source>Camera and Peripheral Data pins clashed! Please remap Camera SCL.</source>
+        <translation>I pin dati della fotocamera e della periferica sono in conflitto! Rimappa il pin SCL della fotocamera.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1592"/>
+        <source>Last </source>
+        <translation>Ultimi </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1766"/>
+        <source>Input Name</source>
+        <translation>Nome input</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1767"/>
+        <source>Set name for Calibration Profile %1</source>
+        <translation>Imposta il nome per il profilo di calibrazione %1</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1829"/>
+        <source>Sent a rumble test pulse.</source>
+        <translation>Inviato un impulso di test al rumble.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1837"/>
+        <source>Sent a solenoid test pulse.</source>
+        <translation>Inviato un impulso di test al solenoide.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1845"/>
+        <source>Set LED to Red.</source>
+        <translation>Imposta il LED su Rosso.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1853"/>
+        <source>Set LED to Green.</source>
+        <translation>Imposta il LED su Verde.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1861"/>
+        <source>Set LED to Blue.</source>
+        <translation>Imposta il LED su Blu.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1869"/>
+        <source>Warning: Unsaved Changes</source>
+        <translation>Attenzione: Modifiche non salvate</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1870"/>
+        <source>Your current calibration profile has an unsaved IR Layout type change.
+Test Mode relies on the profile&apos;s settings since the last save, and may not work as expected.
+It is recommended that you save your changes before continuing.
+
+Continue to Test Mode?</source>
+        <translation>Il profilo di calibrazione corrente presenta una modifica non salvata al tipo di layout IR.
+La modalità test si basa sulle impostazioni del profilo dall&apos;ultimo salvataggio e potrebbe non funzionare come previsto.
+Si consiglia di salvare le modifiche prima di continuare.
+
+Continuare in modalità test?</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1892"/>
+        <source>Really delete saved data?</source>
+        <translation>Eliminare davvero i dati salvati?</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1893"/>
+        <source>This operation will delete all saved data, including:
+
+ - Calibration Profiles
+ - Toggles
+ - Settings
+ - Custom Identifiers
+
+Are you sure about this?</source>
+        <translation>Questa operazione eliminerà tutti i dati salvati, inclusi:
+
+ - Profili di calibrazione
+ - Interruttori
+ - Impostazioni
+ - Identificatori personalizzati
+
+Sei sicuro?</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1898"/>
+        <source>Delete Confirmation</source>
+        <translation>Conferma eliminazione</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1904"/>
+        <source>Board reset to initial settings.</source>
+        <translation>Scheda ripristinata alle impostazioni iniziali.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1908"/>
+        <source>Clear operation canceled.</source>
+        <translation>Operazione di cancellazione annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1934"/>
+        <source>Board reset to bootloader.</source>
+        <translation>Scheda riavviata nel bootloader.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1969"/>
+        <source>Temperature: FAULT</source>
+        <translation>Temperatura: ERRORE</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="1974"/>
+        <source>Temperature: %1°C</source>
+        <translation>Temperatura: %1°C</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2017"/>
+        <source>Device Error: Camera not available!</source>
+        <translation>Errore dispositivo: Fotocamera non disponibile!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2018"/>
+        <source>&lt;p&gt;Data received from the board indicates that the camera is in a bad state.&lt;br&gt;This can happen if, for example, the camera wires are crossed&lt;br&gt;(data wire to clock pin, clock wire to data pin),&lt;br&gt;or the camera pins are wired to a different component,&lt;br&gt;such as a button or Force Feedback output.&lt;/p&gt;&lt;p&gt;You are able to change the camera pins in the &lt;i&gt;Boards Layout&lt;/i&gt; tab&lt;br&gt;if they should be mapped different GPIO;&lt;br&gt;Otherwise, the camera wires must be resoldered to resolve this error.&lt;/p&gt;&lt;p&gt;IR Testing and Calibration will not be available while in this state.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;I dati ricevuti dalla scheda indicano che la telecamera è in uno stato di errore.&lt;br&gt;Questo può accadere se, ad esempio, i cavi della telecamera sono incrociati&lt;br&gt;(cavo dati sul pin di clock, cavo clock sul pin dati),&lt;br&gt;oppure se i pin della telecamera sono collegati a un componente diverso,&lt;br&gt;come un pulsante o un&apos;uscita Force Feedback.&lt;/p&gt;&lt;p&gt;Puoi cambiare i pin della telecamera nella scheda &lt;i&gt;Layout Scheda&lt;/i&gt;&lt;br&gt;se devono essere mappati su GPIO diversi;&lt;br&gt;Altrimenti, i cavi della telecamera devono essere risaldati per risolvere questo errore.&lt;/p&gt;&lt;p&gt;Il Test IR e la Calibrazione non saranno disponibili in questo stato.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2030"/>
+        <source>Peripheral Device Error!</source>
+        <translation>Errore dispositivo periferica!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2031"/>
+        <source>&lt;p&gt;Data received from the board indicates that an I2C peripheral device failed to initialize.&lt;br&gt;This can happen if, for example, the peripheral&apos;s wires are crossed&lt;br&gt;(data wire to clock pin, clock wire to data pin),&lt;br&gt;or the pins for the peripheral are set to a different component,&lt;br&gt;such as a button or Force Feedback output.&lt;/p&gt;&lt;p&gt;Confirm that the wires for the peripheral are connected to the correct &lt;i&gt;Peripheral I2C&lt;/i&gt; pins&lt;br&gt;in the &lt;i&gt;Boards Layout&lt;/i&gt; tab.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;I dati ricevuti dalla scheda indicano che l&apos;inizializzazione di un dispositivo periferico I2C è fallita.&lt;br&gt;Questo può accadere se, ad esempio, i cavi della periferica sono incrociati&lt;br&gt;(cavo dati sul pin di clock, cavo clock sul pin dati),&lt;br&gt;oppure se i pin della periferica sono impostati su un componente diverso,&lt;br&gt;come un pulsante o un&apos;uscita Force Feedback.&lt;/p&gt;&lt;p&gt;Verifica che i cavi della periferica siano collegati ai pin &lt;i&gt;Peripheral I2C&lt;/i&gt; corretti&lt;br&gt;nella scheda &lt;i&gt;Layout Scheda&lt;/i&gt;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2066"/>
+        <source>Successfully reset board settings</source>
+        <translation>Impostazioni della scheda ripristinate con successo</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2067"/>
+        <source>Please unplug the board and reinsert it into the PC.</source>
+        <translation>Scollegare la scheda e reinserirla nel PC.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2116"/>
+        <location filename="../src/appmainwindow.cpp" line="2129"/>
+        <source>Current board has been disconnected.</source>
+        <translation>La scheda corrente è stata scollegata.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2203"/>
+        <location filename="../src/appmainwindow.cpp" line="2204"/>
+        <source>Calibration for Profile </source>
+        <translation>Calibrazione per il profilo </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2203"/>
+        <source> successful</source>
+        <translation> completata con successo</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2204"/>
+        <source> returned with malformed values.</source>
+        <translation> ha restituito valori malformati.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2207"/>
+        <source>Cancelled Calibration for Profile </source>
+        <translation>Calibrazione annullata per il profilo </translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2314"/>
+        <source>Open New Layout</source>
+        <translation>Carica nuovo layout</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2355"/>
+        <source>Save New Layout</source>
+        <translation>Salva nuovo layout</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2343"/>
+        <source>Successfully imported custom layout!</source>
+        <translation>Layout personalizzato importato con successo!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2344"/>
+        <source>Board Doesn&apos;t Match</source>
+        <translation>La scheda non corrisponde</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2345"/>
+        <source>Custom layout file is not compatible with this board.</source>
+        <translation>Il file di layout personalizzato non è compatibile con questa scheda.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2346"/>
+        <source>File Read Error</source>
+        <translation>Errore di lettura del file</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2347"/>
+        <source>Custom layout file could not be read.</source>
+        <translation>Impossibile leggere il file di layout personalizzato.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2348"/>
+        <source>Canceled custom layout load operation.</source>
+        <translation>Operazione di caricamento del layout personalizzato annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2372"/>
+        <source>Custom layout export successful!</source>
+        <translation>Layout personalizzato esportato con successo!</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2373"/>
+        <source>File Write Error</source>
+        <translation>Errore di scrittura del file</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2374"/>
+        <source>Custom layout file could not be written.</source>
+        <translation>Impossibile scrivere il file di layout personalizzato.</translation>
+    </message>
+    <message>
+        <location filename="../src/appmainwindow.cpp" line="2375"/>
+        <source>Canceled custom layout save operation.</source>
+        <translation>Operazione di salvataggio del layout personalizzato annullata.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This Pull Request introduces multi-language support, updates CMake for Qt6, and includes a couple of minor code adjustments to improve consistency and stability.

Here is a detailed breakdown of the changes:

Added Italian translation files (.ts). The application automatically loads the Italian interface if the operating system's default language is set to Italian. On all other systems, the original English text is displayed.

Future-proofing. If translations for other languages are added in the future, the app will automatically load them on systems with those locales.

UI string wrapping. I reviewed the source files and wrapped the user interface strings with the tr() function. This way, as long as new strings are placed inside tr(), updating and implementing new languages will be an immediate process.

CMakeLists.txt update. Updated the CMakeLists.txt file to include the new language. For the Qt6 build branch, I replaced the old command with qt_add_translations, as the previous one is deprecated in Qt6 and did not work as intended.

Note: I do not have a Qt5 environment to test the compilation, so I left the else block for Qt5 identical. Because of this, I am not sure if the multi-language feature works well with Qt5.

Bitmap font rendering fix. I added a simple (int) cast in the font rendering logic: painter.drawPixmap(QPoint(8*i, 0), QPixmap(QString(":/testFont/testFont/%1").arg((int)line.at(i).unicode()), "PNG"));. This ensures that bitmap characters are handled and displayed correctly on newer configurations like mine (Windows + Qt 6.9.0). Before that cast, it was not working for me.

String management consistency. I changed the parameters of a couple of secondary functions to use QString, making string handling more linear throughout the codebase.

No other core mechanics were touched, and everything compiles and works perfectly.