### PR TITLE
Minor build system updates

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,7 +44,7 @@ jobs:
             qt_version: 6.8.3
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'true'
 
@@ -55,14 +55,14 @@ jobs:
     # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged
     - name: Install Qt(5)
       if: ${{ matrix.qt_version == '5.15.2' }}
-      uses: jdpurcell/install-qt-action@v5
+      uses: jurplel/install-qt-action@v4
       with:
         version: '${{ matrix.qt_version }}'
         archives: 'qtbase qtwayland qttranslations qttools qtsvg qtserialport icu'
         cache: true
     - name: Install Qt(6)
       if: ${{ matrix.qt_version != '5.15.2' }}
-      uses: jdpurcell/install-qt-action@v5
+      uses: jurplel/install-qt-action@v4
       with:
         version: '${{ matrix.qt_version }}'
         host: '${{ matrix.qt_host }}'
@@ -102,11 +102,11 @@ jobs:
       working-directory: ${{ github.workspace }}/build
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         # Artifact name
         name: OpenFIREapp-${{ matrix.pretty }}-Qt${{ matrix.qt_version }}-${{ matrix.build_type }}
         path: "OpenFIRE_App-${{matrix.sys_arch}}.AppImage"
 
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -21,7 +21,7 @@ jobs:
             cmake_gen: "MinGW Makefiles"
             pretty: "Windows Artifact (MinGW)"
           - win_arch: win64_msvc2022_64
-            cmake_gen: "Visual Studio 17 2022"
+            cmake_gen: "Visual Studio 18 2026"
             pretty: "Windows Artifact (MSVC)"
         # MSVC insists on being weird with its Debug path, and can't be assed to fix it
         exclude:
@@ -29,7 +29,7 @@ jobs:
             build_type: Debug
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'true'
 
@@ -37,9 +37,8 @@ jobs:
       id: get-short-sha
       run: echo "id=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
 
-    # TODO: using install-qt-action fork until https://github.com/jurplel/install-qt-action/issues/248 is resolved & merged
     - name: Install Qt6
-      uses: jdpurcell/install-qt-action@v5
+      uses: jurplel/install-qt-action@v4
       with:
         version: '6.8.3'
         arch: '${{ matrix.win_arch }}'
@@ -67,7 +66,7 @@ jobs:
         mv "${{ github.workspace }}/build/out/bin" "${{ github.workspace }}/build/out/OpenFIRE App"
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         # Artifact name
         name: OpenFIREapp-${{ matrix.pretty }}-Qt6-${{ matrix.build_type }} # optional, default is artifact
@@ -75,4 +74,4 @@ jobs:
         path: build/out
 
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-cmake_policy(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(OpenFIREapp
         VERSION 3.0.3


### PR DESCRIPTION
Updated `cmake_minimum_required` from 3.5 to version 3.10 (to avoid build warnings). 
Removed `cmake_policy(VERSION 3.5)` as it is redundant. 
Updated GitHub Actions versions to prevent warnings during execution. 
Updated the Windows action to build with Visual Studio 18 2026, which became the default on GitHub in June 2026. 
Restored jurplel's Qt installation action, as bug https://github.com/jurplel/install-qt-action/issues/248 has been resolved.